### PR TITLE
Add independent Claude PR design-review automation

### DIFF
--- a/.github/claude-review-guidelines.md
+++ b/.github/claude-review-guidelines.md
@@ -1,0 +1,49 @@
+# Claude PR review guidelines
+
+These are the criteria the automated reviewer (`.github/workflows/claude-review.yaml`) uses.
+Edit this file to tune the review — it is version-controlled on purpose, the same way the
+[ADRs](../docs/adr/) are, so the review standard evolves with the project.
+
+## What this review is (and isn't)
+
+- **Is:** an *advisory*, independent check that a change fits the project's design and
+  conventions. The reviewer did not write the code and should read the canon fresh each time.
+- **Isn't:** a correctness/test gate. R-CMD-check and pkgdown CI own pass/fail; do not
+  re-litigate those here. Never approve or merge — a human makes the final call. Raise
+  questions directly in the review when something is ambiguous.
+
+## Read first (the canon)
+
+1. `CLAUDE.md` — conventions + the "global vs local solution" guardrail.
+2. `docs/roadmap.md` — the V2 phases and what each is (and isn't) meant to deliver.
+3. `docs/adr/` — the accepted architecture decisions.
+
+## Review checklist
+
+1. **Reuse over re-implementation.** Does the change re-implement something that already
+   exists (`azure_io()`, `eri_read()`/`eri_write()`, `eri_data_path()`, the DQ/catalog/
+   research machinery)? Flag duplication; point at the existing helper.
+2. **Global vs local solution.** If the problem is general (other countries/diseases/users
+   would hit it), is it solved generally — or is a one-off buried in a single workflow?
+3. **ADR alignment.** Does anything contradict an accepted ADR? Common ones:
+   - ADR-0002: metadata-store writes must be concurrency-safe (ETag/optimistic), not naive
+     read-modify-write.
+   - ADR-0003: approver/actor identity comes from the verified token, not a self-declared env var.
+   - ADR-0005: pull-then-process; provenance recorded at the pull entry points — analytic
+     helpers shouldn't fetch implicitly.
+   - ADR-0006: research/analysis code lives in separate repos, **not** in the package source.
+   If a change *intentionally* revisits a decision, it should add/supersede an ADR in the
+   same PR — flag if it doesn't.
+4. **Conventions** (from CLAUDE.md): exported `eri_*` / internal `.eri_*`; `cli::cli_*` for
+   user-facing messages; roxygen with `@examples` (live calls in `\dontrun{}`); one domain
+   per file in `R/`; `NAMESPACE`/`man/` regenerated when exports/roxygen change.
+5. **User-first.** Users are Data Analysts and Epidemiologists, not developers — is the
+   public surface clear, documented, and hard to misuse?
+6. **Docs in sync.** If the change alters the plan or a decision, are `docs/roadmap.md` /
+   the ADRs updated in the same PR?
+
+## How to respond
+
+Post one PR review. Use inline comments where you can point at a specific line. Request
+changes only for clear violations; otherwise comment. Keep it concise and cite the specific
+doc/section (e.g. "ADR-0006") so the maintainer can act quickly.

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,53 @@
+name: Claude PR review
+
+# Independent, advisory design review on every PR. Checks alignment with the governance
+# docs (CLAUDE.md, docs/roadmap.md, docs/adr/) per .github/claude-review-guidelines.md.
+# It complements — does not replace — the deterministic R-CMD-check / pkgdown gates, and it
+# never approves or merges (a human is the merge gate). Do NOT add this to required checks.
+#
+# Setup: add an `ANTHROPIC_API_KEY` repository secret. Until then the review step skips
+# cleanly and this workflow stays green.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    name: Claude design review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Claude design review
+        # Skip cleanly when the secret isn't configured, so this never blocks a PR.
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are an INDEPENDENT design reviewer for the erifunctions R package, reviewing
+            pull request #${{ github.event.pull_request.number }}. You did not write this code;
+            review it fresh.
+
+            Read, in order: .github/claude-review-guidelines.md, then CLAUDE.md,
+            docs/roadmap.md, and the files under docs/adr/. Then read the PR diff with
+            `gh pr diff ${{ github.event.pull_request.number }}`.
+
+            Apply the checklist in .github/claude-review-guidelines.md. Review ONLY for
+            design/convention/vision alignment — NOT test pass/fail (CI owns that).
+
+            Post exactly one PR review via the gh CLI. Use inline comments where you can point
+            at a specific line, and cite the relevant doc/ADR. Request changes only for clear
+            violations; otherwise leave comments. Ask the maintainer questions directly in the
+            review when something is ambiguous. Do NOT approve and do NOT merge.
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api:*)"


### PR DESCRIPTION
Closes #127.

Adds an **independent, advisory** Claude reviewer that runs on every PR and checks design/vision alignment — complementing, not replacing, the deterministic CI gates.

## What it does
- **`.github/workflows/claude-review.yaml`** — on `pull_request` (opened/synchronize/reopened), runs the Claude Code GitHub Action with a prompt that reads the governance docs + the diff and posts a single advisory PR review (inline comments, cites the relevant ADR/section).
- **`.github/claude-review-guidelines.md`** — the review checklist, version-controlled so the standard evolves like the ADRs do.

## Guardrails (by design)
- **Advisory only** — comments / requests changes, **never approves or merges**. Human stays the merge gate.
- **Skips cleanly** when the `ANTHROPIC_API_KEY` secret is absent (step-level `if`), so it never blocks a PR or fails the workflow.
- **Not a required status check** — quality gating stays with R-CMD-check + pkgdown.
- Independent reviewer (cold context) by intent: it catches the long-session "local solution for a global problem" drift that Phase 0 governance targets.

## Action required by maintainer
Add an **`ANTHROPIC_API_KEY`** repository secret to activate it. Until then it no-ops (green).

> Note: pin/verify the `anthropics/claude-code-action@v1` version and input names against the latest action docs when you wire up the secret.