### PR TITLE
Release v0.4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to erifunctions
+
+## Workflow
+
+1. **Open an issue first.** Every change starts with a GitHub issue scoped to ~1-2 hours of work.
+2. **Branch from `dev`** as `{issue-number}-{short-slug}` (e.g. `54-quarto-template`).
+3. **PR targets `dev`**, not `main`. `main` only receives version-bumped phase releases.
+4. **`devtools::check()` must be 0 errors, 0 warnings** before requesting review.
+5. Issues are closed manually after the PR merges.
+
+## Adding a new country schema
+
+Schemas live in `inst/schemas/` (surveillance) and `inst/schemas/cmr/` (CMR).
+
+1. Run `eri_onboard_country()` or `eri_onboard_cmr()` to generate a template in your working directory.
+2. Fill in the TODO sections.
+3. Run `eri_schema_validate("your_schema.yaml")` — fix any issues it reports.
+4. Copy the finished file into `inst/schemas/` (or `inst/schemas/cmr/`) and open a PR.
+
+## Code conventions
+
+- All exported functions are named `eri_*()` — verb-first, tab-completable.
+- Internal helpers are prefixed with `.` and documented with `#' @keywords internal`.
+- Use `cli::cli_abort()` / `cli::cli_inform()` / `cli::cli_alert_success()` for all user-facing messages — no `message()`, `warning()`, or `stop()`.
+- No non-ASCII characters in R source files (no em dashes, smart quotes, tab literals).
+- No `withr::local_mocked_bindings` — use `testthat::local_mocked_bindings()`.
+- Temp files cleaned up with `withr::defer(unlink(tmp))`.
+
+## Phase releases
+
+When all issues in a phase are closed:
+1. Update `NEWS.md` and `README.md`.
+2. Bump `Version:` in `DESCRIPTION`.
+3. Merge `dev` → `main` via a squash PR.
+4. Create a GitHub release tagged `v{version}`.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.3.0
+Version: 0.4.0
 Authors@R: 
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,40 @@
-# erifunctions (development version)
+# erifunctions 0.4.0
+
+## Phase 3 — ODK integration, data catalog, and onboarding
+
+### New functions
+
+**ODK form registry**
+- `eri_odk_register()` — register an ODK form in the shared Azure registry (`odk/registry.yaml`)
+- `eri_odk_deregister()` — soft-delete a registered form (preserves sync history)
+- `eri_odk_list_registered()` — list all active forms as a tibble
+
+**ODK sync**
+- `eri_odk_sync()` — download new submissions for a registered form and write to Azure as parquet
+
+**Survey health**
+- `eri_survey_status()` — fetch live submission counts and recency for one form, all forms in a project, or all projects; S3 class with cli-based print method
+
+**Bulk user management**
+- `eri_odk_bulk_users()` — read a CSV of assign/remove/create actions, run pre-flight validation (collects all errors before touching the API), then execute; `dry_run = TRUE` previews without mutating
+
+**Data catalog**
+- `eri_catalog_register()` — upsert a processed-layer file entry into `_catalog/data_catalog.yaml`
+- `eri_catalog_query()` — filter catalog entries by country, disease, data_type, layer, or period
+- `eri_catalog_verify()` — check each entry exists in Azure; updates `last_verified_at`
+- `eri_approve()` now automatically registers each promoted file in the catalog
+
+**Onboarding**
+- `eri_onboard_country()` — write a surveillance DQ schema YAML template to your working directory and create the three-layer Azure blob directories for a new country/disease
+- `eri_onboard_cmr()` — write a CMR schema YAML template locally; optionally create CMR Azure dirs
+- `eri_schema_validate()` — validate a local YAML schema file; returns a tidy tibble of structural issues
+
+**Analyst workflow**
+- `inst/templates/eri_daily_workflow.qmd` — Quarto template covering the full analyst daily loop (connections, survey health, sync, review, approve); copy to your project with `file.copy(system.file("templates/eri_daily_workflow.qmd", package = "erifunctions"), ".")`
+
+### Other changes
+- `eri_approve()` wrapped with catalog registration (fail-silent so a catalog write never blocks an approval)
+- ODK connection functions refactored to package standards (`cli`, `@export`, roxygen docs)
 
 # erifunctions 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,18 @@
 # erifunctions
 
