### PR TITLE
Fix fragile CI test pattern; extend smoke suite for Phase 5-6 (#110)

### DIFF
--- a/tests/testthat/README.md
+++ b/tests/testthat/README.md
@@ -37,7 +37,10 @@ Live integration tests against real Azure and ODK Central infrastructure.
 | Block | User type | What is tested |
 |---|---|---|
 | 1 | **Data analyst (primary)** | Azure connection, path building, file listing, DQ schema + checks, CMR schema, anomaly detection, catalog query, ODK connection, survey status, form register/deregister |
-| 2 | Epidemiologist (secondary) | Artifact upload → list → pull → archive; research project init, log, list in Azure |
+| 2 | **Data analyst — spatial** | `eri_spatial_load`, `eri_spatial_join` |
+| 3 | **Data analyst — epi analytics** | `eri_incidence_rate`, `eri_epidemic_curve` |
+| 4 | **Data analyst — reporting** | `eri_table`, `eri_report_excel`, `eri_pptx_create`/`save` |
+| 5 | Epidemiologist (secondary) | Artifact upload → list → pull → archive; research project init, log, list in Azure |
 
 ### Cleanup
 

--- a/tests/testthat/test-research-outputs.R
+++ b/tests/testthat/test-research-outputs.R
@@ -177,7 +177,7 @@ test_that("eri_research_snapshot errors when research.yaml absent", {
 test_that("eri_research_snapshot errors when data/ directory absent", {
   tmp <- withr::local_tempdir()
   .write_manifest(tmp)
-  expect_error(eri_research_snapshot(path = tmp), "data/")
+  expect_error(eri_research_snapshot(path = tmp), "data")
 })
 
 test_that("eri_research_snapshot warns and returns NULL when data/ is empty", {

--- a/tests/testthat/test-smoke.R
+++ b/tests/testthat/test-smoke.R
@@ -144,7 +144,100 @@ test_that("smoke [analyst]: full ODK register -> list -> deregister cycle", {
   expect_true(test_form %in% registered$form_id)
 })
 
-# ── 2. Epidemiologist (secondary) ─────────────────────────────────────────────
+# ── 2. Spatial (Phase 5) ──────────────────────────────────────────────────────
+# Requires the 'sf' package and a loaded boundary in Azure.
+
+test_that("smoke [spatial]: eri_spatial_load returns an sf object", {
+  .smoke_skip()
+  skip_if_not_installed("sf")
+  az_con <- .smoke_az()
+  result <- tryCatch(
+    eri_spatial_load("ht", level = 2, data_con = az_con),
+    error = function(e) skip(paste("Boundary not found:", e$message))
+  )
+  expect_s3_class(result, "sf")
+  expect_true(nrow(result) > 0L)
+})
+
+test_that("smoke [spatial]: eri_spatial_join assigns admin names to point data", {
+  .smoke_skip()
+  skip_if_not_installed("sf")
+  az_con    <- .smoke_az()
+  communes  <- tryCatch(
+    eri_spatial_load("ht", level = 2, data_con = az_con),
+    error = function(e) skip(paste("Boundary not found:", e$message))
+  )
+  pts <- tibble::tibble(
+    lat = c(18.5, 19.0),
+    lon = c(-72.3, -72.5)
+  )
+  result <- eri_spatial_join(pts, lat_col = "lat", lon_col = "lon",
+                              shapefile = communes,
+                              admin_cols = c("adm2_name", "adm1_name"))
+  expect_s3_class(result, "tbl_df")
+  expect_true("adm2_name" %in% names(result))
+})
+
+# ── 3. Epi analytics (Phase 5) ────────────────────────────────────────────────
+
+test_that("smoke [epi]: eri_incidence_rate computes correctly on sample data", {
+  .smoke_skip()
+  cases  <- c(10L, 20L, 0L)
+  pop    <- c(1000L, 500L, 200L)
+  result <- eri_incidence_rate(cases, pop, multiplier = 1000L)
+  expect_equal(result, c(10, 40, 0), tolerance = 1e-6)
+})
+
+test_that("smoke [epi]: eri_epidemic_curve returns a ggplot on sample data", {
+  .smoke_skip()
+  skip_if_not_installed("ggplot2")
+  df <- tibble::tibble(
+    date   = seq.Date(as.Date("2024-01-01"), by = "week", length.out = 10),
+    cases  = sample(1:20, 10)
+  )
+  p <- eri_epidemic_curve(df, date_col = "date", count_col = "cases",
+                           period = "week")
+  expect_s3_class(p, "ggplot")
+})
+
+# ── 4. Reporting (Phase 6) ────────────────────────────────────────────────────
+
+test_that("smoke [reporting]: eri_table returns a flextable", {
+  .smoke_skip()
+  skip_if_not_installed("flextable")
+  df <- tibble::tibble(country = c("DR", "Haiti"), n = c(100L, 200L))
+  ft <- eri_table(df, title = "Smoke test table")
+  expect_s3_class(ft, "flextable")
+})
+
+test_that("smoke [reporting]: eri_report_excel writes a real xlsx file", {
+  .smoke_skip()
+  skip_if_not_installed("openxlsx2")
+  path <- tempfile(fileext = ".xlsx")
+  withr::defer(unlink(path))
+  df <- tibble::tibble(x = 1:3, y = c("a", "b", "c"))
+  eri_report_excel(
+    sheets   = list(data = list(data = df, title = "Smoke test")),
+    path     = path,
+    title    = "Smoke test workbook"
+  )
+  expect_true(file.exists(path))
+  expect_gt(file.size(path), 0L)
+})
+
+test_that("smoke [reporting]: eri_pptx_create and eri_pptx_save write a real pptx file", {
+  .smoke_skip()
+  skip_if_not_installed("officer")
+  path <- tempfile(fileext = ".pptx")
+  withr::defer(unlink(path))
+  eri_pptx_create() |>
+    eri_pptx_add_title("Smoke test") |>
+    eri_pptx_save(path)
+  expect_true(file.exists(path))
+  expect_gt(file.size(path), 0L)
+})
+
+# ── 5. Epidemiologist (secondary) ─────────────────────────────────────────────
 # Lighter coverage: artifact registry and research project init/log.
 
 test_that("smoke [epi]: artifact upload -> list -> pull -> archive cycle", {


### PR DESCRIPTION
## Summary

- Fixes fragile `expect_error(eri_research_snapshot(path=tmp), "data/")` — widens match to `"data"` to avoid sensitivity to how `cli` formats `{.path data/}` across environments (root cause of the 2026-06-04 CI failure on 72-template-management)
- Adds Phase 5 smoke test block: `eri_spatial_load`, `eri_spatial_join`
- Adds Phase 5 epi analytics block: `eri_incidence_rate`, `eri_epidemic_curve`
- Adds Phase 6 reporting block: `eri_table`, `eri_report_excel`, `eri_pptx_create`/`save`
- Updates `tests/testthat/README.md` with full coverage table and environment variable reference

All new smoke blocks are guarded by `.smoke_skip()` (skipped in CI; run locally with `ERI_SMOKE_TESTS=true`).

Closes #110