### PR TITLE
Add Quarto analyst daily workflow template (#54)

### DIFF
--- a/inst/templates/eri_daily_workflow.qmd
+++ b/inst/templates/eri_daily_workflow.qmd
@@ -1,0 +1,150 @@
+---
+title: "ERI Daily Analyst Workflow"
+subtitle: "Data sync, survey health, and approval"
+date: today
+format:
+  html:
+    toc: true
+    toc-depth: 2
+    code-fold: false
+    self-contained: true
+knitr:
+  opts_chunk:
+    echo: true
+    message: false
+    warning: false
+---
+
+<!--
+SOP NOTES -- read before running
+=================================
+1. DO NOT commit this file back to the erifunctions repository.
+   It belongs in your analysis project (e.g. under analysis/daily/).
+
+2. Pin the package version you are using:
+      renv::snapshot()
+   Run this after installing or updating erifunctions.
+
+3. NEVER push directly to main or dev of any shared repo.
+   Always use a feature branch and open a pull request.
+
+4. Set all required environment variables in your project .Renviron
+   before knitting. To open it:
+      usethis::edit_r_environ(scope = "project")
+   Required variables:
+      ERIFUNCTIONS_TENANT_ID
+      ERIFUNCTIONS_APP_ID
+      ERIFUNCTIONS_RESOURCE_ENDPOINT
+      ERIFUNCTIONS_STORAGE_NAME
+      ERIFUNCTIONS_DATA_STORAGE_NAME
+      ERI_ANALYST_ID
+      ODK_URL
+      ODK_USER
+      ODK_PASS
+
+5. To get a fresh copy of this template from an updated package:
+      file.copy(
+        system.file("templates/eri_daily_workflow.qmd", package = "erifunctions"),
+        "."
+      )
+-->
+
+```{r setup}
+library(erifunctions)
+
+cat("erifunctions version:", as.character(packageVersion("erifunctions")), "\n")
+cat("Run started:", format(Sys.time(), "%Y-%m-%d %H:%M %Z"), "\n")
+cat("Analyst:", Sys.getenv("ERI_ANALYST_ID", unset = Sys.info()[["user"]]), "\n")
+```
+
+```{r connections}
+# Azure data container (reads ERIFUNCTIONS_* env vars automatically)
+az_con <- get_azure_storage_connection(
+  storage_name = Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", unset = "data")
+)
+
+# ODK Central connection (reads ODK_URL / ODK_USER / ODK_PASS env vars)
+odk_con <- init_odk_connection()
+```
+
+## Survey health check
+
+Check submission recency for all forms you manage. Review the `status`,
+`total_submissions`, `submissions_7d`, and `last_submission_at` columns for
+anything unexpected before syncing.
+
+```{r survey-status}
+# Fetch status for all forms across all projects.
+# Scope to a single project:  eri_survey_status(project_id = 7L, con = odk_con)
+# Scope to a single form:     eri_survey_status(project_id = 7L, form_id = "MyForm", con = odk_con)
+status <- eri_survey_status(con = odk_con)
+print(status)
+```
+
+## Sync new data
+
+Run `eri_odk_sync()` for each form you manage. Add or remove chunks below as
+needed. Each call downloads new submissions and writes them to the Azure data
+blob at `{country}/{disease}/odk/raw/{form_id}.parquet`.
+
+```{r sync-form-1}
+# Replace with your actual project_id, form_id, country, and disease values.
+# The form must be registered via eri_odk_register() before syncing.
+eri_odk_sync(
+  project_id = 7L,
+  form_id    = "RiverProspection",   # <-- replace
+  con        = odk_con,
+  data_con   = az_con
+)
+```
+
+```{r sync-form-2, eval=FALSE}
+# Duplicate this chunk for each additional form you manage.
+eri_odk_sync(
+  project_id = 7L,
+  form_id    = "FlyCollection",      # <-- replace
+  con        = odk_con,
+  data_con   = az_con
+)
+```
+
+## Review and approve
+
+After syncing, inspect the raw data before promoting it to the processed layer.
+`eri_approve()` moves files from `{country}/{disease}/{data_type}/staged/` to
+`{country}/{disease}/{data_type}/processed/` and writes an audit log entry.
+
+**Do not approve data you have not reviewed.** Open the staged parquet file
+first (e.g. with `eri_read()`), check for obvious issues, then call
+`eri_approve()` once you are satisfied.
+
+```{r review-staged, eval=FALSE}
+# Preview what is staged before approving.
+staged_path <- eri_data_path(
+  country   = "uga",       # <-- replace
+  disease   = "oncho",     # <-- replace
+  data_type = "cmr",       # <-- replace (cmr, odk, etc.)
+  layer     = "staged"
+)
+staged_data <- eri_read(staged_path, azcontainer = az_con)
+head(staged_data)
+```
+
+```{r approve, eval=FALSE}
+# Promote staged -> processed.
+# period: the data period being approved (e.g. "2026-05" for monthly, "2026-W22" for weekly).
+eri_approve(
+  country   = "uga",       # <-- replace
+  disease   = "oncho",     # <-- replace
+  data_type = "cmr",       # <-- replace
+  period    = "2026-05"    # <-- replace
+)
+```
+
+## Session summary
+
+```{r session-summary}
+cat("Run completed:", format(Sys.time(), "%Y-%m-%d %H:%M %Z"), "\n")
+cat("Analyst:", Sys.getenv("ERI_ANALYST_ID", unset = Sys.info()[["user"]]), "\n")
+cat("erifunctions version:", as.character(packageVersion("erifunctions")), "\n")
+```

--- a/tests/testthat/test-templates.R
+++ b/tests/testthat/test-templates.R
@@ -1,0 +1,20 @@
+#### Tests for inst/templates ####
+
+test_that("eri_daily_workflow.qmd template is installed and non-empty", {
+  path <- system.file("templates/eri_daily_workflow.qmd", package = "erifunctions")
+  expect_gt(nchar(path), 0L)
+  expect_true(file.exists(path), label = "template file exists on disk")
+  lines <- readLines(path, warn = FALSE)
+  expect_gt(length(lines), 10L)
+})
+
+test_that("eri_daily_workflow.qmd template contains required sections", {
+  path <- system.file("templates/eri_daily_workflow.qmd", package = "erifunctions")
+  skip_if(nchar(path) == 0, "template not installed")
+  content <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  expect_match(content, "eri_survey_status")
+  expect_match(content, "eri_odk_sync")
+  expect_match(content, "eri_approve")
+  expect_match(content, "get_azure_storage_connection")
+  expect_match(content, "init_odk_connection")
+})


### PR DESCRIPTION
## Summary
- Adds `inst/templates/eri_daily_workflow.qmd`: a ready-to-use Quarto document analysts copy into their analysis projects
- Covers the full daily loop: Azure + ODK connections, `eri_survey_status()` health check, `eri_odk_sync()` per form, staged data review, and `eri_approve()` promotion
- Inline SOP comments cover `.Renviron` setup, `renv::snapshot()` pinning, branch hygiene, and how to refresh the template from an updated package
- 2 tests verify the file is present and contains all required function calls after `devtools::load_all()`

## Test plan
- [ ] `devtools::test(filter = "templates")` -- 8 pass
- [ ] `devtools::check()` -- 0/0/0

Closes #54