-R package providing standardized data infrastructure for the Epidemiology, Research and Innovation (ERI) team at The Carter Center's River Blindness, Lymphatic Filariasis, Schistosomiasis and Malaria (RBLFSM) program.
+Standardized data tools for the Epidemiology, Research and Innovation (ERI) team at The Carter Center's NTD and malaria programs.
 
-**Version:** 0.3.0 · **Status:** Active development — Phase 2 complete
-
----
-
-## What it does
-
-`erifunctions` is the connective tissue between raw data sources and the team's analytical workflows. It handles:
-
-- **Azure blob I/O** — standardized read/write/list operations against the team's `data/` and `projects/` storage containers
-- **Data quality (DQ)** — schema-driven checks for surveillance and CMR data; anomaly detection for spikes, gaps, consistency violations, and admin name errors
-- **CMR ingestion** — parse monthly report Excel files, load country schemas, stage files from the projects blob
-- **ODK** — connect to ODK Central, list projects/forms, download submissions, manage app users
-- **Pipeline helpers** — trigger GitHub Actions pipelines, stage intermediate output, approve data to processed layer
+**Version:** 0.4.0 · **Status:** Active development
 
 ---
 
 ## Installation
 
-### From GitHub (recommended for analysts)
-
 ```r
-# Install devtools if needed
-install.packages("devtools")
-
-# Install erifunctions
+# Install from GitHub
 devtools::install_github("thecartercenter/erifunctions")
-```
 
-### With renv (recommended for projects)
-
-```r
+# Pin the version in your analysis project (recommended)
 renv::install("thecartercenter/erifunctions")
 renv::snapshot()
 ```
@@ -41,136 +21,163 @@ renv::snapshot()
 
 ## Setup
 
-Set the following environment variables (add to `.Renviron` via `usethis::edit_r_environ()`):
+Add the following to your project `.Renviron` (`usethis::edit_r_environ(scope = "project")`):
 
 ```
+# Azure storage
 ERIFUNCTIONS_TENANT_ID=<Azure tenant ID>
-ERIFUNCTIONS_APP_ID=<Azure app ID>
-ERIFUNCTIONS_RESOURCE_ENDPOINT=<storage endpoint URL>
+ERIFUNCTIONS_APP_ID=<Azure app registration ID>
+ERIFUNCTIONS_RESOURCE_ENDPOINT=<storage account endpoint URL>
 ERIFUNCTIONS_STORAGE_NAME=projects
 ERIFUNCTIONS_DATA_STORAGE_NAME=data
 
-# Service principal (for automated/scripted use)
+# Service principal — for scripted/automated use only
 ERIFUNCTIONS_SP_CLIENT_ID=<SP client ID>
 ERIFUNCTIONS_SP_CLIENT_SECRET=<SP client secret>
 
-# Analyst identity (appears in approval logs)
+# Your analyst identity (appears in approval and access logs)
 ERI_ANALYST_ID=firstname.lastname
+
+# ODK Central
+ODK_URL=https://rblf.tccodk.org/
+ODK_USER=your.email@cartercenter.org
+ODK_PASS=<ODK password>
 ```
+
+Restart R after editing `.Renviron`.
 
 ---
 
-## Quick start
+## Daily workflow
 
-### Connect to Azure
+The fastest way to get started is to copy the daily workflow template into your analysis project:
 
 ```r
-library(erifunctions)
-
-# Interactive browser login
-con <- get_azure_storage_connection()
-
-# Service principal (scripted)
-con <- get_azure_storage_connection(auth = "client_credentials")
+file.copy(
+  system.file("templates/eri_daily_workflow.qmd", package = "erifunctions"),
+  "."
+)
 ```
 
-### Run DQ checks on a surveillance file
+Open `eri_daily_workflow.qmd` in RStudio and knit it. The template walks through:
+1. Connecting to Azure and ODK Central
+2. Checking survey submission health
+3. Syncing new ODK data to Azure
+4. Reviewing and approving staged data
 
-```r
-# Load the schema for your country/disease
-schema <- load_dq_schema("dominican_republic", "malaria")
+---
 
-# Read the raw file
-df <- eri_read("dr/malaria/surveillance/raw/2024_W01.parquet")
+## Core concepts
 
-# Run all checks and print a report
-result <- run_dq_checks(df, schema)
-dq_report(result)
+### Data layers
 
-# Review flags before approving
-result$flags
+All data lives in the `data/` Azure blob under a standard path:
 
-# Promote staged files to processed
-eri_approve("dr", "malaria", "surveillance", period = "2024-W01")
+```
+data/{country}/{disease}/{data_type}/{layer}/
+                                     raw/        <- as-received from source
+                                     staged/     <- DQ-checked, awaiting approval
+                                     processed/  <- analyst-approved, canonical
 ```
 
-### Ingest and stage a CMR monthly report
+`eri_approve()` is the explicit human gate. Nothing reaches `processed/` without it.
+
+### Data catalog
+
+Every file promoted by `eri_approve()` is automatically registered in `_catalog/data_catalog.yaml`. Query it to see what data exists on the system:
 
 ```r
