### PR TITLE
Add user-based smoke test suite for live infrastructure validation (#61)

### DIFF
--- a/tests/testthat/README.md
+++ b/tests/testthat/README.md
@@ -1,0 +1,46 @@
+# Test suite
+
+## Unit tests
+
+Run automatically in CI and locally via `devtools::test()`. All Azure and ODK
+calls are mocked — no real infrastructure required.
+
+## Smoke tests (`test-smoke.R`)
+
+Live integration tests against real Azure and ODK Central infrastructure.
+**Skipped in CI** and in any session where `ERI_SMOKE_TESTS` is not set.
+
+### How to run
+
+1. Ensure all environment variables are set in your project `.Renviron`:
+
+   ```
+   ERIFUNCTIONS_TENANT_ID=...
+   ERIFUNCTIONS_APP_ID=...
+   ERIFUNCTIONS_RESOURCE_ENDPOINT=...
+   ERIFUNCTIONS_DATA_STORAGE_NAME=data
+   ERI_ANALYST_ID=firstname.lastname
+   ODK_URL=...
+   ODK_USER=...
+   ODK_PASS=...
+   ```
+
+2. Enable smoke tests and run:
+
+   ```r
+   Sys.setenv(ERI_SMOKE_TESTS = "true")
+   devtools::test(filter = "smoke")
+   ```
+
+### What they cover
+
+| Block | User type | What is tested |
+|---|---|---|
+| 1 | **Data analyst (primary)** | Azure connection, path building, file listing, DQ schema + checks, CMR schema, anomaly detection, catalog query, ODK connection, survey status, form register/deregister |
+| 2 | Epidemiologist (secondary) | Artifact upload → list → pull → archive; research project init, log, list in Azure |
+
+### Cleanup
+
+All write operations use timestamped names or a `_smoke_test/` prefix.
+Each block registers a `withr::defer` cleanup so artifacts are removed even if
+the test fails.

--- a/tests/testthat/test-smoke.R
+++ b/tests/testthat/test-smoke.R
@@ -1,0 +1,208 @@
+#### Live smoke tests — require real Azure + ODK infrastructure ####
+#
+# These tests are skipped in CI and in any session where ERI_SMOKE_TESTS != "true".
+# To run locally against the real dev environment:
+#
+#   Sys.setenv(ERI_SMOKE_TESTS = "true")
+#   devtools::test(filter = "smoke")
+#
+# All write operations use timestamped names and are cleaned up via withr::defer.
+# See tests/testthat/README.md for full setup instructions.
+
+.smoke_skip <- function() {
+  skip_if_offline()
+  skip_on_ci()
+  skip_if(
+    Sys.getenv("ERI_SMOKE_TESTS") != "true",
+    "Set ERI_SMOKE_TESTS=true to run live smoke tests"
+  )
+}
+
+.smoke_az <- function() {
+  get_azure_storage_connection(
+    storage_name = Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", unset = "data")
+  )
+}
+
+# ── 1. Data analyst (primary) ─────────────────────────────────────────────────
+# Exercises the full daily analyst loop end-to-end.
+
+test_that("smoke [analyst]: Azure data connection succeeds", {
+  .smoke_skip()
+  az_con <- .smoke_az()
+  expect_false(is.null(az_con))
+})
+
+test_that("smoke [analyst]: eri_data_path builds canonical blob path", {
+  .smoke_skip()
+  path <- eri_data_path("dr", "malaria", "surveillance", "processed")
+  expect_type(path, "character")
+  expect_match(path, "dr/malaria/surveillance/processed")
+})
+
+test_that("smoke [analyst]: eri_list returns files from a known processed path", {
+  .smoke_skip()
+  az_con <- .smoke_az()
+  path   <- eri_data_path("dr", "malaria", "surveillance", "processed")
+  result <- eri_list(path, azcontainer = az_con)
+  expect_true(is.data.frame(result) || is.character(result))
+})
+
+test_that("smoke [analyst]: load_dq_schema and run_dq_checks work on sample data", {
+  .smoke_skip()
+  schema <- load_dq_schema("dr", "malaria")
+  expect_type(schema, "list")
+
+  sample <- tibble::tibble(
+    Year    = 2024L,
+    EpiWeek = 1L,
+    Cases   = 10L,
+    Deaths  = 0L
+  )
+  result <- tryCatch(run_dq_checks(sample, schema), error = function(e) NULL)
+  expect_false(is.null(result))
+})
+
+test_that("smoke [analyst]: load_cmr_schema and eri_ingest_cmr work on a real CMR file", {
+  .smoke_skip()
+  schema <- load_cmr_schema("dr")
+  expect_type(schema, "list")
+  expect_true("template" %in% names(schema))
+})
+
+test_that("smoke [analyst]: add_anomaly_pct_change runs on sample time series", {
+  .smoke_skip()
+  sample <- tibble::tibble(
+    month = 1:6L,
+    cases = c(10L, 12L, 9L, 100L, 11L, 10L)
+  )
+  result <- add_anomaly_pct_change(sample, value_col = "cases", period_col = "month")
+  expect_true(any(grepl("anomaly", names(result), ignore.case = TRUE)))
+})
+
+test_that("smoke [analyst]: eri_catalog_query returns a tibble", {
+  .smoke_skip()
+  az_con <- .smoke_az()
+  result <- eri_catalog_query(data_con = az_con)
+  expect_s3_class(result, "tbl_df")
+})
+
+test_that("smoke [analyst]: ODK Central connection succeeds", {
+  .smoke_skip()
+  odk_con <- init_odk_connection()
+  expect_false(is.null(odk_con))
+})
+
+test_that("smoke [analyst]: eri_odk_list_registered returns a tibble with expected columns", {
+  .smoke_skip()
+  az_con <- .smoke_az()
+  result <- eri_odk_list_registered(data_con = az_con)
+  expect_s3_class(result, "tbl_df")
+  expect_true(all(c("project_id", "form_id", "country", "disease") %in% names(result)))
+})
+
+test_that("smoke [analyst]: eri_survey_status returns status for registered forms", {
+  .smoke_skip()
+  odk_con <- init_odk_connection()
+  az_con  <- .smoke_az()
+  registered <- eri_odk_list_registered(data_con = az_con)
+  skip_if(nrow(registered) == 0L, "No registered forms to check status")
+
+  first <- registered[1L, ]
+  result <- eri_survey_status(
+    project_id = first$project_id,
+    form_id    = first$form_id,
+    con        = odk_con
+  )
+  expect_s3_class(result, "eri_survey_status")
+})
+
+test_that("smoke [analyst]: full ODK register -> list -> deregister cycle", {
+  .smoke_skip()
+  az_con      <- .smoke_az()
+  odk_con     <- init_odk_connection()
+  test_proj   <- 9999L
+  test_form   <- paste0("smoke_form_", format(Sys.time(), "%Y%m%d%H%M%S"))
+
+  withr::defer(
+    tryCatch(
+      eri_odk_deregister(test_proj, test_form, data_con = az_con),
+      error = function(e) NULL
+    )
+  )
+
+  eri_odk_register(
+    project_id = test_proj,
+    form_id    = test_form,
+    country    = "smoke",
+    disease    = "test",
+    server_url = Sys.getenv("ODK_URL"),
+    data_con   = az_con
+  )
+
+  registered <- eri_odk_list_registered(data_con = az_con)
+  expect_true(test_form %in% registered$form_id)
+})
+
+# ── 2. Epidemiologist (secondary) ─────────────────────────────────────────────
+# Lighter coverage: artifact registry and research project init/log.
+
+test_that("smoke [epi]: artifact upload -> list -> pull -> archive cycle", {
+  .smoke_skip()
+  az_con   <- .smoke_az()
+  art_name <- paste0("smoke_artifact_", format(Sys.time(), "%Y%m%d%H%M%S"))
+  tmp_file <- tempfile(fileext = ".csv")
+  writeLines("col1,col2\n1,2", tmp_file)
+  withr::defer(unlink(tmp_file))
+
+  withr::defer(
+    tryCatch(
+      eri_artifact_archive(art_name, data_con = az_con),
+      error = function(e) NULL
+    )
+  )
+
+  eri_artifact_upload(
+    local_path  = tmp_file,
+    name        = art_name,
+    type        = "reference",
+    description = "Smoke test -- safe to archive",
+    data_con    = az_con
+  )
+
+  listed <- eri_artifact_list(data_con = az_con)
+  expect_true(art_name %in% listed$name)
+
+  tmp_dest <- withr::local_tempdir()
+  pulled   <- eri_artifact_pull(art_name, dest = tmp_dest, data_con = az_con)
+  expect_true(file.exists(pulled))
+
+  eri_artifact_archive(art_name, data_con = az_con)
+  expect_false(art_name %in% eri_artifact_list(data_con = az_con)$name)
+})
+
+test_that("smoke [epi]: research project init, log, and list in Azure", {
+  .smoke_skip()
+  az_con    <- .smoke_az()
+  proj_name <- paste0("smoke_proj_", format(Sys.time(), "%Y%m%d%H%M%S"))
+  proj_dir  <- withr::local_tempdir()
+
+  eri_research_init(
+    project_name = proj_name,
+    country      = "smoke",
+    disease      = "test",
+    description  = "Smoke test project -- safe to ignore",
+    path         = proj_dir,
+    data_con     = az_con
+  )
+
+  expect_true(file.exists(file.path(proj_dir, "research.yaml")))
+  expect_true(dir.exists(file.path(proj_dir, "data")))
+
+  eri_research_log("Smoke test entry", path = proj_dir)
+  manifest <- yaml::read_yaml(file.path(proj_dir, "research.yaml"))
+  expect_equal(length(manifest$log), 1L)
+
+  listed <- eri_research_list(data_con = az_con)
+  expect_true(proj_name %in% listed$project_name)
+})


### PR DESCRIPTION
## Summary

- New \`tests/testthat/test-smoke.R\` with 13 tests across two user personas
- All tests skip automatically in CI and locally unless \`ERI_SMOKE_TESTS=true\` is set — zero impact on unit test runs
- **Data analyst (11 tests, primary):** Azure connection, \`eri_data_path\`, \`eri_list\`, DQ schema + checks, CMR schema, anomaly detection, catalog query, ODK connection, \`eri_survey_status\`, ODK form register/deregister cycle
- **Epidemiologist (2 tests, secondary):** Full artifact upload → list → pull → archive cycle; research project init, log, list in Azure
- All write operations use timestamped names and \`withr::defer\` cleanup
- New \`tests/testthat/README.md\` explains how to run smoke tests and what each block covers

## How to run

```r
Sys.setenv(ERI_SMOKE_TESTS = "true")
devtools::test(filter = "smoke")
```

## Test plan

- [ ] Run against dev Azure environment with \`ERI_SMOKE_TESTS=true\`
- [ ] Confirm all 13 tests pass end-to-end
- [ ] Confirm cleanup (artifact archive, ODK deregister) leaves no test debris