### PR TITLE
Add cache flag to eri_spatial_load() (reproducible spatial sourcing)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   provenance, and the output manifest into an immutable, citable tag in Azure, recorded in
   `research.yaml`. Makes a tagged analysis reproducible from a citation, including across data
   updates. Tags are immutable and auto-create a snapshot if none exists. (#135)
+- `eri_spatial_load(cache = TRUE)` -- cache an admin boundary into the research project and
+  record its provenance (delegating to `eri_research_pull()`), then read the local copy, so a
+  study's spatial inputs are reproducible and frozen by `eri_research_tag()`. See ADR-0007. (#133)
 
 # erifunctions 0.9.0
 

--- a/R/research.R
+++ b/R/research.R
@@ -317,19 +317,30 @@ eri_research_pull <- function(
   local_dest <- if (!is.null(dest)) dest else file.path(getwd(), "data")
   if (!dir.exists(local_dest)) dir.create(local_dest, recursive = TRUE)
 
-  all_names <- tryCatch(
-    AzureStor::list_storage_files(data_con, azure_path, info = "name"),
-    error = function(e) {
-      cli::cli_abort("Could not list {.path {azure_path}}: {conditionMessage(e)}")
+  # A path may point at a single file (e.g. a spatial boundary) or a directory of
+  # files. Handle the single-file case directly; otherwise list the directory.
+  is_single_file <- isTRUE(tryCatch(
+    AzureStor::storage_file_exists(data_con, azure_path),
+    error = function(e) FALSE
+  ))
+
+  if (is_single_file) {
+    file_names <- azure_path
+  } else {
+    all_names <- tryCatch(
+      AzureStor::list_storage_files(data_con, azure_path, info = "name"),
+      error = function(e) {
+        cli::cli_abort("Could not list {.path {azure_path}}: {conditionMessage(e)}")
+      }
+    )
+
+    # Keep only files (no trailing slash / no directory entries)
+    file_names <- all_names[!grepl("/$", all_names) & nchar(basename(all_names)) > 0L]
+
+    if (length(file_names) == 0L) {
+      cli::cli_warn("No files found at {.path {azure_path}}.")
+      return(invisible(character(0L)))
     }
-  )
-
-  # Keep only files (no trailing slash / no directory entries)
-  file_names <- all_names[!grepl("/$", all_names) & nchar(basename(all_names)) > 0L]
-
-  if (length(file_names) == 0L) {
-    cli::cli_warn("No files found at {.path {azure_path}}.")
-    return(invisible(character(0L)))
   }
 
   local_paths <- vapply(file_names, function(f) {

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -34,14 +34,24 @@
 #' @param level `int` Admin level (0 = country, 1 = region/department, 2 = province/commune,
 #'   3 = municipality/locality, 4 = sub-locality).
 #' @param data_con Azure container object for the `data/` blob. If `NULL`, connects automatically.
+#' @param cache `lgl` If `TRUE`, cache the boundary into the local research project and read it
+#'   from there instead of reading directly from Azure. Caching delegates to
+#'   [eri_research_pull()], which downloads into `dest` and records the pull in `research.yaml`
+#'   when present -- so a study's spatial inputs are reproducible and frozen by
+#'   [eri_research_tag()]. Default `FALSE` (read directly from Azure). See ADR-0007.
+#' @param dest `chr` Directory to cache into when `cache = TRUE`. Defaults to the project
+#'   `data/` directory.
 #' @returns An `sf` object with the admin boundary geometries.
 #' @examples
 #' \dontrun{
 #' haiti_communes <- eri_spatial_load("ht", level = 2)
 #' dr_provinces   <- eri_spatial_load("dr", level = 2)
+#'
+#' # Inside a research project: cache the boundary and record its provenance.
+#' dr_loc <- eri_spatial_load("dr", level = 4, cache = TRUE)
 #' }
 #' @export
-eri_spatial_load <- function(country, level, data_con = NULL) {
+eri_spatial_load <- function(country, level, data_con = NULL, cache = FALSE, dest = NULL) {
   if (!requireNamespace("sf", quietly = TRUE)) {
     cli::cli_abort("Package {.pkg sf} must be installed to use {.fn eri_spatial_load}.")
   }
@@ -60,6 +70,21 @@ eri_spatial_load <- function(country, level, data_con = NULL) {
       "i" = "Upload it first with:",
       " " = "{.code eri_spatial_upload(local_path, country = \"{country}\", level = {level})}"
     ))
+  }
+
+  if (isTRUE(cache)) {
+    # Source reproducibly: cache into the research project and record provenance through
+    # the pull entry point (ADR-0005/0007), then read the local copy.
+    local_dest  <- if (is.null(dest)) file.path(getwd(), "data") else dest
+    local_paths <- eri_research_pull(path = blob_path, dest = local_dest, data_con = con)
+    if (length(local_paths) == 0L) {
+      cli::cli_abort("Failed to cache {.path {blob_path}}.")
+    }
+    sf_obj <- readRDS(local_paths[[1L]])
+    cli::cli_alert_success(
+      "Loaded {.val {country}} admin level {level} from cache {.path {local_paths[[1L]]}} ({nrow(sf_obj)} feature{?s})."
+    )
+    return(sf_obj)
   }
 
   sf_obj <- eri_read(blob_path, azcontainer = con)

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -75,8 +75,13 @@ eri_spatial_load <- function(country, level, data_con = NULL, cache = FALSE, des
   if (isTRUE(cache)) {
     # Source reproducibly: cache into the research project and record provenance through
     # the pull entry point (ADR-0005/0007), then read the local copy.
-    local_dest  <- if (is.null(dest)) file.path(getwd(), "data") else dest
-    local_paths <- eri_research_pull(path = blob_path, dest = local_dest, data_con = con)
+    if (!file.exists(file.path(getwd(), "research.yaml"))) {
+      cli::cli_warn(c(
+        "{.arg cache = TRUE} but no {.file research.yaml} in the working directory.",
+        "i" = "The boundary is cached locally, but its provenance is NOT recorded -- run {.fn eri_research_init} first for a reproducible pull."
+      ))
+    }
+    local_paths <- eri_research_pull(path = blob_path, dest = dest, data_con = con)
     if (length(local_paths) == 0L) {
       cli::cli_abort("Failed to cache {.path {blob_path}}.")
     }

--- a/docs/adr/0007-research-aware-spatial-sourcing.md
+++ b/docs/adr/0007-research-aware-spatial-sourcing.md
@@ -1,0 +1,43 @@
+# ADR-0007 — Research-aware spatial sourcing via a `cache` flag
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+
+## Context
+
+Spatial layers (admin boundaries, LandScan) live in the Azure `spatial/` blob and are read by
+`eri_spatial_load()` / `eri_spatial_pop()`, which return objects **directly from Azure** with no
+local cache and no provenance record. But research reproducibility (ADR-0005, ADR-0006) requires
+that a study's inputs be cached into the project and recorded in `research.yaml`, so a tagged
+analysis (`eri_research_tag()`, ADR — Phase 1) freezes the exact spatial inputs it used.
+
+`eri_research_pull()` already caches arbitrary Azure paths and records provenance at the single
+pull entry point (ADR-0005) — but it isn't wired to the spatial path convention
+(`spatial/{country}/adm{level}.rds`), and analysts (non-developers) shouldn't have to know it.
+The maintainer's requirement: "source spatial from Azure via the package, but keep a cached copy
+in the research folder for reproducibility."
+
+## Decision
+
+Add a `cache` flag to `eri_spatial_load(country, level, cache = TRUE, dest = NULL)`. When set, it
+sources the boundary by **delegating to `eri_research_pull()`** (which downloads into the project
+`data/` and records the pull in `research.yaml` when present), then reads and returns the local
+copy. Provenance therefore still flows through the one pull entry point (ADR-0005); the flag is a
+convenience over that machinery, not a parallel download path. `cache = FALSE` (the default)
+keeps the direct-from-Azure read.
+
+We chose this over a separate `eri_research_pull_spatial()` so there is **one obvious entry
+point** for loading a boundary, with reproducibility a single argument away.
+
+## Consequences
+
+- **Easier:** one call sources a boundary reproducibly; the study's spatial inputs are cached and
+  appear in `research.yaml`, so `eri_research_tag()` freezes them. Non-developer users get an
+  obvious, low-ceremony path to reproducible spatial sourcing.
+- **Harder:** `eri_spatial_load()` now optionally depends on the research module; and a cached
+  file keeps its basename (`adm{level}.rds`), so a single project mixing two countries' same-level
+  boundaries would collide on disk. Acceptable for the one-country pilots (`dr_irs`); revisit with
+  country-qualified local names if multi-country projects appear.
+- **Not doing:** scattering implicit downloads through every spatial helper, or auto-fetching
+  inside analytic functions (ADR-0005 rejects that). LandScan (`eri_spatial_pop()`) can grow the
+  same flag later if the need arises.

--- a/docs/adr/0007-research-aware-spatial-sourcing.md
+++ b/docs/adr/0007-research-aware-spatial-sourcing.md
@@ -19,7 +19,7 @@ in the research folder for reproducibility."
 
 ## Decision
 
-Add a `cache` flag to `eri_spatial_load(country, level, cache = TRUE, dest = NULL)`. When set, it
+Add a `cache` flag to `eri_spatial_load(country, level, cache = FALSE, dest = NULL)`. When set, it
 sources the boundary by **delegating to `eri_research_pull()`** (which downloads into the project
 `data/` and records the pull in `research.yaml` when present), then reads and returns the local
 copy. Provenance therefore still flows through the one pull entry point (ADR-0005); the flag is a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0004](0004-duckdb-query-layer.md) | Blob as system-of-record + serverless DuckDB query layer | Accepted |
 | [0005](0005-pull-then-process.md) | Pull-then-process with provenance | Accepted |
 | [0006](0006-research-projects-as-repos.md) | Research projects as separate template-generated repos | Accepted |
+| [0007](0007-research-aware-spatial-sourcing.md) | Research-aware spatial sourcing via a `cache` flag | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,6 +62,7 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 | [0004](adr/0004-duckdb-query-layer.md) | Keep blob as system-of-record; add a serverless DuckDB query layer | "Better use of Azure storage?" |
 | [0005](adr/0005-pull-then-process.md) | Confirm pull-then-process; provenance via the pull entry points | "Pull-then-process vs push?" |
 | [0006](adr/0006-research-projects-as-repos.md) | Research projects are separate repos generated from a template, depending on erifunctions | "How to organise Epi analysis code?" |
+| [0007](adr/0007-research-aware-spatial-sourcing.md) | Research-aware spatial sourcing: a `cache` flag on `eri_spatial_load()` delegating to `eri_research_pull()` | Reproducible spatial inputs (Phase 1) |
 
 ---
 

--- a/man/eri_spatial_load.Rd
+++ b/man/eri_spatial_load.Rd
@@ -4,7 +4,7 @@
 \alias{eri_spatial_load}
 \title{Load admin boundary from Azure}
 \usage{
-eri_spatial_load(country, level, data_con = NULL)
+eri_spatial_load(country, level, data_con = NULL, cache = FALSE, dest = NULL)
 }
 \arguments{
 \item{country}{\code{chr} Country code (e.g. \code{"dr"}, \code{"ht"}).}
@@ -13,6 +13,15 @@ eri_spatial_load(country, level, data_con = NULL)
 3 = municipality/locality, 4 = sub-locality).}
 
 \item{data_con}{Azure container object for the \verb{data/} blob. If \code{NULL}, connects automatically.}
+
+\item{cache}{\code{lgl} If \code{TRUE}, cache the boundary into the local research project and read it
+from there instead of reading directly from Azure. Caching delegates to
+\code{\link[=eri_research_pull]{eri_research_pull()}}, which downloads into \code{dest} and records the pull in \code{research.yaml}
+when present -- so a study's spatial inputs are reproducible and frozen by
+\code{\link[=eri_research_tag]{eri_research_tag()}}. Default \code{FALSE} (read directly from Azure). See ADR-0007.}
+
+\item{dest}{\code{chr} Directory to cache into when \code{cache = TRUE}. Defaults to the project
+\verb{data/} directory.}
 }
 \value{
 An \code{sf} object with the admin boundary geometries.
@@ -25,5 +34,8 @@ in the \verb{data/} Azure blob. Returns it ready for mapping or spatial joins.
 \dontrun{
 haiti_communes <- eri_spatial_load("ht", level = 2)
 dr_provinces   <- eri_spatial_load("dr", level = 2)
+
+# Inside a research project: cache the boundary and record its provenance.
+dr_loc <- eri_spatial_load("dr", level = 4, cache = TRUE)
 }
 }

--- a/tests/testthat/test-research-pull.R
+++ b/tests/testthat/test-research-pull.R
@@ -79,6 +79,36 @@ test_that("eri_research_pull by canonical args resolves processed path and downl
   expect_true(any(grepl("2024_W02.parquet", downloaded)))
 })
 
+test_that("eri_research_pull handles a single-file path directly (no directory listing)", {
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "data"))
+  .write_manifest(tmp)
+
+  downloaded <- character(0)
+  listed     <- FALSE
+
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    storage_file_exists = function(...) TRUE,                       # path is a single file
+    list_storage_files  = function(...) { listed <<- TRUE; character(0) },
+    storage_download    = function(con, src, dest, ...) {
+      downloaded <<- c(downloaded, src); invisible(NULL)
+    },
+    .package = "AzureStor"
+  )
+
+  withr::with_dir(tmp, {
+    result <- eri_research_pull(path = "spatial/dr/adm4.rds", dest = file.path(tmp, "data"))
+  })
+
+  expect_equal(length(result), 1L)
+  expect_equal(downloaded, "spatial/dr/adm4.rds")
+  expect_false(listed)  # single-file branch skips the directory listing
+})
+
 test_that("eri_research_pull records pull in research.yaml", {
   tmp <- withr::local_tempdir()
   dir.create(file.path(tmp, "data"))

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -140,36 +140,54 @@ test_that("eri_spatial_load errors informatively when file not in Azure", {
   expect_error(eri_spatial_load("dr", 2), "Upload it first")
 })
 
-test_that("eri_spatial_load(cache=TRUE) delegates to eri_research_pull and returns the sf", {
+test_that("eri_spatial_load(cache=TRUE) caches the single file via the real pull chain and records provenance", {
   skip_if_not_installed("sf")
-  tmp <- withr::local_tempdir()
+  proj <- withr::local_tempdir()
+  withr::local_dir(proj)
 
-  # The "downloaded" boundary that eri_research_pull would produce.
+  # A minimal research project so eri_research_pull records provenance.
+  yaml::write_yaml(
+    list(
+      project_name = "p", country = "dr", disease = "malaria", description = "d",
+      created_at = "t", created_by = "u", azure_path = "research/p/",
+      pulled_data = list(), artifacts_used = list(), log = list(),
+      snapshots = list(), outputs = list(), tags = list()
+    ),
+    file.path(proj, "research.yaml")
+  )
+
   fake_sf <- sf::st_sf(
     adm2_name = "Azua",
     geometry  = sf::st_sfc(sf::st_point(c(0, 0)), crs = 4326)
   )
-  cached_path <- file.path(tmp, "adm2.rds")
-  saveRDS(fake_sf, cached_path)
 
-  pulled <- NULL
+  downloaded_src <- NULL
   local_mocked_bindings(
     get_azure_storage_connection = function(...) "fake_con",
     eri_file_exists              = function(...) TRUE,
-    eri_research_pull            = function(path, dest, data_con, ...) {
-      pulled <<- list(path = path, dest = dest)
-      cached_path
-    },
     .package = "erifunctions"
   )
+  # Let the REAL eri_research_pull run; only mock Azure. storage_file_exists = TRUE
+  # exercises the single-file branch; storage_download writes the boundary locally.
+  local_mocked_bindings(
+    storage_file_exists = function(...) TRUE,
+    storage_download    = function(container, src, dest, ...) {
+      downloaded_src <<- src
+      saveRDS(fake_sf, dest)
+      invisible(NULL)
+    },
+    .package = "AzureStor"
+  )
 
-  out <- eri_spatial_load("dr", 2, cache = TRUE, dest = tmp)
+  out <- eri_spatial_load("dr", 2, cache = TRUE)
 
   expect_s3_class(out, "sf")
   expect_equal(nrow(out), 1L)
-  # delegated to the pull entry point with the canonical spatial path
-  expect_equal(pulled$path, "spatial/dr/adm2.rds")
-  expect_equal(pulled$dest, tmp)
+  expect_equal(downloaded_src, "spatial/dr/adm2.rds")  # canonical single-file path
+
+  # provenance was recorded through the pull entry point (ADR-0005/0007)
+  manifest <- yaml::read_yaml(file.path(proj, "research.yaml"))
+  expect_equal(length(manifest$pulled_data), 1L)
 })
 
 #### eri_landscan_upload validation ####

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -140,6 +140,38 @@ test_that("eri_spatial_load errors informatively when file not in Azure", {
   expect_error(eri_spatial_load("dr", 2), "Upload it first")
 })
 
+test_that("eri_spatial_load(cache=TRUE) delegates to eri_research_pull and returns the sf", {
+  skip_if_not_installed("sf")
+  tmp <- withr::local_tempdir()
+
+  # The "downloaded" boundary that eri_research_pull would produce.
+  fake_sf <- sf::st_sf(
+    adm2_name = "Azua",
+    geometry  = sf::st_sfc(sf::st_point(c(0, 0)), crs = 4326)
+  )
+  cached_path <- file.path(tmp, "adm2.rds")
+  saveRDS(fake_sf, cached_path)
+
+  pulled <- NULL
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "fake_con",
+    eri_file_exists              = function(...) TRUE,
+    eri_research_pull            = function(path, dest, data_con, ...) {
+      pulled <<- list(path = path, dest = dest)
+      cached_path
+    },
+    .package = "erifunctions"
+  )
+
+  out <- eri_spatial_load("dr", 2, cache = TRUE, dest = tmp)
+
+  expect_s3_class(out, "sf")
+  expect_equal(nrow(out), 1L)
+  # delegated to the pull entry point with the canonical spatial path
+  expect_equal(pulled$path, "spatial/dr/adm2.rds")
+  expect_equal(pulled$dest, tmp)
+})
+
 #### eri_landscan_upload validation ####
 
 test_that("eri_landscan_upload errors on invalid year", {


### PR DESCRIPTION
**Part of #133** (the spatial-caching half; incidence-via-pipeline + the data-update test remain on #133).

Implements the maintainer-chosen design (ADR-0007): make reproducible spatial sourcing **one argument** on the function analysts already use.

## What it does
`eri_spatial_load(country, level, cache = TRUE, dest = NULL)` delegates to `eri_research_pull(path = spatial/{country}/adm{level}.rds, dest = ...)`, which downloads into the project `data/` and **records the pull in `research.yaml`** (provenance through the single ADR-0005 entry point), then reads and returns the local copy. `cache = FALSE` (default) keeps the direct Azure read. So a study''s spatial inputs are cached + provenance-tracked, and frozen by `eri_research_tag()` (#135).

## Decision recorded
ADR-0007 (chosen over a separate `eri_research_pull_spatial()` for one obvious entry point); ADR index + roadmap updated. Known trade-off: cached files keep their basename, so one project mixing two countries'' same-level boundaries would collide — fine for the one-country pilots.

## Verification
New test asserts `cache=TRUE` delegates with the canonical path and returns the `sf` (Azure mocked, offline). `devtools::check()` 0E/0W/0N; `check_pkgdown()` clean; `man/` regenerated.