-# Parse a CMR Excel file (English template)
-df <- eri_ingest_cmr("path/to/uga_202603.xlsx", sheet = "RB Treatment", country = "uga")
+# What processed Uganda oncho data do we have?
+eri_catalog_query(country = "uga", disease = "oncho", layer = "processed")
 
-# Parse a French template using a canonical slug
-df <- eri_ingest_cmr("path/to/tcd_202603.xlsx", sheet = "rb_treatment", country = "tcd")
-
-# Stage CMR files from the projects blob into data/staged
-eri_stage_cmr("uga", period = "202603")   # specific period
-eri_stage_cmr("nga")                       # auto-selects most recent
+# Is everything in the catalog still in Azure?
+eri_catalog_verify()
 ```
 
 ---
 
 ## Function reference
 
-### Azure I/O
+### Connections
 
-| Function | Description |
+| Function | What it does |
 |---|---|
-| `get_azure_storage_connection()` | Authenticate and return an Azure container object |
+| `get_azure_storage_connection()` | Authenticate with Azure (browser or service principal) |
+| `init_odk_connection()` | Authenticate with ODK Central |
+
+### Reading and writing data
+
+| Function | What it does |
+|---|---|
 | `eri_read(file_loc)` | Read a file from Azure (parquet, csv, xlsx, rds) |
 | `eri_write(obj, file_loc)` | Write an object to Azure |
 | `eri_upload(local_path, file_loc)` | Upload any local file to Azure |
 | `eri_list(file_loc)` | List files in an Azure directory |
 | `eri_file_exists(file_loc)` | Check whether a file exists |
-| `eri_dir_exists(file_loc)` | Check whether a directory exists |
-| `eri_dir_create(file_loc)` | Create a directory |
-| `eri_delete(file_loc)` | Delete a file |
-| `eri_dir_delete(file_loc)` | Delete a directory |
+| `eri_data_path(country, disease, data_type, layer)` | Build a canonical blob path |
 
-### Pipeline helpers
+### Data pipeline
 
-| Function | Description |
+| Function | What it does |
 |---|---|
-| `eri_data_path(country, disease, data_type, layer)` | Build a canonical `data/` blob path |
-| `eri_stage(pipeline, country, disease)` | Pull intermediate pipeline output into `data/staged/` |
-| `eri_stage_cmr(country, period)` | Pull CMR files from projects blob into `data/rblf/cmr/staged/` |
-| `eri_ingest(path, country, disease)` | DQ-check a local surveillance file and dual-write to both blobs |
 | `eri_approve(country, disease, data_type, period)` | Promote staged files to processed (human gate) |
+| `eri_stage(pipeline, country, disease)` | Pull pipeline output from projects blob into staged |
+| `eri_ingest(path, country, disease)` | DQ-check a local file and dual-write to both blobs |
 | `eri_trigger(pipeline, country, disease)` | Dispatch a GitHub Actions pipeline |
 
 ### Data quality
 
-| Function | Description |
+| Function | What it does |
 |---|---|
 | `load_dq_schema(country, disease)` | Load a bundled YAML DQ schema |
 | `run_dq_checks(data, schema)` | Run all schema-driven checks; returns a `dq_result` |
 | `dq_report(result)` | Print a summary of flags and corrections |
 | `add_anomaly_pct_change(data, value_col, period_col)` | Flag period-over-period spikes |
 | `add_anomaly_gaps(data, period_col, period_type)` | Detect missing periods in a time series |
-| `add_anomaly_consistency(data, schema)` | Validate cross-field rules from schema |
+| `add_anomaly_consistency(data, schema)` | Validate cross-field rules |
 | `add_anomaly_spatial(data, schema)` | Validate admin names against reference shapefiles |
 
 ### CMR monthly reports
 
-| Function | Description |
+| Function | What it does |
 |---|---|
-| `eri_ingest_cmr(path, sheet, country)` | Parse a CMR Excel sheet using field code row |
+| `eri_ingest_cmr(path, sheet, country)` | Parse a CMR Excel sheet |
 | `load_cmr_schema(country)` | Load a bundled CMR country schema |
-| `eri_stage_cmr(country, period)` | Stage CMR files from projects blob |
+| `eri_stage_cmr(country, period)` | Stage CMR files from the projects blob |
 
 ### ODK
 
-| Function | Description |
+| Function | What it does |
 |---|---|
-| `init_odk_connection(url, user, pass)` | Authenticate with ODK Central |
+| `eri_odk_register(project_id, form_id, country, disease, server_url)` | Register a form in the Azure registry |
+| `eri_odk_deregister(project_id, form_id)` | Soft-delete a registered form |
+| `eri_odk_list_registered()` | List all active registered forms |
+| `eri_odk_sync(project_id, form_id)` | Download new submissions to Azure as parquet |
+| `eri_survey_status(project_id, form_id)` | Check submission counts and recency |
+| `eri_odk_bulk_users(csv_path)` | Assign/remove/create app users from a CSV |
 | `list_odk_projects()` | List all ODK projects |
-| `list_odk_forms(project_id)` | List forms within a project |
+| `list_odk_forms(project_id)` | List forms in a project |
 | `download_odk_form(project_id, form_id)` | Download all submissions from a form |
-| `update_odk_app_user_role(action, project_id, ...)` | Create/delete/assign app users |
+
+### Data catalog
+
+| Function | What it does |
+|---|---|
+| `eri_catalog_register(path, country, disease, data_type, layer)` | Register a file in the catalog |
+| `eri_catalog_query(country, disease, data_type, layer, period)` | Query catalog entries |
+| `eri_catalog_verify()` | Check catalog entries exist in Azure; update verification timestamps |
+
+### Onboarding a new country or disease
+
+| Function | What it does |
+|---|---|
+| `eri_onboard_country(country_code, country_name, disease)` | Scaffold a surveillance schema and create Azure directories |
+| `eri_onboard_cmr(country_code, country_name)` | Scaffold a CMR schema |
+| `eri_schema_validate(schema_path)` | Validate a local schema YAML for structural issues |
 
 ### Teams notifications
 
-| Function | Description |
+| Function | What it does |
 |---|---|
 | `get_teams_connection(webhook_url)` | Create a Teams connection object |
 | `eri_teams_send(con, message)` | Send a message to a Teams channel |
@@ -178,20 +185,7 @@ eri_stage_cmr("nga")                       # auto-selects most recent
 
 ---
 
-## Data model
-
-```
-data/{country}/{disease}/{data_type}/{layer}/
-                                     raw/        ← as-received
-                                     staged/     ← DQ checked, awaiting approval
-                                     processed/  ← analyst-approved canonical
-```
-
-`eri_approve()` is the explicit human gate before anything reaches `processed/`.
-
----
-
-## Supported countries and diseases
+## Supported countries
 
 | Country | Code | Programs |
 |---|---|---|
@@ -205,14 +199,11 @@ data/{country}/{disease}/{data_type}/{layer}/
 | Madagascar | `mad` | LF |
 | Chad | `tcd` | oncho, LF |
 
+To add a new country, run `eri_onboard_country()` and follow the checklist it prints.
+
 ---
 
-## Contributing
+## Getting help
 
-See the development workflow in the repository wiki. Briefly:
-- Open a GitHub issue before writing code
-- Branch from `dev` as `{issue-number}-{slug}`
-- PRs target `dev`; `main` receives only version-bumped phase releases
-- `devtools::check()` must be 0 errors, 0 warnings before merging
-
-Report bugs at <https://github.com/thecartercenter/erifunctions/issues>.
+- Open an issue: <https://github.com/thecartercenter/erifunctions/issues>
+- For developer contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
Phase 3 complete. This PR bumps the version and updates documentation before merging dev -> main.

**Changes:**
- `DESCRIPTION`: Version 0.3.0 -> 0.4.0
- `NEWS.md`: Full Phase 3 changelog (ODK registry, sync, survey status, bulk users, data catalog, onboarding, Quarto template)
- `README.md`: Rewritten as analyst-facing reference — installation, setup, daily workflow template pointer, complete function table
- `CONTRIBUTING.md`: New file capturing developer workflow and code conventions

**Phase 3 issues closed:** #49, #50, #51, #52, #53, #54, #57, #43