### PR TITLE
Add geocoder API-key preflight to eri_spatial_reconcile() (#143)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
   admin units by point-in-polygon through `eri_spatial_join()`. Returns the data with names
   reconciled in place plus coordinates and a `reconcile_status` column. Only place-name strings
   are sent to the geocoder. (#134)
+  - When a keyed method (e.g. `method = "google"`) is selected without its API key set,
+    `eri_spatial_reconcile()` now aborts up front with guidance to store the key once in the
+    user `.Renviron` (e.g. `GOOGLEGEOCODE_API_KEY`), rather than surfacing a lower-level
+    geocoder error. (#143)
 
 # erifunctions 0.9.0
 

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -345,7 +345,9 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
 #' @keywords internal
 .eri_geocode <- function(addresses, method = "osm", ...) {
   # Key preflight first: a pure environment check (needs no package) and the most
-  # common setup gap for non-developer users. Keyless methods skip it.
+  # common setup gap for non-developer users. This is a key-*presence* check, not a
+  # method allow-list: `method = NULL` and any unlisted method deliberately fall
+  # through to tidygeocoder's own handling.
   key_env <- if (!is.null(method) && method %in% names(.ERI_GEOCODE_KEY_ENV)) {
     .ERI_GEOCODE_KEY_ENV[[method]]
   } else {

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -328,8 +328,38 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
   trimws(x)
 }
 
+# Geocoding services that need an API key, mapped to the env var tidygeocoder reads
+# (see `tidygeocoder::geocode()`). Keyless services (e.g. "osm") are not listed.
+.ERI_GEOCODE_KEY_ENV <- c(
+  google   = "GOOGLEGEOCODE_API_KEY",
+  geocodio = "GEOCODIO_API_KEY",
+  here     = "HERE_API_KEY",
+  mapbox   = "MAPBOX_API_KEY",
+  tomtom   = "TOMTOM_API_KEY",
+  mapquest = "MAPQUEST_API_KEY",
+  opencage = "OPENCAGE_KEY",
+  bing     = "BINGMAPS_API_KEY",
+  geoapify = "GEOAPIFY_KEY"
+)
+
 #' @keywords internal
 .eri_geocode <- function(addresses, method = "osm", ...) {
+  # Key preflight first: a pure environment check (needs no package) and the most
+  # common setup gap for non-developer users. Keyless methods skip it.
+  key_env <- if (!is.null(method) && method %in% names(.ERI_GEOCODE_KEY_ENV)) {
+    .ERI_GEOCODE_KEY_ENV[[method]]
+  } else {
+    NULL
+  }
+  if (!is.null(key_env) && !nzchar(Sys.getenv(key_env))) {
+    cli::cli_abort(c(
+      "Geocoding method {.val {method}} needs an API key, but {.envvar {key_env}} is not set.",
+      "i" = "Sign up for your own key, then store it once in your user {.file .Renviron}:",
+      "*" = "Run {.code usethis::edit_r_environ()} and add a line: {.code {key_env}=your_key}",
+      "*" = "Save the file, then restart R so the key is loaded.",
+      "i" = "No key is needed for {.code method = \"osm\"} (free) or {.code method = NULL} (match only)."
+    ))
+  }
   if (!requireNamespace("tidygeocoder", quietly = TRUE)) {
     cli::cli_abort(c(
       "Package {.pkg tidygeocoder} must be installed to geocode place names.",
@@ -370,9 +400,12 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
 #'    `method = NULL` to skip geocoding entirely (match-only).
 #'
 #' Only the place-name address strings are sent to the geocoder; no data records
-#' leave the machine. The `"google"` method is the most accurate but requires an
-#' API key (`GOOGLEGEOCODE_API_KEY`) and is billed per call; the default
-#' `"osm"` (Nominatim) needs no key. See [tidygeocoder::geocode()].
+#' leave the machine. The `"google"` method is the most accurate but requires
+#' **your own API key** and is billed per call: sign up for a key, then store it
+#' once in your user `.Renviron` as `GOOGLEGEOCODE_API_KEY` (e.g. via
+#' `usethis::edit_r_environ()`) and restart R. The function checks for the key up
+#' front and explains this if it is missing. The default `"osm"` (Nominatim) needs
+#' no key. See [tidygeocoder::geocode()].
 #'
 #' @param data A data frame or tibble containing the free-text place-name columns.
 #' @param loc_cols `chr` vector of free-text column names, ordered **finest to

--- a/man/eri_spatial_reconcile.Rd
+++ b/man/eri_spatial_reconcile.Rd
@@ -79,9 +79,12 @@ admin unit by point-in-polygon via \code{\link[=eri_spatial_join]{eri_spatial_jo
 }
 
 Only the place-name address strings are sent to the geocoder; no data records
-leave the machine. The \code{"google"} method is the most accurate but requires an
-API key (\code{GOOGLEGEOCODE_API_KEY}) and is billed per call; the default
-\code{"osm"} (Nominatim) needs no key. See \code{\link[tidygeocoder:geocode]{tidygeocoder::geocode()}}.
+leave the machine. The \code{"google"} method is the most accurate but requires
+\strong{your own API key} and is billed per call: sign up for a key, then store it
+once in your user \code{.Renviron} as \code{GOOGLEGEOCODE_API_KEY} (e.g. via
+\code{usethis::edit_r_environ()}) and restart R. The function checks for the key up
+front and explains this if it is missing. The default \code{"osm"} (Nominatim) needs
+no key. See \code{\link[tidygeocoder:geocode]{tidygeocoder::geocode()}}.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -494,3 +494,12 @@ test_that(".eri_geocode skips the key check for keyless methods", {
   withr::local_envvar(GOOGLEGEOCODE_API_KEY = "")
   expect_error(.eri_geocode("Somewhere", method = "osm"), regexp = "tidygeocoder")
 })
+
+test_that(".eri_geocode passes the key gate when the key is present", {
+  # A set key clears the preflight; the next gate is the tidygeocoder requireNamespace
+  # error. Skip when tidygeocoder is installed (proceeding would make a network call).
+  skip_if(requireNamespace("tidygeocoder", quietly = TRUE),
+          "tidygeocoder installed; passing the gate would make a network call")
+  withr::local_envvar(GOOGLEGEOCODE_API_KEY = "dummy-key")
+  expect_error(.eri_geocode("Somewhere", method = "google"), regexp = "tidygeocoder")
+})

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -475,3 +475,22 @@ test_that("eri_spatial_reconcile validates its arguments", {
     regexp = "already exist"
   )
 })
+
+#### .eri_geocode key preflight ####
+
+test_that(".eri_geocode aborts early when a keyed method has no API key", {
+  withr::local_envvar(GOOGLEGEOCODE_API_KEY = "")
+  expect_error(
+    .eri_geocode("Somewhere, Country", method = "google"),
+    regexp = "needs an API key|GOOGLEGEOCODE_API_KEY"
+  )
+})
+
+test_that(".eri_geocode skips the key check for keyless methods", {
+  # If the key check did not fire for "osm", the next gate is the tidygeocoder
+  # requireNamespace error. Skip when tidygeocoder is installed (would hit network).
+  skip_if(requireNamespace("tidygeocoder", quietly = TRUE),
+          "tidygeocoder installed; keyless path would make a network call")
+  withr::local_envvar(GOOGLEGEOCODE_API_KEY = "")
+  expect_error(.eri_geocode("Somewhere", method = "osm"), regexp = "tidygeocoder")
+})


### PR DESCRIPTION
Closes #143. Follow-up to #134.

## What

When a keyed geocoding method (e.g. `method = "google"`) is selected but its API key is not set, `.eri_geocode()` now aborts **up front** with actionable `cli` guidance instead of letting `tidygeocoder` surface a lower-level error. For our non-developer (Epi) users the message names the env var and shows the one-time setup.

```
Geocoding method "google" needs an API key, but GOOGLEGEOCODE_API_KEY is not set.
ℹ Sign up for your own key, then store it once in your user .Renviron:
• Run usethis::edit_r_environ() and add a line: GOOGLEGEOCODE_API_KEY=your_key
• Save the file, then restart R so the key is loaded.
ℹ No key is needed for method = "osm" (free) or method = NULL (match only).
```

## Design

- `.ERI_GEOCODE_KEY_ENV` maps keyed services to the env var `tidygeocoder` already reads (`google` → `GOOGLEGEOCODE_API_KEY`, plus other common services). Keyless methods (`"osm"`, `NULL`) skip the check.
- Key storage stays the package convention (an env var from the user `.Renviron`) — no new mechanism, and the same variable name `tidygeocoder` reads, so no extra plumbing.
- **Per-epi key model**: the guidance steers each user to sign up for and store their own key.
- The key check runs **before** the `tidygeocoder` `requireNamespace` check, so the guidance needs no package and is unit-testable offline.

## Tests / checks

- New offline tests: missing-key abort for `method = "google"`; keyless `"osm"` skips the key gate (skipped when `tidygeocoder` is installed, to avoid a network call).
- `devtools::document()` regenerated the `.Rd`. Spatial suite: **0 failures, 68 pass** locally.