### PR TITLE
Add four package vignettes: DQ, spatial, epi, research (#99-102)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
     cowplot,
     exactextractr,
     ggnewscale,
+    knitr,
     lifecycle,
     quarto,
     rmarkdown,
@@ -50,3 +51,4 @@ Suggests:
     terra,
     testthat (>= 3.0.0),
     urlchecker
+VignetteBuilder: knitr

--- a/vignettes/dq-pipeline.Rmd
+++ b/vignettes/dq-pipeline.Rmd
@@ -1,0 +1,247 @@
+---
+title: "Data Quality Pipeline"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Data Quality Pipeline}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+The DQ pipeline is a schema-driven system for cleaning and validating
+surveillance data before analysis. A single YAML schema file describes the
+expected columns, types, ranges, allowed values, translations, and
+cross-field consistency rules for one dataset. The functions `load_dq_schema()`
+and `run_dq_checks()` then apply those rules automatically, returning a
+structured `dq_result` object that distinguishes automated corrections from
+issues requiring analyst review.
+
+## Quick start
+
+```{r quickstart}
+library(erifunctions)
+
+# Load the bundled DR malaria case schema (falls back to local if Azure unavailable)
+schema <- load_dq_schema("dr", "malaria_case", azcontainer = NULL)
+
+# Run all automated checks
+result <- run_dq_checks(raw_data, schema)
+
+# Inspect
+result                # calls dq_report() automatically
+```
+
+## Schema anatomy
+
+Each schema is a YAML file in `inst/schemas/` (or optionally in Azure
+`schemas/`). The key blocks are:
+
+```yaml
+country: dr
+disease: malaria_case
+version: "1.0"
+
+preprocessing:
+  - remove_smart_quotes      # fix curly quotes from Excel
+  - strip_column_name_spaces # remove spaces/parens from header row
+
+temporal:
+  date_col:  sample_date
+  year_col:  year
+  cross_check_year_col: year  # flags rows where year != year(sample_date)
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, Año, ano]      # recognised alternative column names
+    range: [2000, 2035]
+
+  province:
+    required: true
+    type: character
+    aliases: [Province_Residence, Provincia_residencia]
+    allowed_values: [Distrito Nacional, Santo Domingo, ...]
+    translations:                  # auto-corrected silently
+      "sto. Domingo": "Santo Domingo"
+    corrections:                   # also auto-corrected
+      "Sto Domingo": "Santo Domingo"
+
+derived:
+  imported_flag:
+    formula: "as.integer(province %in% c('Haiti', 'Extranjero', 'Otros'))"
+
+consistency:
+  epiweek_valid:
+    lhs: epiweek
+    op: ">="
+    rhs_value: 1
+    message: "Epiweek below 1"
+  positives_le_tested:
+    lhs: n_positive
+    op: "<="
+    rhs: n_tested
+    message: "Positives exceed tested"
+```
+
+## What `run_dq_checks()` does
+
+The pipeline runs these steps in order:
+
+1. **Preprocessing** — removes smart quotes, optionally strips column name
+   whitespace, drops rows with a missing year value.
+2. **Alias resolution** — renames recognised alternative column headers to the
+   canonical name defined in the schema.
+3. **Required-column check** — adds a `NA`-row flag for any column marked
+   `required: true` that is completely absent from the data.
+4. **Type coercion** — converts columns to `numeric`, `date`, or `character`
+   as declared; flags values that cannot be coerced.
+5. **Range checks** — flags numeric values outside the `[min, max]` range.
+6. **Translations and corrections** — applies the lookup maps silently,
+   logging each change to `$log`.
+7. **Allowed-values check** — flags values not in the `allowed_values` list.
+8. **NA fill** — fills `NA` in `na_fill`-annotated columns with the specified
+   default and logs the change.
+9. **Temporal cross-check** — flags rows where `year(date_col) != year_col`.
+10. **Derived columns** — evaluates each `formula` with `with(data, ...)` and
+    adds the result as a new column.
+11. **Aggregate consistency** — for any derived column, checks the formula
+    against the existing value and flags discrepancies (useful for pre-computed
+    totals).
+
+## Inspecting the result
+
+```{r inspect}
+# Full formatted report
+dq_report(result)
+
+# Access components directly
+cleaned <- result$data    # tibble with corrections applied + derived columns
+log     <- result$log     # what was changed automatically
+flags   <- result$flags   # what needs analyst attention
+```
+
+The `$log` tibble records every automated correction:
+
+| row | column   | original_value | corrected_value | rule        | action    |
+|-----|----------|----------------|-----------------|-------------|-----------|
+| 3   | province | sto. Domingo   | Santo Domingo   | translation | corrected |
+
+The `$flags` tibble records everything requiring review:
+
+| row | column  | value | issue                              |
+|-----|---------|-------|------------------------------------|
+| 12  | epiweek | 55    | Value outside expected range [1, 53] |
+| NA  | species | NA    | Required column is missing          |
+
+## Anomaly detection
+
+After the baseline checks you can chain additional anomaly detectors. All
+three accept either a plain tibble or a `dq_result`, and return the same
+type — so they compose with `|>`.
+
+### Period-over-period percent change
+
+```{r pct-change}
+# Aggregate first, then check for unusual week-to-week swings
+weekly <- dplyr::count(result$data, year, epiweek, province, name = "n_cases")
+
+result <- result |>
+  add_anomaly_pct_change(
+    value_col  = "n_cases",
+    period_col = "epiweek",
+    year_col   = "year",
+    group_cols = "province",
+    threshold  = 0.5   # flag > 50% change
+  )
+```
+
+Two columns are added to `$data`: `pct_change_n_cases` and
+`anomaly_pct_change_n_cases`. Flagged rows are also appended to `$flags`.
+
+### Structural gaps
+
+```{r gaps}
+gaps <- result |>
+  add_anomaly_gaps(
+    period_col  = "epiweek",
+    period_type = "week",
+    group_cols  = "province",
+    year_col    = "year"
+  )
+```
+
+Returns a tibble of missing epiweek/group combinations, or appends them to
+`$flags` when given a `dq_result`.
+
+### Cross-field consistency rules
+
+```{r consistency}
+result <- result |> add_anomaly_consistency(schema)
+```
+
+Evaluates every rule in the schema's `consistency:` block against the cleaned
+data (including derived columns). Use this after `run_dq_checks()` so that
+derived columns are available.
+
+### Spatial admin name validation
+
+```{r spatial}
+# Requires Azure access and the sf/terra packages
+result <- result |> add_anomaly_spatial(schema)
+```
+
+Downloads the reference shapefile from Azure and flags province or commune
+names that do not appear in the canonical list. Skipped gracefully when
+Azure is unavailable.
+
+## Custom checks
+
+Pass a list of functions to `run_dq_checks()` for checks that cannot be
+expressed in YAML:
+
+```{r custom}
+check_no_future_dates <- function(data, log, flags) {
+  future_rows <- which(data$sample_date > Sys.Date())
+  if (length(future_rows) > 0) {
+    flags <- dplyr::bind_rows(
+      flags,
+      tibble::tibble(
+        row    = future_rows,
+        column = "sample_date",
+        value  = as.character(data$sample_date[future_rows]),
+        issue  = "sample_date is in the future"
+      )
+    )
+  }
+  list(data = data, log = log, flags = flags)
+}
+
+result <- run_dq_checks(raw_data, schema, custom_checks = list(check_no_future_dates))
+```
+
+## Exporting results
+
+Once satisfied with the cleaned data, export for downstream use:
+
+```{r export}
+# Parquet for analysis pipelines
+arrow::write_parquet(result$data, "data/clean/dr_malaria_clean.parquet")
+
+# Excel summary for review meetings
+eri_report_excel(
+  sheets = list(
+    data  = list(data = result$data,  title = "Cleaned data"),
+    flags = list(data = result$flags, title = "Flags for review"),
+    log   = list(data = result$log,   title = "Automated corrections")
+  ),
+  path  = "outputs/dq_review.xlsx"
+)
+```

