### PR TITLE
Add SharePoint workflow and adding-a-program vignettes (#115)

### DIFF
--- a/vignettes/adding-a-program.Rmd
+++ b/vignettes/adding-a-program.Rmd
@@ -1,0 +1,158 @@
+---
+title: "Adding a New NTD Program"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Adding a New NTD Program}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+This vignette walks through the full process of adding a new disease program
+to `erifunctions` -- from generating skeleton schemas to opening a pull request.
+Estimated time: 1--2 hours for a new country/disease combination.
+
+## 1. Generate skeleton schemas
+
+`eri_onboard_disease()` writes one YAML file per data type:
+
+```{r scaffold}
+library(erifunctions)
+
+eri_onboard_disease(
+  disease    = "schisto",
+  country    = "ug",
+  data_types = c("mda", "prevalence"),
+  output_dir = "schemas/"     # write locally, not to the package
+)
+# Writes schemas/ug_schisto_mda.yaml and schemas/ug_schisto_prevalence.yaml
+```
+
+Use `dry_run = TRUE` first to preview what will be written:
+
+```{r dry-run}
+eri_onboard_disease("rb", "eth", dry_run = TRUE)
+```
+
+## 2. Fill in disease-specific columns
+
+Open each skeleton file and complete the TODO sections:
+
+```yaml
+# ug_schisto_mda.yaml (excerpt)
+columns:
+  species_target:
+    required: true
+    type: categorical
+    aliases: [Species, species, schisto_species]
+    allowed_values:
+      - S.mansoni        # fill in the species relevant to this country
+      - S.haematobium
+
+  school_name:           # add country-specific columns here
+    required: false
+    type: character
+    aliases: [School, school_name, etablissement]
+```
+
+Key decisions to make for each column:
+
+- **`required`** -- will the pipeline hard-error if this column is missing?
+- **`type`** -- `numeric`, `character`, `categorical`, or `date`
+- **`aliases`** -- all the column name variants found in raw data files
+- **`range`** -- for numeric columns; flag implausible values
+- **`allowed_values`** -- for categorical columns; triggers a flag if a value is unexpected
+- **`translations`** -- map raw variants to a canonical value (e.g. `"YES"` -> `"Yes"`)
+
+## 3. Validate the schema
+
+Run `eri_schema_validate()` to check for structural problems:
+
+```{r validate}
+result <- eri_schema_validate("schemas/ug_schisto_mda.yaml")
+# Prints: "Schema ug_schisto_mda.yaml is valid." if no issues found
+# Or:     a summary of issues with field names and messages
+print(result)
+```
+
+Fix any flagged issues before moving on. Common problems:
+
+- Missing `required` or `type` on a column definition
+- A consistency rule referencing a column name not defined in `columns`
+- A `temporal.year_col` or `temporal.period_col` pointing to a column not in `columns`
+
+## 4. Test with sample data
+
+Before submitting, test the schema against real or synthetic data:
+
+```{r test-dq}
+schema <- load_dq_schema("ug", "schisto_mda", azcontainer = NULL)
+# azcontainer = NULL tells it to use the local file, not Azure
+
+# Create a small synthetic data frame that matches your schema
+sample_data <- data.frame(
+  year       = c(2023L, 2023L, 2024L),
+  round      = c(1L, 2L, 1L),
+  district   = c("Kampala", "Wakiso", "Kampala"),
+  target_pop = c(5000L, 3200L, 5100L),
+  treated    = c(4800L, 3100L, 4950L),
+  coverage_pct = c(96.0, 96.9, 97.1)
+)
+
+result <- run_dq_checks(sample_data, schema)
+cat("Flags:", nrow(result$flags), "\n")
+```
+
+If the sample data passes cleanly (`nrow(result$flags) == 0`), the schema is
+ready for real data.
+
+## 5. Submit to the package
+
+Copy the validated schema file to `inst/schemas/` using the naming convention
+`{country}_{disease}_{data_type}.yaml`:
+
+```
+inst/schemas/ug_schisto_mda.yaml
+inst/schemas/ug_schisto_prevalence.yaml
+```
+
+PR checklist:
+
+- [ ] Schema file is in `inst/schemas/` with correct name
+- [ ] `eri_schema_validate()` returns 0 issues
+- [ ] `load_dq_schema("ug", "schisto_mda", azcontainer = NULL)` works
+- [ ] At least one `load_dq_schema` + `eri_schema_validate` test added to
+  `tests/testthat/test-onboarding.R` following the existing pattern
+- [ ] NEWS.md entry in the next version section
+
+## 6. Optional: add disease-specific epi functions
+
+If the new program needs custom analytics beyond the generic DQ pipeline
+(e.g. DALY calculations, TAS interpretation, programme status maps), add
+them to a new file `R/epi_{disease}.R` following the pattern in
+`R/epi_lf.R`:
+
+```{r epi-template}
+# R/epi_schisto.R
+
+#' Compute school-level Kato-Katz prevalence from survey data
+#'
+#' @param data A tibble with one row per tested individual.
+#' @param result_col `chr` Column containing `"Positive"` / `"Negative"`.
+#' @param group_cols `chr` vector Grouping columns (school, district, year).
+#' @returns A tibble of prevalence estimates by group.
+#' @export
+eri_schisto_kk_prevalence <- function(data, result_col, group_cols) {
+  # implementation here
+}
+```
+
+Export and document following standard roxygen conventions, then add tests in
+`tests/testthat/test-epi-schisto.R`.

