### PR TITLE
Fix claude-review workflow: secrets not allowed in if:

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -5,8 +5,10 @@ name: Claude PR review
 # It complements — does not replace — the deterministic R-CMD-check / pkgdown gates, and it
 # never approves or merges (a human is the merge gate). Do NOT add this to required checks.
 #
-# Setup: add an `ANTHROPIC_API_KEY` repository secret. Until then the review step skips
-# cleanly and this workflow stays green.
+# Setup (both required to activate; until done the review step skips cleanly and stays green):
+#   1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
+#      (gives the bot its GitHub identity/permissions to read PRs and post reviews).
+#   2. Add an `ANTHROPIC_API_KEY` repository secret (model usage/billing).
 
 on:
   pull_request:

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -22,6 +22,10 @@ jobs:
   review:
     name: Claude design review
     runs-on: ubuntu-latest
+    # The `secrets` context isn't allowed in `if:`; map it to job env (which can read
+    # secrets) and gate on that, so the step skips cleanly when the key isn't configured.
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -29,10 +33,10 @@ jobs:
 
       - name: Claude design review
         # Skip cleanly when the secret isn't configured, so this never blocks a PR.
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           prompt: |
             You are an INDEPENDENT design reviewer for the erifunctions R package, reviewing
             pull request #${{ github.event.pull_request.number }}. You did not write this code;


### PR DESCRIPTION
Follow-up fix to #127 / PR #128.

The merged `claude-review.yaml` used `if: ${{ secrets.ANTHROPIC_API_KEY != '' }}`. GitHub does not allow the `secrets` context in `if:` conditions, so the workflow file was invalid and produced a startup failure on push to `main`.

Fix: map the secret to a **job-level `env`** (where `secrets` *is* allowed) and gate the review step on `env.ANTHROPIC_API_KEY` instead. Same clean skip-when-absent behaviour, valid workflow.

Opening this PR re-triggers the workflow from this branch — its own check passing (job runs, review step skips for lack of the secret) is the validation.