--- a/vignettes/epi-analytics.Rmd
+++ b/vignettes/epi-analytics.Rmd
@@ -1,0 +1,193 @@
+---
+title: "Epidemiological Analytics"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Epidemiological Analytics}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+This vignette covers the epidemiological helper functions for malaria, lymphatic
+filariasis, and onchocerciasis analyses — from computing incidence rates and
+epiweek dates to LF pooled prevalence and onchocerciasis programme-status maps.
+
+## Malaria: incidence and epidemic curves
+
+### Incidence rate
+
+```{r incidence}
+library(erifunctions)
+library(dplyr)
+
+weekly <- result$data |>
+  group_by(year, epiweek, province) |>
+  summarise(n_cases = n(), .groups = "drop") |>
+  left_join(population_data, by = c("year", "province")) |>
+  mutate(rate_per_1000 = eri_incidence_rate(n_cases, population, multiplier = 1000))
+```
+
+Rows with `population <= 0` or `NA` values automatically return `NA` to avoid
+silent division errors.
+
+### Epiweek dates
+
+Convert CDC epiweek numbers to calendar dates for time-series plots:
+
+```{r epiweek}
+weekly <- weekly |>
+  mutate(week_start = eri_epiweek_date(year, epiweek, week_start = "Sunday"))
+
+library(ggplot2)
+ggplot(weekly, aes(week_start, n_cases, colour = province)) +
+  geom_line() +
+  labs(x = NULL, y = "Cases", title = "Weekly malaria cases by province") +
+  eri_brand_ggplot_theme()
+```
+
+### Study week
+
+`eri_study_week()` expresses epiweeks relative to an index event — useful for
+intervention analyses such as IRS campaigns:
+
+```{r study-week}
+irs_date <- as.Date("2023-06-15")
+
+weekly <- weekly |>
+  mutate(study_week = eri_study_week(year, epiweek, index_date = irs_date))
+
+# week < 0 = before IRS; week >= 1 = after IRS
+pre_post <- weekly |>
+  mutate(period = ifelse(study_week < 0, "Pre-IRS", "Post-IRS"))
+```
+
+### Epiweek from date
+
+Convert individual case dates to epiweek numbers for aggregation:
+
+```{r date-to-epiweek}
+cases <- cases |>
+  mutate(epiweek = eri_date_to_epiweek(sample_date))
+```
+
+## Branded ggplot theme and colour palette
+
+All ERI figures should use `eri_brand_ggplot_theme()` and colours from
+`eri_brand_colors()`:
+
+```{r theme}
+cols <- eri_brand_colors()
+# navy="#44546A"  blue="#4472C4"  orange="#ED7D31"
+# gold="#FFC000"  green="#70AD47" light_blue="#5B9BD5"  gray="#A5A5A5"
+
+ggplot(weekly, aes(week_start, rate_per_1000)) +
+  geom_col(fill = cols[["blue"]]) +
+  eri_brand_ggplot_theme() +
+  labs(title = "Malaria incidence rate", y = "Cases per 1 000")
+```
+
+## Lymphatic filariasis: pooled prevalence
+
+LF TAS data is typically collected in pools (FTS cards). Use
+`eri_lf_pooled_prev()` to estimate individual-level prevalence from pool
+results using the standard formula
+`1 - ((1 - npos/npool)^(1/pool_size))`.
+
+```{r lf-prev}
+# Scalar estimate for a single survey
+eri_lf_pooled_prev(npos = 3, npool = 100, pool_size = 5)
+
+# Per-commune estimates
+commune_prev <- tas_data |>
+  group_by(commune) |>
+  summarise(
+    npos      = sum(fts_result == "Positive"),
+    npool     = n(),
+    pool_size = mean(pool_size, na.rm = TRUE),
+    .groups   = "drop"
+  ) |>
+  mutate(pooled_prev = eri_lf_pooled_prev(npos, npool, pool_size))
+```
+
+The function warns (rather than errors) when `npos > npool` and returns `NA`
+for those rows, so batch processing is not interrupted.
+
+## Lymphatic filariasis: MDA coverage
+
+Use the `ht_lf_mda` and `dr_lf_mda` schemas to clean coverage data, then
+compute programme indicators:
+
+```{r lf-mda}
+schema <- load_dq_schema("ht", "lf_mda", azcontainer = NULL)
+result <- run_dq_checks(raw_mda, schema)
+
+coverage <- result$data |>
+  mutate(
+    coverage_pct = treated / target_pop * 100,
+    reached_80   = coverage_pct >= 80
+  )
+
+dplyr::count(coverage, year, reached_80)
+```
+
+## Onchocerciasis: programme status map
+
+Onchocerciasis uses a standardised five-level programme status framework.
+`eri_oncho_program_levels()` returns the ordered factor levels used across
+all OEPA visualisations, and `eri_oncho_status_map()` produces a
+ready-to-insert `ggplot` object:
+
+```{r oncho}
+eri_oncho_program_levels()
+# [1] "Non-endemic"
+# [2] "Under surveillance"
+# [3] "MDA ongoing"
+# [4] "MDA stopped - under surveillance"
+# [5] "Verified free of transmission"
+
+eus <- eri_spatial_load("oepa", level = 2)
+
+status_map <- eri_oncho_status_map(
+  shapefile   = eus,
+  status_data = programme_status_2024,
+  eu_col      = "eu_name",
+  status_col  = "programme_status",
+  title       = "OEPA Onchocerciasis Programme Status 2024",
+  scale_bar   = TRUE,
+  north_arrow = TRUE
+)
+```
+
+## Styled tables
+
+`eri_table()` produces a Carter Center-branded `flextable` that renders
+consistently in PowerPoint, HTML, and Excel:
+
+```{r table}
+summary_tbl <- weekly |>
+  group_by(province) |>
+  summarise(
+    total_cases = sum(n_cases),
+    mean_weekly = round(mean(n_cases), 1),
+    peak_rate   = max(rate_per_1000, na.rm = TRUE)
+  )
+
+ft <- eri_table(
+  summary_tbl,
+  title    = "Malaria summary by province",
+  footnote = "Source: DIGEPI surveillance data"
+)
+
+# Insert into a PowerPoint presentation
+eri_pptx_create() |>
+  eri_pptx_add_title("Hispaniola Malaria 2024") |>
+  eri_pptx_add_table(summary_tbl, title = "Province summary") |>
+  eri_pptx_save("outputs/malaria_2024.pptx")
+```

