### PR TITLE
Fix ADR-0001: role workflows are templates, not vignettes

### DIFF
--- a/docs/adr/0001-single-package-with-pkgdown.md
+++ b/docs/adr/0001-single-package-with-pkgdown.md
@@ -22,8 +22,10 @@ documentation, not package boundaries:
 - A **pkgdown site** with a **grouped function reference** (Connections / Data I/O / Pipeline
   / Data quality / Catalog / ODK / Spatial / Epi analytics / Reporting / Research / Onboarding).
 - roxygen `@family` tags so related functions cross-link.
-- The two existing **role-based onboarding vignettes** (`eri_daily_workflow` for DAs,
-  `eri_research_workflow` for Epis) as the front door.
+- The two **role-based onboarding templates** (`eri_daily_workflow` for DAs,
+  `eri_research_workflow` for Epis), bundled in `inst/templates/` and pulled via
+  `eri_template_pull()`, plus the task-oriented **workflow vignettes** (`vignettes/*.Rmd`,
+  surfaced as pkgdown articles) as the front door.
 
 ## Consequences
 


### PR DESCRIPTION
Closes #130.

ADR-0001 described `eri_daily_workflow` / `eri_research_workflow` as "role-based onboarding **vignettes**." They are bundled **templates** (`inst/templates/*.qmd`) pulled via `eri_template_pull()`. Reworded to distinguish the role templates from the task-oriented workflow vignettes (`vignettes/*.Rmd`) that are the actual pkgdown articles.

Found by the local `review-agent` during the live test on #124. Docs-only; no behaviour change.