### PR TITLE
Release 0.9.0 (V2 Phase 0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.8.0
+Version: 0.9.0
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,21 @@
-# erifunctions (development version)
+# erifunctions 0.9.0
 
 ## V2 Phase 0 -- Governance & shared-memory scaffolding
 
-Documentation and project-infrastructure only; no changes to package functions.
+Documentation and project-infrastructure only; no changes to package functions. Marks the
+start of the V2 effort.
 
 - `docs/roadmap.md` -- version-controlled V2 development roadmap (Phases 0-5)
 - `docs/adr/` -- architecture decision records (single-package vs split, concurrency-safe
   metadata, token-derived identity, DuckDB query layer, pull-then-process, research-as-repos)
 - `docs/vision.md` -- the founding vision brief, moved out of the gitignored `sandbox/`
 - `CLAUDE.md` -- working memory and conventions for contributors (human and AI)
-- `_pkgdown.yml` + `.github/workflows/pkgdown.yaml` -- grouped-reference documentation site
-- README version banner corrected to 0.8.0 and linked to the roadmap
+- `_pkgdown.yml` + `.github/workflows/pkgdown.yaml` -- grouped-reference documentation site,
+  published to <https://thecartercenter.github.io/erifunctions/>
+- README version banner and CI status badges (R-CMD-check, pkgdown)
+- Cleared the pre-existing `R CMD check` warning and notes (non-ASCII source, `utils::tail`
+  import, `CONTRIBUTING.md` in `.Rbuildignore`); bumped CI actions to `checkout@v5`
+- `main` branch protection requiring the R-CMD-check and pkgdown gates
 
 # erifunctions 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Standardized data tools for the Epidemiology, Research and Innovation (ERI) team at The Carter Center's NTD and malaria programs.
 
-**Version:** 0.8.0 · **Status:** Active development
+**Version:** 0.9.0 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the [V2 roadmap](docs/roadmap.md) and the
 > [architecture decision records](docs/adr/) for the development plan and the reasoning


### PR DESCRIPTION
Cuts **0.9.0**, marking the start of V2 with the Phase 0 governance scaffolding now landed.

- `DESCRIPTION`: 0.8.0 → 0.9.0
- `NEWS.md`: V2 Phase 0 entry finalized under the `0.9.0` heading (roadmap, ADRs, vision doc, CLAUDE.md, pkgdown site, CI badges, check-cruft cleanup, branch protection)
- `README.md`: version banner → 0.9.0

Docs/infra only; no `R/` changes. After merge: tag `v0.9.0` and publish the GitHub release.