### PR TITLE
Add V2 Phase 0 governance scaffolding

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,7 +7,10 @@
 ^cran-comments\.md$
 ^data-raw$
 ^pkgdown$
+^pkgdown_site$
 ^_pkgdown\.yml$
+^docs$
+^CLAUDE\.md$
 ^\.github$
 ^sandbox$
 ^\.claude$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,7 +36,9 @@ jobs:
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        # dest_dir must be pkgdown_site (not the default "docs"): docs/ holds the committed
+        # roadmap + ADRs, not pkgdown output (matches _pkgdown.yml `destination`).
+        run: pkgdown::build_site_github_pages(dest_dir = "pkgdown_site", new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,48 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+permissions:
+  contents: write
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict the deploy concurrency, not the build for PRs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: pkgdown_site

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ vignettes/*.pdf
 # R Environment Variables
 .Renviron
 
-# pkgdown site
-docs/
+# pkgdown site (built output; docs/ itself holds committed roadmap + ADRs)
+pkgdown_site/
 
 # translation temp files
 po/*~

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md — erifunctions working memory
+
+Project memory for anyone (human or AI) developing this package. Read this first, then the
+[V2 roadmap](docs/roadmap.md) and the [ADRs](docs/adr/) for the *why* behind the design.
+
+## What this is
+
+`erifunctions` is the Carter Center ERI team's R package — the API through which **Data
+Analysts (DAs)** and **Epidemiologists (Epis)** interact with TCC's Azure-centred data system
+across countries (Haiti, DR, Uganda, OEPA) and diseases (malaria, oncho, LF, SCH, STH). Users
+are domain experts, **not software developers**: they install with `install_github()` /
+`renv`, authenticate via interactive browser auth, and call functions — they do not edit the
+package. Optimise every change for *their* clarity and reliability.
+
+## Core model
+
+Data lives in the `data/` Azure blob under a canonical path built by `eri_data_path()`:
+
+```
+data/{country}/{disease}/{data_type}/{layer}/
+  raw/        as-received from source
+  staged/     DQ-checked, awaiting approval
+  processed/  analyst-approved, canonical
+```
+
+- **`eri_approve()` is the human gate.** Nothing reaches `processed/` without it; it writes an
+  approval log and registers the file in the data catalog (`_catalog/data_catalog.yaml`).
+- The `projects/` blob is the legacy contractor (hsp-mal) space; V2 is migrating authority to
+  `data/` (see roadmap Phase 3).
+- Metadata stores (catalog, ODK registry, artifact registry) are YAML blobs — see ADR-0002
+  for the concurrency rules when touching them.
+
+## Conventions
+
+- **Naming:** exported functions are `eri_*` (or domain verbs like `run_dq_checks`); internal
+  helpers are `.eri_*` and `@keywords internal`, not exported.
+- **Style:** `cli::cli_*` for all user-facing messages; roxygen2 with markdown; functions get
+  `@examples` (wrap live Azure/ODK calls in `\dontrun{}`).
+- **Source layout:** one domain per file in `R/` (`dal.R`, `dq.R`, `catalog.R`, `odk*.R`,
+  `research.R`, `reports*.R`, `spatial.R`, `epi*.R`, `onboarding.R`, …).
+- **Schemas** are bundled YAML under `inst/schemas/`; **templates** under `inst/templates/`.
+- After changing exports or roxygen, regenerate `NAMESPACE`/`man/` with `devtools::document()`.
+
+## Guardrail: global vs local solutions
+
+This codebase grew through project-driven development, which scattered local fixes for global
+problems. Before adding a function or pattern:
+
+1. **Search for an existing helper first** — reuse `azure_io()` / `eri_read()` / `eri_write()`
+   / `eri_data_path()` and the DQ/catalog/research machinery rather than re-implementing.
+2. If a problem is general (other countries/diseases/users would hit it), solve it generally
+   and put the decision in an **ADR** — don't bury a one-off in a single workflow.
+3. Keep the roadmap and ADRs current: if a change alters the plan or a decision, update
+   `docs/roadmap.md` / add an ADR in the same PR.
+
+## Before opening a PR
+
+- `devtools::document()` if exports/docs changed; `devtools::check()` should pass clean.
+- `devtools::test()` — unit tests run offline; live integration tests in
+  `tests/testthat/test-smoke.R` run only when `Sys.setenv(ERI_SMOKE_TESTS = "true")`.
+- Update `NEWS.md` under the current phase heading and bump `DESCRIPTION` `Version` if shipping.
+- Note: the cloud dev container has **no local R/quarto** — `R CMD check` and
+  `pkgdown::build_site()` are verified in GitHub Actions CI, not locally.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))
 Description: Key functions used by the Epidemiology, Research and Innovation Team in the Health Programs at the Carter Center.
-URL: https://github.com/thecartercenter/erifunctions
+URL: https://github.com/thecartercenter/erifunctions, https://thecartercenter.github.io/erifunctions
 BugReports: https://github.com/thecartercenter/erifunctions/issues
 Depends: R (>= 4.1.0)
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# erifunctions (development version)
+
+## V2 Phase 0 -- Governance & shared-memory scaffolding
+
+Documentation and project-infrastructure only; no changes to package functions.
+
+- `docs/roadmap.md` -- version-controlled V2 development roadmap (Phases 0-5)
+- `docs/adr/` -- architecture decision records (single-package vs split, concurrency-safe
+  metadata, token-derived identity, DuckDB query layer, pull-then-process, research-as-repos)
+- `docs/vision.md` -- the founding vision brief, moved out of the gitignored `sandbox/`
+- `CLAUDE.md` -- working memory and conventions for contributors (human and AI)
+- `_pkgdown.yml` + `.github/workflows/pkgdown.yaml` -- grouped-reference documentation site
+- README version banner corrected to 0.8.0 and linked to the roadmap
+
 # erifunctions 0.8.0
 
 ## Phase 7 -- SharePoint integration and multi-program expansion

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Standardized data tools for the Epidemiology, Research and Innovation (ERI) team at The Carter Center's NTD and malaria programs.
 
-**Version:** 0.5.0 · **Status:** Active development
+**Version:** 0.8.0 · **Status:** Active development
+
+> 🛣️ **Where this is going:** see the [V2 roadmap](docs/roadmap.md) and the
+> [architecture decision records](docs/adr/) for the development plan and the reasoning
+> behind key design choices.
 
 ---
 
@@ -234,3 +238,6 @@ To add a new country, run `eri_onboard_country()` and follow the checklist it pr
 
 - Open an issue: <https://github.com/thecartercenter/erifunctions/issues>
 - For developer contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md)
+- For the development roadmap and design decisions, see [docs/roadmap.md](docs/roadmap.md)
+  and [docs/adr/](docs/adr/); working conventions live in [CLAUDE.md](CLAUDE.md), and the
+  founding vision in [docs/vision.md](docs/vision.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # erifunctions
 
+<!-- badges: start -->
+[![R-CMD-check](https://github.com/thecartercenter/erifunctions/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/thecartercenter/erifunctions/actions/workflows/R-CMD-check.yaml)
+[![pkgdown](https://github.com/thecartercenter/erifunctions/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/thecartercenter/erifunctions/actions/workflows/pkgdown.yaml)
+<!-- badges: end -->
+
 Standardized data tools for the Epidemiology, Research and Innovation (ERI) team at The Carter Center's NTD and malaria programs.
 
 **Version:** 0.8.0 · **Status:** Active development

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,188 @@
+url: https://thecartercenter.github.io/erifunctions
+
+destination: pkgdown_site
+
+template:
+  bootstrap: 5
+
+navbar:
+  structure:
+    left:  [intro, reference, articles, roadmap, news]
+    right: [search, github]
+  components:
+    roadmap:
+      text: Roadmap
+      href: https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md
+
+articles:
+- title: Workflows
+  navbar: Workflows
+  contents:
+  - dq-pipeline
+  - epi-analytics
+  - spatial-workflow
+  - research-workflow
+  - sharepoint-workflow
+  - adding-a-program
+
+reference:
+- title: Connections & authentication
+  desc: Authenticate to Azure, ODK, SharePoint, and Teams.
+  contents:
+  - get_azure_storage_connection
+  - init_odk_connection
+  - eri_sharepoint_connect
+  - get_teams_connection
+
+- title: Reading & writing data
+  desc: Read, write, list, and manage files in Azure (and locally).
+  contents:
+  - eri_read
+  - eri_write
+  - eri_upload
+  - eri_list
+  - eri_file_exists
+  - eri_dir_exists
+  - eri_dir_create
+  - eri_delete
+  - eri_dir_delete
+  - eri_data_path
+  - erifunctions_io
+  - azure_io
+
+- title: Data pipeline
+  desc: Ingest, stage, approve, and trigger surveillance and CMR pipelines.
+  contents:
+  - eri_ingest
+  - eri_stage
+  - eri_approve
+  - eri_trigger
+  - eri_ingest_cmr
+  - eri_stage_cmr
+  - load_cmr_schema
+
+- title: Data quality
+  desc: Schema-driven DQ checks and anomaly detection.
+  contents:
+  - load_dq_schema
+  - run_dq_checks
+  - dq_result-methods
+  - dq_report
+  - add_anomaly_pct_change
+  - add_anomaly_gaps
+  - add_anomaly_consistency
+  - add_anomaly_spatial
+
+- title: Data catalog
+  desc: Register, query, and verify processed-layer data.
+  contents:
+  - eri_catalog_register
+  - eri_catalog_query
+  - eri_catalog_verify
+
+- title: ODK
+  desc: Register forms, sync submissions, monitor surveys, and manage users.
+  contents:
+  - eri_odk_register
+  - eri_odk_deregister
+  - eri_odk_list_registered
+  - eri_odk_sync
+  - eri_survey_status
+  - print.survey_status
+  - eri_odk_bulk_users
+  - list_odk_projects
+  - list_odk_forms
+  - download_odk_form
+  - download_form_attachments
+  - list_all_odk_app_users
+  - list_odk_form_users
+  - update_odk_app_user_role
+
+- title: Spatial
+  desc: Admin boundaries, LandScan population, and spatial joins.
+  contents:
+  - eri_spatial_load
+  - eri_spatial_upload
+  - eri_spatial_join
+  - eri_spatial_pop
+  - eri_bbox_expand
+  - eri_landscan_upload
+  - eri_landscan_list
+
+- title: Epi analytics
+  desc: Incidence, epiweeks, epidemic curves, and disease-specific functions.
+  contents:
+  - eri_incidence_rate
+  - eri_case_summary
+  - eri_epidemic_curve
+  - eri_epiweek_date
+  - eri_study_week
+  - eri_date_to_epiweek
+  - eri_epiweek_range
+  - eri_lf_pooled_prev
+  - eri_lf_program_levels
+  - eri_lf_tas_summary
+  - eri_lf_status_map
+  - eri_oncho_program_levels
+  - eri_oncho_status_map
+
+- title: Reporting & visual style
+  desc: Branded tables, themes, maps, and Excel/HTML/PowerPoint reports.
+  contents:
+  - eri_brand_colors
+  - eri_brand_ggplot_theme
+  - eri_color_scheme
+  - eri_plot_theme
+  - eri_table
+  - eri_map_choropleth
+  - eri_map_incidence
+  - eri_map_points
+  - eri_map_inset
+  - eri_report_excel
+  - eri_wb_create
+  - eri_wb_add_sheet
+  - eri_wb_save
+  - eri_report_html
+  - eri_report_qmd_template
+  - eri_pptx_create
+  - eri_pptx_add_title
+  - eri_pptx_add_section
+  - eri_pptx_add_table
+  - eri_pptx_add_plot
+  - eri_pptx_save
+
+- title: Research projects
+  desc: Scaffold studies, track provenance, manage artifacts, and snapshot data.
+  contents:
+  - eri_research_init
+  - eri_research_resume
+  - eri_research_log
+  - eri_research_list
+  - eri_research_pull
+  - eri_research_upload_figure
+  - eri_research_upload_output
+  - eri_research_snapshot
+  - eri_artifact_upload
+  - eri_artifact_list
+  - eri_artifact_pull
+  - eri_artifact_archive
+  - eri_template_list
+  - eri_template_pull
+  - eri_template_upload
+
+- title: SharePoint & Teams
+  desc: Share files via SharePoint and post notifications to Teams.
+  contents:
+  - eri_sharepoint_list
+  - eri_sharepoint_read
+  - eri_sharepoint_upload
+  - eri_teams_send
+  - eri_notify_dq
+
+- title: Onboarding new programs
+  desc: Scaffold schemas and Azure directories for a new country, disease, or CMR.
+  contents:
+  - eri_onboard_country
+  - eri_onboard_disease
+  - eri_onboard_cmr
+  - eri_schema_validate

--- a/docs/adr/0001-single-package-with-pkgdown.md
+++ b/docs/adr/0001-single-package-with-pkgdown.md
@@ -1,0 +1,36 @@
+# ADR-0001 — Stay a single package; solve discoverability with pkgdown
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+`erifunctions` exports ~110 functions in one package. There is a recurring instinct to split
+it into interdependent packages (`eriauth`, `eriresearch`, `erianalyst`, …) on the theory
+that the sheer number of functions is overwhelming for users.
+
+The package's users are **Data Analysts and Epidemiologists, not software developers**. They
+install via `install_github()` and pin with `renv`. Internal helpers such as `azure_io()`
+and `.eri_log_session()` are used throughout (I/O, pipeline, research, reporting all depend
+on them).
+
+## Decision
+
+**Keep `erifunctions` as a single package.** Address the discoverability problem with
+documentation, not package boundaries:
+
+- A **pkgdown site** with a **grouped function reference** (Connections / Data I/O / Pipeline
+  / Data quality / Catalog / ODK / Spatial / Epi analytics / Reporting / Research / Onboarding).
+- roxygen `@family` tags so related functions cross-link.
+- The two existing **role-based onboarding vignettes** (`eri_daily_workflow` for DAs,
+  `eri_research_workflow` for Epis) as the front door.
+
+## Consequences
+
+- **Easier:** one install, one version to pin, one release to cut, one CI matrix. Internal
+  helpers stay internal. Users get a curated, role-oriented entry point instead of a flat
+  function list.
+- **Harder / not doing:** no independent versioning of sub-domains; a consumer who wanted
+  *only* the auth layer still installs the whole package.
+- **Revisit when:** a separate repository genuinely needs the auth layer standalone — at that
+  point extract `eriauth` and depend on it. Until then this is YAGNI.

--- a/docs/adr/0002-concurrency-safe-metadata.md
+++ b/docs/adr/0002-concurrency-safe-metadata.md
@@ -1,0 +1,39 @@
+# ADR-0002 — Concurrency-safe, rebuildable metadata stores
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+Several metadata stores are single YAML blobs updated with a full read-modify-write cycle:
+
+- the data catalog — `eri_catalog_register()` reads `_catalog/data_catalog.yaml`, mutates the
+  list, and writes the whole thing back (`R/catalog.R`).
+- the ODK form registry (`R/odk_registry.R`).
+- the artifact registry (`R/artifacts.R`).
+
+If two analysts act at the same time (e.g. both approve data, which auto-registers a catalog
+entry), their writes race: the second overwrites the first and an entry is silently lost.
+This is the real concern behind "should we move to a formal database?" — the issue is
+**atomicity**, not SQL.
+
+## Decision
+
+1. **Optimistic concurrency on every metadata write.** Read the blob together with its ETag,
+   and write back conditionally (`If-Match` / AzureStor conditional upload). On a `412`
+   conflict, re-read, re-apply the change, and retry with small backoff.
+2. **Make the index rebuildable.** Add `eri_catalog_rebuild()` that reconstructs the catalog
+   by scanning the `processed/` directories of the `data/` blob. The catalog becomes a cache
+   of derivable truth, not an irreplaceable system of record.
+
+Implemented in **Phase 2** (architecture hardening), before concurrent surveillance approval
+becomes load-bearing.
+
+## Consequences
+
+- **Easier:** concurrent analysts no longer lose updates; a corrupted or stale catalog can be
+  regenerated rather than hand-repaired.
+- **Harder:** writes gain a retry loop and must thread the ETag through; a tiny amount of
+  added complexity in the metadata helpers.
+- **Not doing:** standing up a database server (Postgres). The blob remains the store of
+  record (see ADR-0004 for the query layer).

--- a/docs/adr/0003-token-derived-identity.md
+++ b/docs/adr/0003-token-derived-identity.md
@@ -1,0 +1,36 @@
+# ADR-0003 — Approver identity from the auth token
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+`eri_approve()` is the human gate that promotes staged data to `processed/`. Its audit value
+depends entirely on the recorded identity of the approver being trustworthy.
+
+Today that identity comes from `ERI_ANALYST_ID` (`R/dal.R`), a value the analyst sets in
+their own `.Renviron`. It is self-declared and therefore spoofable: anyone can set it to any
+string, including someone else's name. The same env var is used across the operation logs
+and the catalog `registered_by` field.
+
+## Decision
+
+Derive the authoritative actor identity from the **verified Azure AD token** used for the
+connection. Add an internal `.eri_token_identity()` that extracts the verified claim
+(`upn` / `preferred_username`) from the AzureAuth token, and use it as `approved_by` in the
+approval log and catalog registration.
+
+`ERI_ANALYST_ID` is retained only as a **display fallback** for non-interactive runs under a
+service principal (which has no human user claim).
+
+Implemented in **Phase 2**.
+
+## Consequences
+
+- **Easier:** the approval record and access logs reflect who actually authenticated, making
+  the gate a real control rather than a convention.
+- **Harder:** requires every DA/Epi to authenticate interactively with their own Azure AD
+  identity and have RBAC on the storage account (tracked as a Phase 2 input). Service-principal
+  runs must explicitly carry an actor label.
+- **Not doing:** building a separate user-management system; we lean on Azure AD as the
+  identity provider.

--- a/docs/adr/0004-duckdb-query-layer.md
+++ b/docs/adr/0004-duckdb-query-layer.md
@@ -1,0 +1,34 @@
+# ADR-0004 — Blob as system-of-record + serverless DuckDB query layer
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+Two related questions: "should the final datasets live in a formal database?" and "what else
+could we do with Azure storage?" Final datasets are currently parquet files in the `data/`
+blob, indexed by the YAML catalog. Analysts increasingly need cross-dataset queries
+(cross-country/disease roll-ups, ad-hoc requests) that are awkward to express as a series of
+per-file reads.
+
+## Decision
+
+**Keep the Azure blob as the system of record** — parquet remains the canonical storage
+format, which also keeps the data directly consumable by ArcGIS, Power BI, and dashboards.
+Do **not** stand up a database server.
+
+Add a **serverless query layer**: `eri_query()` attaches the relevant processed parquet files
+into an in-process **DuckDB** session and runs SQL across them, with zero operational
+overhead. The catalog (ADR-0002) is the metadata index that tells `eri_query()` which files
+to attach for a given country/disease/data_type.
+
+Implemented in **Phase 2**; consumed by ad-hoc helpers in **Phase 5**.
+
+## Consequences
+
+- **Easier:** SQL joins/aggregations across datasets without a server, without moving data
+  out of the blob, and without a second copy to keep in sync.
+- **Harder:** adds a DuckDB dependency; very large cross-dataset scans are bounded by local
+  memory/download.
+- **Not doing:** Postgres or any managed relational DB — rejected for operational burden on a
+  non-developer team.

--- a/docs/adr/0005-pull-then-process.md
+++ b/docs/adr/0005-pull-then-process.md
@@ -1,0 +1,35 @@
+# ADR-0005 — Pull-then-process with provenance
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+When an analyst works with data, the helpers could either (a) require the analyst to pull the
+data down once and then operate on the local copy, or (b) have each helper pull and process
+the data itself. Option (b) means every function re-downloads, often the same file many times
+in a session.
+
+The research workflow already follows (a): `eri_research_pull()` downloads canonical processed
+data (or any Azure path) into the local project and records the pull in `research.yaml`.
+
+## Decision
+
+**Standardise on pull-then-process.** The analyst pulls data into a local project once;
+helpers operate on local objects/paths. Make the **pull entry points the single place
+provenance is recorded**:
+
+- `eri_research_pull()` — canonical processed data and arbitrary Azure paths.
+- `eri_artifact_pull()` — non-standard reference files registered via `eri_artifact_upload()`.
+
+Both already append to `research.yaml`; keep that the contract and do not scatter implicit
+downloads through analytic helpers.
+
+## Consequences
+
+- **Easier:** no repeated downloads; a single, inspectable record of exactly what entered an
+  analysis and when; reproducible because the manifest pins the inputs.
+- **Harder:** the analyst must remember to pull before processing — mitigated by the workflow
+  templates and `eri_research_resume()` prompting at session start.
+- **Not doing:** auto-fetching inside analytic functions, which would obscure provenance and
+  thrash the network.

--- a/docs/adr/0006-research-projects-as-repos.md
+++ b/docs/adr/0006-research-projects-as-repos.md
@@ -1,0 +1,37 @@
+# ADR-0006 — Research projects as separate template-generated repos
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+Epidemiologists develop analysis code per study (e.g. the DR IRS interrupted-time-series
+analysis, today living as `dr_irs.R` in a gitignored `sandbox/one_off_analyses` folder).
+There needs to be a consistent way to organise this code so analyses are reproducible,
+reviewable, and not entangled with the package itself. The open question was whether analysis
+code should live *inside* `erifunctions` or *outside* it.
+
+## Decision
+
+**Each research project is its own version-controlled repository that depends on
+`erifunctions`** — analysis code does not go into the package. Ship a project-repo template,
+pulled via `eri_template_pull()`, that scaffolds:
+
+- a `renv` lockfile pinning the `erifunctions` version (reproducibility),
+- a `research.yaml` manifest (provenance, lab notebook — see `R/research.R`),
+- an `analysis/` directory for the study code,
+- a README and a minimal `.github/` CI.
+
+The existing `eri_research_workflow.qmd` template is extended into this full repo skeleton.
+Per-study design intent lives in that repo's README/notebook, mirroring at the study level
+what `roadmap.md` + ADRs do for the package.
+
+Implemented in **Phase 1**, with `dr_irs` as the reference example.
+
+## Consequences
+
+- **Easier:** the package stays a clean, testable API; studies are independently versioned and
+  reproducible; a study can be archived, shared, or published without touching `erifunctions`.
+- **Harder:** a new study is a new repo rather than a new file — mitigated by the template
+  making setup one command.
+- **Not doing:** accumulating one-off analysis scripts inside the package source tree.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,46 @@
+# Architecture Decision Records
+
+An **Architecture Decision Record (ADR)** captures a single significant decision: the
+context that forced it, the decision taken, and the consequences. The point is durability —
+so that six months or one long session later, anyone (teammate or AI assistant) can see
+*why* the system is the way it is, instead of re-litigating it or inventing a local
+workaround. This is the per-decision counterpart to the higher-level
+[`roadmap.md`](../roadmap.md).
+
+## Format
+
+Each record is a numbered file, `NNNN-short-title.md`, with these sections:
+
+```markdown
+# ADR-NNNN — Title
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+
+## Context
+What problem or force prompted the decision? Reference concrete code where relevant.
+
+## Decision
+The position taken, stated plainly.
+
+## Consequences
+What becomes easier, what becomes harder, and what we are explicitly *not* doing.
+```
+
+## Conventions
+
+- One decision per file. Keep it short.
+- ADRs are append-only: don't rewrite an accepted ADR to change its meaning — add a new ADR
+  that supersedes it and update the old one's status.
+- Link the ADR from the roadmap when it shapes a phase.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-single-package-with-pkgdown.md) | Stay a single package; discoverability via pkgdown | Accepted |
+| [0002](0002-concurrency-safe-metadata.md) | Concurrency-safe, rebuildable metadata stores | Accepted |
+| [0003](0003-token-derived-identity.md) | Approver identity from the auth token | Accepted |
+| [0004](0004-duckdb-query-layer.md) | Blob as system-of-record + serverless DuckDB query layer | Accepted |
+| [0005](0005-pull-then-process.md) | Pull-then-process with provenance | Accepted |
+| [0006](0006-research-projects-as-repos.md) | Research projects as separate template-generated repos | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,189 @@
+# erifunctions V2 — Development Phases Roadmap
+
+> **Status:** living document. This is the shared, version-controlled north star for V2.
+> Update it as phases land or decisions change, and record any architectural decision as an
+> ADR under [`docs/adr/`](adr/). See [`CLAUDE.md`](../CLAUDE.md) for the working conventions
+> that keep development aligned with this roadmap, and [`vision.md`](vision.md) for the
+> founding brief this plan derives from.
+
+## Context
+
+`erifunctions` is the Carter Center ERI team's R package: the API through which Data
+Analysts (DAs) and Epidemiologists (Epis) interact with TCC's Azure-centred data system
+across countries (Haiti, DR, Uganda, OEPA) and diseases. V1 was built fast and organically
+through **seven phases (v0.2.0 → v0.8.0)** and already ships most of the founding vision: the
+3-layer data model + approval gate (`R/dal.R`), DQ engine (`R/dq.R`), CMR/surveillance
+ingest, ODK lifecycle, data catalog, research scaffolding (`R/research.R`),
+spatial/epi/reporting, SharePoint/Teams, and onboarding.
+
+So **V2 is not a greenfield refactor.** It is: (1) resolve the architecture decisions V1
+deferred, (2) harden V1 for real non-developer users, (3) fill the functional gaps the
+vision implies, and (4) keep design intent under version control so it survives across
+sessions and teammates.
+
+**All three pilots — `dr_irs`, CMR/surveillance, and ODK — are first-class V2 work.**
+`dr_irs` leads simply because its data is already available; the real CMR and ODK uploads
+are ~a week out. Critically, the CMR/surveillance and ODK phases are **not blocked on those
+uploads**: they can be developed against the data already in Azure (`staged/`, `raw/`) as a
+**simulation harness**, with real-data validation following when the uploads land. Caveat:
+much of the staged Excel is *already clean*, so to exercise the DQ and cleaning-rule paths
+the harness must **synthesize realistic anomalies** into a copy of that clean data rather
+than assume dirty input.
+
+```mermaid
+flowchart TD
+    P0["Phase 0 — Governance scaffolding<br/>roadmap.md, ADRs, CLAUDE.md, pkgdown"]
+    P1["Phase 1 — dr_irs vertical slice<br/>Epi research workflow end-to-end"]
+    P2["Phase 2 — Architecture hardening<br/>concurrency, identity, query layer"]
+    P3["Phase 3 — hsp-mal cutover + CMR<br/>eri_compare, authoritative data/ blob"]
+    P4["Phase 4 — ODK live pilot (Uganda)<br/>cleaning rules, edit tracking, dashboard"]
+    P5["Phase 5 — DA breadth helpers<br/>ad-hoc, log triage, new-dataset onboarding"]
+    P0 --> P1 --> P2 --> P3 --> P4 --> P5
+    P2 -. "needed before multi-user<br/>surveillance pilots" .-> P3
+```
+
+The ordering puts the chosen first pilot (`dr_irs`, single-analyst, low-stakes, exercises
+the most novel research machinery) ahead of the multi-user surveillance pilots, and inserts
+architecture hardening (concurrency/identity) *before* concurrent surveillance approval
+becomes load-bearing.
+
+---
+
+## Architecture decisions
+
+Each decision below is captured as a standalone ADR. They are the substance of the founding
+brief's "Some Questions" section (see [`vision.md`](vision.md)).
+
+| ADR | Decision | Resolves |
+|-----|----------|----------|
+| [0001](adr/0001-single-package-with-pkgdown.md) | Stay a single package; solve discoverability with pkgdown grouped reference + role vignettes | "Split into eriauth/eriresearch/…?" |
+| [0002](adr/0002-concurrency-safe-metadata.md) | Make catalog/registry writes concurrency-safe (ETag/optimistic) and rebuildable | "Do we need a formal database?" |
+| [0003](adr/0003-token-derived-identity.md) | Derive approver identity from the auth token, not a self-declared env var | Approval-gate integrity |
+| [0004](adr/0004-duckdb-query-layer.md) | Keep blob as system-of-record; add a serverless DuckDB query layer | "Better use of Azure storage?" |
+| [0005](adr/0005-pull-then-process.md) | Confirm pull-then-process; provenance via the pull entry points | "Pull-then-process vs push?" |
+| [0006](adr/0006-research-projects-as-repos.md) | Research projects are separate repos generated from a template, depending on erifunctions | "How to organise Epi analysis code?" |
+
+---
+
+## Phase 0 — Governance & shared memory scaffolding  *(landed)*
+
+Moves design intent out of the gitignored `sandbox/` and into the repo so teammates and
+fresh sessions inherit it.
+
+- **`docs/roadmap.md`** — this document.
+- **`docs/adr/`** — the six ADRs above plus a README explaining the format.
+- **`CLAUDE.md`** (repo root) — concise project memory: purpose, the 3-layer model +
+  approval gate, naming conventions, where ADRs/roadmap live, the "global vs local solution"
+  guardrail, and the pre-PR check routine.
+- **`_pkgdown.yml`** — grouped function reference (ADR-0001) + articles from existing vignettes.
+- **`.github/workflows/pkgdown.yaml`** — build/deploy the documentation site.
+- README version banner fix + roadmap link.
+
+**Verification:** `R CMD check` clean; `pkgdown::build_site()` renders with the grouped
+reference; ADRs and roadmap render; links resolve. (Built in CI — this repo's dev container
+has no local R.)
+
+---
+
+## Phase 1 — `dr_irs` vertical slice (Epi research, end-to-end)  *(first pilot)*
+
+Drive the real DR IRS interrupted-time-series study entirely through the package, letting
+the friction expose the missing helpers. The scaffolding already fits —
+`eri_research_init("dr_irs_2024", "dr", "malaria", …)` is the documented example.
+
+**Required input:** `dr_irs.R` and example IRS + incidence data shapes (currently in
+gitignored `sandbox/`).
+
+1. **Onboard the IRS dataset.** IRS is not routinely reported, so digitized IRS data enters
+   via `eri_artifact_upload()` → `eri_artifact_pull()`; malaria incidence comes from the
+   surveillance `processed/` layer via `eri_research_pull()`. Confirm both land with
+   provenance in `research.yaml`.
+2. **Build the analysis helpers** `dr_irs.R` needs but the package lacks — an IRS↔incidence
+   temporal/spatial **matching** helper and an **ITS modelling** convenience (in `R/epi.R`;
+   `eri_incidence_rate()`, `eri_study_week()` are existing building blocks).
+3. **Version-tag-linked-to-publication** (genuine gap): `eri_research_snapshot()` freezes
+   `data/` but gives no named tag binding *data + code commit + outputs* to a publication.
+   Add `eri_research_tag(label, …)` recording snapshot ref + analysis git SHA + output
+   manifest, so an analysis is reproducible from a citation.
+4. **Research-repo template** (ADR-0006): port `dr_irs` into a standalone repo from the new
+   template as the reference example.
+
+**Verification:** full study via a `test-smoke.R`-style live test (`ERI_SMOKE_TESTS=true`):
+init → pull IRS artifact + incidence → match → ITS fit → upload outputs → tag; re-pull the
+tag on a clean checkout and reproduce a figure.
+
+---
+
+## Phase 2 — Architecture hardening
+
+Implements ADR-0002/0003/0004 before multi-user surveillance pilots make concurrency and
+identity load-bearing.
+- Concurrency-safe + rebuildable catalog/registries (`R/catalog.R`, `R/odk_registry.R`,
+  `R/artifacts.R`); add `eri_catalog_rebuild()`.
+- `.eri_token_identity()`; `eri_approve()` uses verified identity.
+- `eri_query()` DuckDB-over-parquet read layer.
+
+**Verification:** concurrent-writer unit test shows no lost updates; a spoofed
+`ERI_ANALYST_ID` no longer changes `approved_by`; `eri_query()` SQL across two processed
+datasets returns a correct join.
+
+---
+
+## Phase 3 — hsp-mal cutover tooling + CMR/surveillance pilot
+
+Make the `data/` blob authoritative and retire the contractor pipeline on evidence. Built
+against existing Azure data as a simulation; validated against real uploads when they land.
+- **Simulation harness**: pull existing `staged/`/`raw/` files to stand in for "new data."
+  Because that data is largely already clean, add an anomaly-injection helper so the DQ and
+  cleaning paths are genuinely exercised.
+- **`eri_compare()`**: diff `eri_ingest()`'s `data/staged` output against the
+  `projects/intermediate` (hsp-mal) output the dual-write already produces — row/column/value
+  reconciliation. No such tool exists today.
+- Define written **cutover criteria** (N consecutive periods of equivalence) as an ADR.
+- Harden `eri_ingest_cmr()` / `eri_stage()`; fold DQ failures into the log-triage surface
+  (Phase 5).
+
+**Verification:** simulation run ingests an Azure-sourced (anomaly-injected) file both ways;
+`eri_compare()` reports parity or precise deltas; approval promotes with token identity;
+catalog updated atomically. Re-run against the real June CMR + malaria files once uploaded.
+
+---
+
+## Phase 4 — ODK live pilot (Uganda survey)
+
+Developed against existing synced ODK submissions (simulation); validated against the live
+Uganda form once it launches. Exercises register/sync/status and fills two named gaps:
+- **Live cleaning-rules layer**: versioned, declarative cleaning applied *on read* for
+  dashboards while `raw/` stays pristine — distinct from the slow `approve` gate. New
+  `cleaning_rules` concept layered on the DQ schema engine (`R/dq.R`).
+- **Manual-edit tracking**: capture ODK Central submission edit history during
+  `eri_odk_sync()` so direct edits are auditable.
+- Quarto **survey dashboard** template (replacing PowerBI) built on `R/reports_html.R`.
+
+**Verification:** sync the form; introduce a manual edit and confirm capture; a cleaning rule
+changes the dashboard view but not `raw/`; dashboard renders the indicator set (counts, age
+range, map, positives, open-text, DQ flags).
+
+---
+
+## Phase 5 — DA breadth helpers
+
+The remaining DA tasks, once the spine is solid.
+- **Ad-hoc request** helpers on top of `eri_query()` (lookups/figures for presentations).
+- **Error/log triage** surface: the structured op-logs already written to Azure `…/logs/`
+  need a reader — `eri_logs()` to list/filter/triage a backlog and mark items handled.
+- **New-dataset onboarding** generalised (IRS as the worked example) so adding a
+  country/disease/data-type doesn't require core edits — extends `R/onboarding.R`.
+
+**Verification:** `eri_logs()` surfaces a seeded error backlog; an ad-hoc cross-country query
+returns expected numbers; onboarding a new data type round-trips ingest→approve→catalog.
+
+---
+
+## Inputs needed from the team (before the relevant phase)
+- **Phase 1:** `dr_irs.R` and example IRS + incidence data shapes.
+- **Phase 2:** confirmation of the Azure AD app registration / RBAC so all DAs/Epis can use
+  interactive browser auth (ADR-0003 assumes token identity is available to every user).
+- **Phases 3–4:** not blocked on the real uploads — built against existing Azure
+  `staged/raw` + synced ODK data as a simulation, then re-validated when the real CMR/ODK
+  uploads arrive. Phase 4 also needs ODK Central audit-log/permissions for edit tracking.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,111 @@
+# erifunctions — Founding Vision
+
+> This is the original founding brief for the erifunctions data system, written by an
+> epidemiologist on the ERI team. It is the source-of-truth for *user intent* behind the package and the V2
+> roadmap. The architectural questions it raises (the "Some Questions" section) are resolved
+> in the [ADRs](adr/); the development plan derived from it lives in [`roadmap.md`](roadmap.md).
+> Preserved here (moved out of the gitignored `sandbox/`) so the strategy travels with the repo.
+
+---
+
+# Background
+
+I am a computational epidemiologist at The Carter Center (TCC) working in the health programs in disease eradication. I've written this code base where I've aggregated various functions and SOPs for data analysts (DA) and epidemiologists (Epi) into processes but now I need to refactor this to be a fully functional system for use by those two primary end users. I want you to use the functions within the codebase as the api to interact with the Azure and other microsoft resources. If you find something missing, it is likely that the users would need it too so we can develop it. I'm going to describe key responsibilities and processes for each of these users. The goal is for helper functions, vignettes, guides and reports from this codebase to be used to streamline and simplify the work of the DAs and the epis. Other actors who may not directly use the system but are key parts of the office are associate directors (ADs - they are program managers for countries / regions) and country representatives (program managers that are country specific).
+
+The reason this repository and data system is so fragmented right now is due to project driven development rather than complete organizational development. Historically TCC has hired contractors to build out small pieces of a data collection or processing system (hsp-mal and the other things in the 'projects' blob). I am working to build a centralized data management system and repository that works for DAs and epis across projects. The primary unit of work is the "country". DAs, Epis, ADs all have specific countrys that they are in charge of and work with. Within each country we can have a variety of disease we work with. Each disease line can have different funders and reporting requirements. I am in charge of Haiti, Dominican Republic, Uganda and OEPA. I want to build a centralized system that can help my DAs and epis manage and work with the data from these locations. Eventually I want to be able to expand this to provide support for other epis / countries / diseases.
+
+I'm building the plane while I'm flying it. I need a good way to keep track of the overall vision and development while keeping on building it and not letting long development sessions lose context and create local solutions for global issues. Happy to take any recommendations on the best way to deal with this.
+
+# Your Task
+I want you to go into ultraplan mode and evaluate various ways to do this correctly. Go through multiple rounds of questions to try to narrow this down further before we finish the plans and try to poke holes in what I'm trying to build.
+
+# Design principles
+- Whatever we build needs to be of maximum utility to data analysts and epidemiologists. They need to be able to reliably use this system to drive the data processing and interact with the data outputs. Think of it as a suite of tools or an API built specifically to deal with TCC health data.
+- Key usage will be as an R package loaded through install_github, not load_all() within a repo. All the functions and any necessary authentication need to be able to work with interactive browser authentication for the users.
+- This will need to be a mature set of tools that the DAs and epis will use for interaction with the data system. I don't want them to have to continuously edit the code base. They may fine tune functions or add in new error checks but generally speaking, these are not software developers.
+- Consider this system an API to interact with these new TCC data systems. We want to "dogfood" our process meaning that we use the same tools we're building to then access the system. The idea is that we find other features or helpers we might need to continue to improve this interaction.
+- Nobody is currently using these tools yet so we're okay making breaking changes or large systems changes.
+- Follow best practices in software development, documentation, usability and security.
+- We will build the system primarily in R but if there are other languages or processes that you'd recommend I'm happy to take input. We are using R because it is something that the DAs and epis are used to. Visualizations / processing can be done in other languages if needed but we should aim for R.
+- TCC uses many systems so I want the Azure data store to play the role of a central repository. This is especially useful when we want dashboards or ArcGIS to use the space as a reference for data. We may, for example, create a new spatial file representing an evaulation area consisting of multiple districts. I want to be able to store this in the spatial section of azure and call it up through our system but also have it available through ArcGIS.
+- All the helper functions need to be well organized and straight forward for DAs epis to use.
+- I have reference files for all these data inputs and outputs. Rather than providing all of these at once I want to give you the opportunity to ask for them when they're needed so we don't rely on long context windows.
+
+# Users
+## Data Analysts
+### Description
+They usually have masters in public health and have some experience with SAS and R. They are very capable and able to follow training and documentation on how to run systems. We'll need to provide all of this as part of the system we develop. I'm going to provide you details about their tasks with as much detail as possible.
+### Tasks
+#### Load CMR data
+- ADs or country representatives receive data in an email from the countries. The country team here can be external ministry of health or internal carter center country teams. In either case, they will not need access to these systems.
+- ADs share the data with DAs. Usually through email but sometimes by uploading them to Sharepoint.
+- DAs do a quick visual review of the data and then upload the Excel files into 'projects' blob in 'eridev'.
+- Zack, a contractor, has built out the processing system in the repos I've shared with you (hsp-mal and others) which processes the excel data into final formats (in 'intermediate') and into formats that can ge ready by Power BI dashboards.
+- Currently the processing often fails or throws errors that Zack has to fix or provide feedback for that the DAs then go and clean and re-upload.
+- Some data quality checks are delayed until they hit the dashboard.
+##### Notes
+- The currently "ingest" function should do some of the cleaning and dq checks but then follow the existing stream where it places a cleaned excel sheet in 'projects' and then maintains a similar cleaned dataset in 'data'. If the data from 'intermediate' in 'projects' looks the same at the centralized database we have in 'data' then we can slowly phase out the work that is happening in 'hsp-mal'.
+#### Load malaria surveillance data
+- Senior country representative receives the data from the country and then either uploads it to Sharepoint or emails it to the DA.
+- DAs do a quick visual review of the data and then upload the Excel files into the relevant section in the 'projects' blob in 'eridev'.
+- A GHA process (similar to what Zack runs above) does some review and analysis. Cleaned data are dumped in 'intermediate' and then data for a powerBI dashboard are also output.
+- DAs review the data in the dashboard or the GHA process hits an error and Zack needs to go in and check where it failed.
+- Let me know if there is a good way for me to share the power bi data, again, the goal is to eventually move away from powerbi and use quarto reports or something else that you might recommend.
+#### Process OEPA data
+- ADs receive data on oncho treatments in Brazil and Venezuela in the yanomami region
+- DAs receive data from ADs and then store and manually aggregate the data. I can provide you examples of what these data inputs and outputs look like so far when we get to that step.
+#### Provide initial analytic products for epi QC
+- There are numerous articles and products created by TCC such as funding reports and publications. ADs will present statements like "The final 2025 treatment data for the Uganda program were X, achieving X% of the treatment target. The program also delivered X treatments for schistosomiasis in X RB co-endemic districts, reaching X% of the targeted eligible population. As of May 2026, the MOH, with support from TCC, conducted RB MDA in the five districts of Madi Mid-North, with treatment data pending." which the DAs will have to enter initial data into and then have Epis QC before going back to the ADs.
+#### Generate figures for proceedings or other outputs
+- In a similar theme as the task above, DAs will often be asked to generate maps or figures for reports or publications. We want to build helper functions that will help them quickly analyze, verify and respond to this.
+- This can also include regularly produced outputs like reports for SIL (a reporting requirement), Boart of Trustee reports and Eye of the Eagle articles. (I can provide examples of all of these later as a reference). Remember, we're not trying to regenerate those reportly completely but making the lookup and QC job of data analysts a lot easier.
+#### Create ODK forms for surveys
+- DAs will receive a protocol and example surveys from Epis
+- They will polish the survey xlsform through multiple rounds of development
+- They upload the XLS form into ODK and begin testing the system
+- They pilot the form and ensure that everything is working well
+- They load all users and manage access / submissions in the form.
+#### Monitor the deployment of surveys in ODK and fix errors
+- DAs develop a PowerBI dashboard to view the progress of the survey. This keeps track of key indicators such as # of surveys conducted, age range of respondents, location of survey, a map of survey completion, number of positives and other important metrics, keeping track of errors or data quality issues, keeping track of open response fields where surveyors can provide responses.
+- As data collection begins they review and manage the data daily and provide feedback
+- For any data entry errors, they speak with the supervisors and edit the data directly in ODK (need a better way to keep track of these manual edits)
+##### Notes
+- perhaps the DAs could input cleaning code into the analytic process so that they data are cleaned before they hit the dasboard as issues come up but they remain raw in the original dataset? Happy to take input.
+#### Pre-process the ODK data into analytic datasets and create reports
+- After a study is finished, the DA (or sometimes the Epi), take the first stab at extracting the data, cleaning, matching data across forms and creating a final analytic dataset that will be used for publications. These final tables are stored in Sharepoint and a report is created.
+#### Perform QC on data and provide feedback to countries
+- DAs will regularly review the data that are being received and email back to country teams to specify errors and issues in the data that are being shared.
+#### Perform ad-hoc data requests
+- DAs will often be asked to quickly look up metrics or interest or produce figures for presentations.
+#### Review errors and logs for troubleshooting
+- DAs need a way to easily look at a backlog of errors / logs and process them while keeping track of all the work that they've done.
+#### Onboarding additional datasets
+- indoor residual spraying is not part of our regular surveillance but it is necessary for a new analysis we're conducting. We need a way to add this data (belongs to a country and disease) without upending our entire centrlalized system.
+## Epidemiologists
+### Description
+These are PhD scientists who guide the research and development of the disease eradication program at Carter Cetner. They manage DAs and guide the development of studies and protocols. They are able to use R but some may be rusty and will need lots of documentation and guidance. They will also need to be able to do all of the data processing and management tasks that the DAs conduct.
+### Tasks
+#### Conduct Research
+- Much of the research will be driven by the outputs of the centralized surveillance / CMR data or through the studies conducted in the ODK form.
+- Epis will often have extra or secondary data that will need to be added for analysis. This will often need to be referred to for reporting later but will also need to be tracked / updated for their specific research.
+- once all data are loaded they will need to be tracked for version with specific tags created for data versions that are linked to publications so analyses can be reproduced.
+- Epis will develop code for analysis and we need a system or process to organize these. Maybe we run their analysis in a new repo under a TCC research repo and use erifunctions to do the analysis?
+- Epis will store / stage data, pre-process it to be relevant to their existing scope and then being performing analysis.
+- Analytic outputs will often be figures, tables, text that will need to be staged somehow.
+- Analyses will eventually need to produce presentations and publications. We should think about how this can be most easily shared / tracked. Currently TCC just uses Word with version to control publications.
+#### Quality control of outputs
+- look through the work that the DAs have conducted and verify that Epis calculate the same metrics / figures.
+#### Quick one off analyses
+- You've seen my "one_off_analyses" folder, but Epis are often asked to do quick analytic tasks ranging from figure creation to analyses.
+
+# Piloting
+- There are new CMR data expected on June 10th and new malaria surveillance data expected later this month. We should build the system so that we can test out some of the key DA tasks by trying out loading the new data and seeing what happens.
+- There is a new ODK form being created for a survey in Uganda. Great opportunity to try out new dashboards and reporting. This will start in the next few weeks.
+- There is an existing research project 'dr_irs.R' where we are conducting an analysis on the impact of indoor residual spraying on malaria incidendce in the DR. We are using an interrupted time series analysis. For this research I've had to digitize IRS data (which are not routinely reported) and matched that with malaria incidence data to calculate impact. We can work through this example to get even more feedback.
+
+# Some Questions
+- Should I break this up into a set of interdependent packages? eriauth, eriresearch, erianalyst, erifunctions etc. I can see the benefit of having everything in one package but am worried that the sheer number of functions will be overwhelming. How should I think about this given the use cases I've described above?
+- Are there other things we could be doing with Azure storage to better complete our tasks?
+- Should we consider using a more formal database for our final datasets or is an Azure based file storage system with good guardrails fine here?
+- In the DA workflow, does it make more sense for them to pull specific data down and then process it through helper functions or have helper function directly pull and process the data? I'm leaning towards the former just so that every function doesn't require a similar data download.
+- Would it be useful to have some sort or memory or agent that remembers this higher level design process and ensures that it is being followed or updated at each step?


### PR DESCRIPTION
Closes #123.

## What & why

Kicks off erifunctions **V2** by moving design intent out of the gitignored `sandbox/` and into the repo, so it persists across sessions and teammates. V1 shipped most of the founding vision across phases 1-7 (v0.2.0 to v0.8.0); V2 resolves deferred architecture decisions, hardens for real users, fills functional gaps, and keeps the plan version-controlled. **Phase 0 is documentation/infrastructure only — no package function changes.**

## Contents

- **`docs/roadmap.md`** — V2 development roadmap (Phases 0-5) with dependency diagram.
- **`docs/adr/`** — six Architecture Decision Records resolving the open design questions: single-package vs split (0001), concurrency-safe metadata (0002), token-derived identity (0003), serverless DuckDB query layer (0004), pull-then-process (0005), research-as-repos (0006); plus a README on the ADR format.
- **`docs/vision.md`** — the founding vision brief, moved out of the gitignored `sandbox/` so the strategy travels with the repo (attributed to an epidemiologist on the ERI team).
- **`CLAUDE.md`** — working memory/conventions, incl. the "global vs local solution" guardrail and pre-PR routine.
- **`_pkgdown.yml`** + **`.github/workflows/pkgdown.yaml`** — grouped-reference documentation site, built to gitignored `pkgdown_site/`, deployed to `gh-pages`.
- **`DESCRIPTION`** — pkgdown site URL added to the `URL` field (required by pkgdown).
- README version banner fix (0.5.0 to 0.8.0) + roadmap links; NEWS, .gitignore, .Rbuildignore updated.

## Verification (run locally — the web session had no R)

- `pkgdown::check_pkgdown()` — clean (reference reconciled against all documented topics).
- `pkgdown::build_site()` — all reference pages + 6 articles render.
- `devtools::check()` — **0 errors**. Remaining 1 warning / 3 notes are all pre-existing (non-ASCII in `R/templates.R`, `tail` import in `R/research.R`, `CONTRIBUTING.md` at top level, file-timestamp note) and untouched by this PR; CI `error-on` is `error`, so they do not block.
- No `R/` behaviour changes.

## Follow-ups (not in this PR)

- Enable GitHub Pages on the `gh-pages` branch (repo Settings) once the pkgdown workflow first runs on `main`.
- Small cleanup PR for the pre-existing check cruft (escape non-ASCII, `@importFrom utils tail`, `.Rbuildignore` CONTRIBUTING.md).