--- a/vignettes/research-workflow.Rmd
+++ b/vignettes/research-workflow.Rmd
@@ -1,0 +1,183 @@
+---
+title: "Research Project Workflow"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Research Project Workflow}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+The research workflow functions scaffold a reproducible project structure that
+ties a local working directory to a corresponding folder in Azure blob storage.
+This ensures data lineage, reproducibility across analysts, and clean separation
+of raw, cleaned, and output data.
+
+## Starting a new project
+
+Call `eri_research_init()` once at the beginning of a study. It creates the
+local scaffold and the corresponding Azure directory:
+
+```{r init}
+library(erifunctions)
+
+eri_research_init(
+  project_name = "dr_irs_2024",
+  country      = "dr",
+  disease      = "malaria",
+  description  = "Interrupted time-series analysis of IRS impact on malaria incidence"
+)
+```
+
+This creates:
+
+```
+<project_root>/
+├── data/          # raw data downloads go here
+├── figs/          # all figures
+├── outputs/       # cleaned data, model results, reports
+└── research.yaml  # project manifest (auto-managed)
+```
+
+And in Azure: `research/dr_irs_2024/`
+
+Use `dry_run = TRUE` to preview what will be created without writing anything.
+
+## Resuming a session
+
+At the top of every subsequent work session, call `eri_research_resume()` to
+reconnect and see a brief project summary:
+
+```{r resume}
+eri_research_resume()
+# ✔ Project: 'dr_irs_2024' (dr / malaria)
+#   Azure:      research/dr_irs_2024/
+#   Last pull:  2024-03-10T14:32:00Z
+#   Last log:   [2024-03-10T15:01:00Z] Ran ITS model — negative binomial converged.
+#   Snapshots:  2
+```
+
+## Pulling data
+
+Use `eri_research_pull()` to download a specific dataset from Azure into
+`data/`. The pull is recorded in `research.yaml` for reproducibility:
+
+```{r pull}
+eri_research_pull(
+  blob_path  = "clean/dr_malaria_clean.parquet",
+  local_name = "dr_malaria_clean.parquet"
+)
+# Downloads to data/dr_malaria_clean.parquet
+# Records: blob_path, local_name, file hash, timestamp in research.yaml
+```
+
+## Logging decisions
+
+Record analytical decisions in the project lab notebook with `eri_research_log()`:
+
+```{r log}
+eri_research_log("Excluded 2020 data due to COVID-19 disruptions to surveillance.")
+eri_research_log("Chose negative binomial GLM over Poisson — overdispersion confirmed (dispersion test p < 0.001).")
+eri_research_log("Index date set to 2023-06-15 based on IRS deployment records from DIGEPI.")
+```
+
+Entries are stored with a UTC timestamp in `research.yaml` and can be reviewed
+any time by calling `eri_research_resume()`.
+
+## Snapshotting outputs
+
+Before a major analysis step (model run, sensitivity analysis), save a snapshot
+of your output files to Azure for rollback if needed:
+
+```{r snapshot}
+eri_research_snapshot(
+  files = c("outputs/its_results.csv", "outputs/coef_table.csv"),
+  note  = "Baseline ITS model before adding province fixed effects"
+)
+```
+
+Snapshots are stored at `research/dr_irs_2024/snapshots/<timestamp>/`.
+
+## Uploading outputs
+
+When your analysis is complete, push cleaned data and final outputs back to Azure:
+
+```{r push}
+eri_research_push(
+  local_path = "outputs/dr_malaria_clean.parquet",
+  blob_path  = "clean/dr_malaria_clean_v2.parquet"
+)
+```
+
+## Typical session structure
+
+A typical analysis session follows this pattern:
+
+```{r session-structure}
+# ── 1. Resume ───────────────────────────────────────────────────────────────
+eri_research_resume()
+
+# ── 2. Pull data ────────────────────────────────────────────────────────────
+eri_research_pull("clean/dr_malaria_clean.parquet", "dr_malaria_clean.parquet")
+df <- arrow::read_parquet("data/dr_malaria_clean.parquet")
+
+# ── 3. Analyse ──────────────────────────────────────────────────────────────
+schema <- load_dq_schema("dr", "malaria_case", azcontainer = NULL)
+result <- run_dq_checks(df, schema) |>
+  add_anomaly_pct_change("n_cases", "epiweek", year_col = "year",
+                          group_cols = "province")
+
+eri_research_log("DQ checks complete — 12 out-of-range epiweek values flagged.")
+
+# ── 4. Snapshot before modelling ────────────────────────────────────────────
+arrow::write_parquet(result$data, "outputs/dr_malaria_dq.parquet")
+eri_research_snapshot("outputs/dr_malaria_dq.parquet", note = "Post-DQ data")
+
+# ── 5. Report ────────────────────────────────────────────────────────────────
+eri_report_excel(
+  sheets = list(
+    data  = list(data = result$data,  title = "Cleaned data"),
+    flags = list(data = result$flags, title = "Flags for review")
+  ),
+  path = "outputs/dq_review.xlsx"
+)
+
+# ── 6. Push outputs ──────────────────────────────────────────────────────────
+eri_research_push("outputs/dq_review.xlsx", "research/dr_irs_2024/dq_review.xlsx")
+
+eri_research_log("Session complete. DQ review shared with DIGEPI counterparts.")
+```
+
+## Azure data access
+
+All Azure connectivity goes through two environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ERIFUNCTIONS_DATA_STORAGE_NAME` | `"data"` | Main data blob container |
+| `ERIFUNCTIONS_LOGS_STORAGE_NAME` | `"logs"` | Access log container |
+
+Set these in your `.Renviron` (or in the project `.Renviron.local`) using
+`usethis::edit_r_environ()`. Authentication uses your Azure AD credentials via
+`AzureAuth` — run `get_azure_storage_connection()` interactively once to cache
+the token.
+
+```{r environ}
+# In .Renviron:
+# ERIFUNCTIONS_DATA_STORAGE_NAME=data
+# ERIFUNCTIONS_LOGS_STORAGE_NAME=logs
+# ERI_ANALYST_ID=nkishore
+```
+
+## Data policy
+
+Raw and cleaned surveillance data must never leave Azure or this machine.
+Only aggregate summaries, model coefficients, and formatted reports should be
+shared externally. See the team data handling policy for details.

--- a/vignettes/spatial-workflow.Rmd
+++ b/vignettes/spatial-workflow.Rmd
@@ -1,0 +1,169 @@
+---
+title: "Spatial Workflow"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Spatial Workflow}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+The spatial workflow covers three use cases: loading canonical admin boundaries
+from Azure, joining GPS coordinates to those boundaries, and producing
+programmatic maps. All functions require the `sf` package.
+
+## Loading admin boundaries
+
+Admin boundaries are stored in Azure at
+`spatial/{country}/adm{level}.rds` as validated `sf` objects.
+Levels follow the standard hierarchy: 0 = country, 1 = department/region,
+2 = province/commune, 3 = municipality/locality, 4 = sub-locality.
+
+```{r load}
+library(erifunctions)
+
+# Load Haiti commune (adm2) boundaries
+communes <- eri_spatial_load("ht", level = 2)
+
+# Load DR province (adm2) boundaries
+provinces <- eri_spatial_load("dr", level = 2)
+```
+
+Every object loaded from Azure has been validated to have:
+- A defined CRS (WGS 84, EPSG 4326)
+- No empty geometries
+- A canonical name column `adm{level}_name`
+
+## Uploading new boundaries
+
+When adding a new country or updating boundaries, use `eri_spatial_upload()`.
+It validates the shapefile before accepting the upload:
+
+```{r upload}
+# Prepare your shapefile first:
+#   - Set CRS to 4326 if not already set
+#   - Rename the admin name column to adm2_name
+#   - Remove any empty geometries
+
+eri_spatial_upload(
+  local_path = "data/shapefiles/hti_adm2.shp",
+  country    = "ht",
+  level      = 2
+)
+```
+
+The function blocks with a descriptive error if any validation check fails,
+explaining exactly what to fix.
+
+## Spatial join: GPS coordinates to admin units
+
+Use `eri_spatial_join()` to assign admin unit names to point data with lat/lon
+columns. Rows with missing coordinates are dropped with a warning.
+
+```{r join}
+# Load the reference boundary
+communes <- eri_spatial_load("ht", level = 2)
+
+# Attach commune and department names to case records
+case_data <- eri_spatial_join(
+  data       = raw_cases,
+  lat_col    = "latitude",
+  lon_col    = "longitude",
+  shapefile  = communes,
+  admin_cols = c("adm2_name", "adm1_name")
+)
+```
+
+The result is a plain tibble — geometry is dropped automatically, so downstream
+analysis does not need to handle `sf` objects.
+
+## Bounding box expansion
+
+When composing maps it is often useful to add a buffer around the study area
+so that boundary features are fully visible. `eri_bbox_expand()` takes an `sf`
+bounding box and expands it by a specified distance in metres:
+
+```{r bbox}
+library(sf)
+
+haiti <- eri_spatial_load("ht", level = 0)
+bbox  <- sf::st_bbox(haiti) |>
+  eri_bbox_expand(X = 30000, Y = 30000)   # 30 km padding on all sides
+
+# Use the expanded bbox as a crop/map extent
+```
+
+## Choropleth maps
+
+Combine `eri_spatial_load()` with `eri_brand_ggplot_theme()` and standard
+`ggplot2` / `sf` functions to produce branded choropleth maps.
+
+```{r choropleth}
+library(ggplot2)
+library(sf)
+
+# Aggregate case counts by commune
+case_counts <- dplyr::count(case_data, adm2_name, name = "n_cases")
+
+# Join to boundaries
+map_data <- dplyr::left_join(communes, case_counts, by = "adm2_name")
+
+ggplot(map_data) +
+  geom_sf(aes(fill = n_cases), colour = "white", linewidth = 0.2) +
+  scale_fill_gradient(
+    low  = "#E8F4FD",
+    high = eri_brand_colors()[["navy"]],
+    na.value = "grey90",
+    name = "Cases"
+  ) +
+  labs(title = "Malaria cases by commune") +
+  eri_brand_ggplot_theme()
+```
+
+## LandScan population raster
+
+LandScan global population rasters are stored in Azure under
+`spatial/landscan/`. Use `eri_spatial_load_landscan()` (from `R/spatial.R`)
+to load the raster for a given year, then extract population for each admin
+unit using the `exactextractr` package:
+
+```{r landscan}
+library(terra)
+library(exactextractr)
+
+pop_raster <- eri_spatial_load_landscan(year = 2023)
+communes   <- eri_spatial_load("ht", level = 2)
+
+# Sum population pixels within each commune
+communes$population <- exact_extract(pop_raster, communes, "sum")
+```
+
+## Onchocerciasis programme-status maps
+
+For OEPA onchocerciasis data, `eri_oncho_status_map()` wraps the full mapping
+pipeline — it joins status data to a shapefile, applies the standard ERI
+programme-status colour palette, and adds a scale bar and north arrow:
+
+```{r oncho-map}
+eus     <- eri_spatial_load("oepa", level = 2)  # evaluation unit boundaries
+status  <- read_dq_result("outputs/oepa_status_2024.parquet")
+
+map <- eri_oncho_status_map(
+  shapefile   = eus,
+  status_data = status,
+  eu_col      = "eu_name",
+  status_col  = "programme_status",
+  title       = "OEPA Onchocerciasis Programme Status 2024"
+)
+
+eri_pptx_create() |>
+  eri_pptx_add_plot(map, title = "Programme Status") |>
+  eri_pptx_save("outputs/oepa_status_report.pptx")
+```


### PR DESCRIPTION
## Summary

- Adds `vignettes/dq-pipeline.Rmd` — schema anatomy, `run_dq_checks()` pipeline, anomaly detectors, custom checks, and export to Excel (#99)
- Adds `vignettes/spatial-workflow.Rmd` — loading boundaries, uploading shapefiles, spatial join, bbox expansion, choropleth maps, LandScan population, oncho status maps (#100)
- Adds `vignettes/epi-analytics.Rmd` — incidence rate, epiweek dates, study week, LF pooled prevalence, MDA coverage, oncho programme maps, branded tables (#101)
- Adds `vignettes/research-workflow.Rmd` — project init, session resume, data pull, lab notebook logging, snapshots, output push, full session walkthrough (#102)
- Adds `knitr` to Suggests and `VignetteBuilder: knitr` to DESCRIPTION

All code chunks use `eval=FALSE` so vignettes build without Azure access or large dependencies.

## Test plan

- [ ] `devtools::check(vignettes=FALSE)` passes (0 errors)
- [ ] `devtools::build_vignettes()` renders all four HTML files without errors locally
- [ ] Vignette index entries appear correctly in pkgdown / `browseVignettes("erifunctions")`

Closes #99
Closes #100
Closes #101
Closes #102