--- a/vignettes/sharepoint-workflow.Rmd
+++ b/vignettes/sharepoint-workflow.Rmd
@@ -1,0 +1,182 @@
+---
+title: "SharePoint Workflow"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{SharePoint Workflow}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+This vignette covers the full SharePoint read/write pattern using the `eri_sharepoint_*`
+functions. These functions require the `Microsoft365R` package:
+
+```{r install, eval=FALSE}
+install.packages("Microsoft365R")
+```
+
+## 1. Connect to a SharePoint site
+
+```{r connect}
+library(erifunctions)
+
+site <- eri_sharepoint_connect("https://cartercenter.sharepoint.com/sites/ERI")
+```
+
+`eri_sharepoint_connect()` opens a browser window for interactive authentication the first
+time. The token is cached by `AzureAuth` so subsequent calls within a session do not
+re-prompt.
+
+## 2. List files in a document library folder
+
+```{r list}
+# List the root of the default document library
+files <- eri_sharepoint_list(site)
+
+# List a specific subfolder
+weekly_files <- eri_sharepoint_list(site, "Shared Documents/Weekly Data/Haiti")
+print(weekly_files)
+# A tibble with columns: name, size, modified, is_folder, path
+```
+
+Filter to find the most recent weekly upload:
+
+```{r filter-list}
+library(dplyr)
+
+latest <- weekly_files |>
+  filter(!is_folder, grepl("\\.xlsx$", name)) |>
+  arrange(desc(modified)) |>
+  slice(1)
+
+cat("Latest file:", latest$name, "\n")
+cat("Modified:   ", format(latest$modified), "\n")
+```
+
+## 3. Read a file directly into R
+
+`eri_sharepoint_read()` downloads the file to a temp location and reads it based on
+the extension (`.xlsx`, `.csv`, `.parquet`, `.rds`).
+
+```{r read-excel}
+# Read an Excel file
+df <- eri_sharepoint_read(site, "Shared Documents/Weekly Data/Haiti/ht_weekly_2024.xlsx")
+head(df)
+```
+
+```{r read-csv}
+# Read a CSV file with extra readr arguments
+df_csv <- eri_sharepoint_read(
+  site,
+  "Shared Documents/Weekly Data/DR/dr_cases_2024.csv",
+  col_types = readr::cols(.default = "c")
+)
+```
+
+```{r read-sheet}
+# Read a specific Excel sheet
+df_sheet <- eri_sharepoint_read(
+  site,
+  "Shared Documents/Reports/annual_summary.xlsx",
+  sheet = "Malaria"
+)
+```
+
+For an unknown extension the function returns the local temp path so you can read
+it manually:
+
+```{r read-unknown}
+path <- eri_sharepoint_read(site, "Shared Documents/Data/custom_format.sav")
+# path is a character string -- use haven::read_sav(path) or similar
+```
+
+## 4. Upload a finished report to SharePoint
+
+```{r upload}
+# Push a local Excel report to the team SharePoint
+eri_sharepoint_upload(
+  local_path  = "outputs/ht_malaria_weekly_summary.xlsx",
+  site        = site,
+  folder_path = "Shared Documents/Reports/Haiti/2024"
+)
+```
+
+The destination folder is created automatically if it does not exist. Use
+`overwrite = FALSE` to prevent accidentally replacing a file:
+
+```{r upload-guard}
+eri_sharepoint_upload(
+  local_path  = "outputs/ht_malaria_weekly_summary.xlsx",
+  site        = site,
+  folder_path = "Shared Documents/Reports/Haiti/2024",
+  overwrite   = FALSE   # errors if the file already exists
+)
+```
+
+The function returns the SharePoint item URL invisibly:
+
+```{r upload-url}
+url <- eri_sharepoint_upload("outputs/report.xlsx", site, "Shared Documents/Reports")
+cat("Shared at:", url, "\n")
+```
+
+## 5. Combined workflow
+
+The most common pattern is: pull data from SharePoint, run DQ checks, generate a
+report, push the report back.
+
+```{r full-workflow}
+library(erifunctions)
+library(dplyr)
+
+# ---- Step 1: connect ----
+site <- eri_sharepoint_connect("https://cartercenter.sharepoint.com/sites/ERI")
+
+# ---- Step 2: pull the latest weekly submission ----
+files <- eri_sharepoint_list(site, "Shared Documents/Weekly Data/Haiti")
+latest_path <- files |>
+  filter(!is_folder, grepl("\\.xlsx$", name)) |>
+  arrange(desc(modified)) |>
+  slice(1) |>
+  pull(path)
+
+raw <- eri_sharepoint_read(site, latest_path)
+
+# ---- Step 3: run DQ checks ----
+schema <- load_dq_schema("haiti", "malaria", azcontainer = NULL)
+result <- run_dq_checks(raw, schema)
+
+# ---- Step 4: generate a summary Excel report ----
+tmp_report <- tempfile(fileext = ".xlsx")
+eri_report_excel(
+  list(
+    data   = list(data = result$data),
+    flags  = list(data = result$flags)
+  ),
+  path = tmp_report
+)
+
+# ---- Step 5: push back to SharePoint ----
+week_label <- format(Sys.Date(), "%Y-W%V")
+eri_sharepoint_upload(
+  local_path  = tmp_report,
+  site        = site,
+  folder_path = paste0("Shared Documents/DQ Reports/Haiti/", week_label)
+)
+```
+
+## Authentication notes
+
+- Tokens are cached in `~/.AzureR/` by `AzureAuth`. If you are prompted every
+  session, check that `~/.AzureR/` is writable.
+- For scripted / CI use, prefer service-principal auth configured through
+  `Microsoft365R::create_sharepoint_site()` with `auth_type = "client_credentials"`.
+- All `eri_sharepoint_*` functions guard against `Microsoft365R` not being
+  installed and give a clear install instruction if it is absent.


### PR DESCRIPTION
## Summary

- `vignettes/sharepoint-workflow.Rmd` -- full connect/list/read/upload cycle with combined pull-DQ-report-push workflow example
- `vignettes/adding-a-program.Rmd` -- step-by-step: `eri_onboard_disease()`, schema editing, `eri_schema_validate()`, DQ test with sample data, PR checklist, and pattern for disease-specific epi functions

## Test plan

- [x] Both vignettes use `eval=FALSE` throughout -- no runtime dependencies
- [x] knitr can parse both files (no syntax errors)
- [x] VignetteIndexEntry titles match file names