### PR TITLE
Clean up R CMD check warning and notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,6 +5,7 @@
 ^README\.Rmd$
 ^LICENSE\.md$
 ^cran-comments\.md$
+^CONTRIBUTING\.md$
 ^data-raw$
 ^pkgdown$
 ^_pkgdown\.yml$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     sf,
     tibble,
     tidyr,
+    utils,
     withr,
     writexl,
     yaml

--- a/R/research.R
+++ b/R/research.R
@@ -149,7 +149,7 @@ eri_research_resume <- function(path = getwd(), data_con = NULL) {
 
   last_pull <- if (length(manifest$pulled_data) > 0L) {
     pulls <- manifest$pulled_data
-    tail(vapply(pulls, function(p) rlang::`%||%`(p$pulled_at, ""), character(1L)), 1L)
+    utils::tail(vapply(pulls, function(p) rlang::`%||%`(p$pulled_at, ""), character(1L)), 1L)
   } else {
     "none"
   }

--- a/R/templates.R
+++ b/R/templates.R
@@ -15,7 +15,7 @@
 
 #' @keywords internal
 .eri_template_bundled <- function() {
-  # Probe via a known file to get the directory — system.file() on a directory
+  # Probe via a known file to get the directory -- system.file() on a directory
   # path can return "" in pkgload dev contexts even when the dir exists.
   probe    <- system.file("templates/eri_daily_workflow.qmd", package = "erifunctions")
   tmpl_dir <- if (nchar(probe)) dirname(probe) else ""
@@ -90,7 +90,7 @@ eri_template_list <- function(data_con = NULL) {
       reg <- .eri_template_registry_read(con)
       reg$entries
     }, error = function(e) {
-      cli::cli_warn("Could not reach Azure template registry — showing bundled templates only.")
+      cli::cli_warn("Could not reach Azure template registry -- showing bundled templates only.")
       list()
     })
   }
@@ -123,7 +123,7 @@ eri_template_list <- function(data_con = NULL) {
 
 #' Copy a template to a local destination
 #'
-#' Copies a named template — bundled or Azure-hosted — to `dest`. Bundled templates
+#' Copies a named template -- bundled or Azure-hosted -- to `dest`. Bundled templates
 #' are copied directly from the package installation. Azure templates are downloaded
 #' from `templates/{filename}` in the `data/` blob.
 #'

--- a/man/eri_template_pull.Rd
+++ b/man/eri_template_pull.Rd
@@ -17,7 +17,7 @@ eri_template_pull(name, dest = getwd(), data_con = NULL)
 Local path to the copied template (invisibly).
 }
 \description{
-Copies a named template — bundled or Azure-hosted — to \code{dest}. Bundled templates
+Copies a named template -- bundled or Azure-hosted -- to \code{dest}. Bundled templates
 are copied directly from the package installation. Azure templates are downloaded
 from \code{templates/{filename}} in the \verb{data/} blob.
 }


### PR DESCRIPTION
Closes #125.

Clears the pre-existing `R CMD check` warning/notes (surfaced during V2 Phase 0 verification, but unrelated to it):

- **`R/templates.R`** — replace non-ASCII em-dashes with ASCII `--` (portability WARNING); the one in the `cli_warn` message and two in comments/roxygen. Regenerated `man/eri_template_pull.Rd` to match.
- **`R/research.R`** — qualify `utils::tail()` and add `utils` to `DESCRIPTION` Imports (undefined-global NOTE).
- **`.Rbuildignore`** — ignore `CONTRIBUTING.md` (non-standard top-level file NOTE).

## Verification
`devtools::check()` locally: **0 errors, 0 warnings, 0 notes** (aside from the environmental "future file timestamps" note). No behaviour change.