### PR TITLE
Guard against false-confident geocodes in eri_spatial_reconcile() (#145)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,11 @@
     `eri_spatial_reconcile()` now aborts up front with guidance to store the key once in the
     user `.Renviron` (e.g. `GOOGLEGEOCODE_API_KEY`), rather than surfacing a lower-level
     geocoder error. (#143)
+  - Geocodes are now trusted (status `"geocoded"`, names assigned) only when the service did
+    not flag a partial/low-confidence match *and* the assigned coarser admin units agree with
+    the parent levels supplied. Otherwise the row is flagged `"geocoded_review"`: coordinates
+    are kept for inspection but the analyst's names are left untouched. Guards against geocoders
+    that best-guess a fabricated or unmatched locality into a plausible point. (#145)
 
 # erifunctions 0.9.0
 

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -375,6 +375,7 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
   # substituted a coarser guess (e.g. a fabricated locality resolved to its parent) --
   # the signal a reconciliation should not trust. Request full results to capture it.
   # Methods that expose no such flag report `partial = NA` (not flagged).
+  # `full_results` is managed here for google; do not also pass it via `...`.
   if (identical(method, "google")) {
     out     <- tidygeocoder::geocode(
       df, address = "address", method = method,
@@ -580,6 +581,11 @@ eri_spatial_reconcile <- function(data,
     if (length(to_geo) > 0L) {
       cli::cli_alert_info("Geocoding {length(to_geo)} unmatched localit{?y/ies} via {.val {method}}...")
       geo <- .eri_geocode(addr[nzchar(addr)], method = method, ...)
+      if (nrow(geo) != length(to_geo)) {
+        cli::cli_abort(
+          "Geocoder returned {nrow(geo)} row{?s} for {length(to_geo)} address{?es} (expected one per address)."
+        )
+      }
       res$.lon[to_geo]     <- geo$longitude
       res$.lat[to_geo]     <- geo$latitude
       res$.partial[to_geo] <- if ("partial" %in% names(geo)) geo$partial else NA
@@ -610,6 +616,7 @@ eri_spatial_reconcile <- function(data,
           jrow <- ord[i]
           if (is.na(jrow) || is.na(jr[[admin_cols[1L]]][jrow])) next  # outside all polygons
 
+          # Any coarser level disagreeing with the analyst's claim flags the row.
           consistent <- TRUE
           if (n_lvl > 1L) {
             for (j in 2:n_lvl) {
@@ -617,6 +624,7 @@ eri_spatial_reconcile <- function(data,
               assigned <- .eri_normalize_name(jr[[admin_cols[j]]][jrow])
               if (!is.na(claimed) && !is.na(assigned) && !identical(claimed, assigned)) {
                 consistent <- FALSE
+                break
               }
             }
           }

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -369,15 +369,30 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
       "i" = "Or call {.fn eri_spatial_reconcile} with {.code method = NULL} to match only (no geocoding)."
     ))
   }
-  df  <- tibble::tibble(address = as.character(addresses))
-  out <- tidygeocoder::geocode(
-    df, address = "address", method = method,
-    lat = "latitude", long = "longitude", ...
-  )
+  df <- tibble::tibble(address = as.character(addresses))
+
+  # Google returns `partial_match = TRUE` when it could not fully match the query and
+  # substituted a coarser guess (e.g. a fabricated locality resolved to its parent) --
+  # the signal a reconciliation should not trust. Request full results to capture it.
+  # Methods that expose no such flag report `partial = NA` (not flagged).
+  if (identical(method, "google")) {
+    out     <- tidygeocoder::geocode(
+      df, address = "address", method = method,
+      lat = "latitude", long = "longitude", full_results = TRUE, ...
+    )
+    partial <- if ("partial_match" %in% names(out)) out[["partial_match"]] %in% TRUE else NA
+  } else {
+    out     <- tidygeocoder::geocode(
+      df, address = "address", method = method,
+      lat = "latitude", long = "longitude", ...
+    )
+    partial <- NA
+  }
   tibble::tibble(
     address   = out[["address"]],
     longitude = out[["longitude"]],
-    latitude  = out[["latitude"]]
+    latitude  = out[["latitude"]],
+    partial   = partial
   )
 }
 
@@ -400,6 +415,16 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
 #'    address built from `loc_cols` (+ `country_name`), then assigned a canonical
 #'    admin unit by point-in-polygon via [eri_spatial_join()]. Set
 #'    `method = NULL` to skip geocoding entirely (match-only).
+#'
+#' A geocode is only **trusted** (status `"geocoded"`, names assigned) when the
+#' service did not flag a partial/low-confidence match *and* the assigned coarser
+#' admin units agree with the parent levels supplied in `loc_cols`. Otherwise the
+#' row is flagged `"geocoded_review"`: its coordinates are recorded for inspection
+#' but the analyst's names are left untouched. This guards against geocoders that
+#' "best-guess" a fabricated or unmatched locality into a plausible nearby point
+#' (issue #145). The partial-match signal is currently read from the `"google"`
+#' method; methods that do not expose one rely on the parent-consistency check
+#' alone.
 #'
 #' Only the place-name address strings are sent to the geocoder; no data records
 #' leave the machine. The `"google"` method is the most accurate but requires
@@ -425,16 +450,17 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
 #' @param max_dist `int` Maximum edit distance for an approximate match on the
 #'   finest level. `0` (default) requires an exact normalized match.
 #' @param status_col `chr` Name of the status column added to the result.
-#'   Default `"reconcile_status"`; values are `"matched"`, `"geocoded"`, or
-#'   `"unresolved"`.
+#'   Default `"reconcile_status"`; values are `"matched"`, `"geocoded"`,
+#'   `"geocoded_review"` (geocoded but low-confidence or parent-inconsistent --
+#'   verify before use), or `"unresolved"`.
 #' @param coord_cols `chr` length-2 names for the longitude and latitude columns
 #'   added to the result. Default `c("longitude", "latitude")`. Populated for any
 #'   row sent to the geocoder, regardless of its final status (so geocoded points
 #'   that fall outside every polygon still record their coordinates).
 #' @param ... Passed to [tidygeocoder::geocode()] (e.g. `min_time`, `api_options`).
 #' @returns A tibble: `data` with `loc_cols` replaced by their canonical values
-#'   where reconciled (originals kept where unresolved), plus the two `coord_cols`
-#'   and `status_col`.
+#'   where confidently reconciled (originals kept where unresolved or flagged
+#'   `"geocoded_review"`), plus the two `coord_cols` and `status_col`.
 #' @examples
 #' \dontrun{
 #' dr_loc <- eri_spatial_load("dr", level = 4, cache = TRUE)
@@ -529,9 +555,10 @@ eri_spatial_reconcile <- function(data,
   canon_out <- paste0(".canon_", loc_cols)
   res <- keys
   for (k in seq_len(n_lvl)) res[[canon_out[k]]] <- NA_character_
-  res$.lon    <- NA_real_
-  res$.lat    <- NA_real_
-  res$.status <- NA_character_
+  res$.lon     <- NA_real_
+  res$.lat     <- NA_real_
+  res$.status  <- NA_character_
+  res$.partial <- NA
 
   matched <- !is.na(match_idx)
   for (k in seq_len(n_lvl)) {
@@ -553,8 +580,9 @@ eri_spatial_reconcile <- function(data,
     if (length(to_geo) > 0L) {
       cli::cli_alert_info("Geocoding {length(to_geo)} unmatched localit{?y/ies} via {.val {method}}...")
       geo <- .eri_geocode(addr[nzchar(addr)], method = method, ...)
-      res$.lon[to_geo] <- geo$longitude
-      res$.lat[to_geo] <- geo$latitude
+      res$.lon[to_geo]     <- geo$longitude
+      res$.lat[to_geo]     <- geo$latitude
+      res$.partial[to_geo] <- if ("partial" %in% names(geo)) geo$partial else NA
 
       has_coords <- to_geo[!is.na(geo$longitude) & !is.na(geo$latitude)]
       if (length(has_coords) > 0L) {
@@ -571,14 +599,37 @@ eri_spatial_reconcile <- function(data,
         # than one unit; keep the first (shapefile order) so each input row resolves
         # to exactly one admin unit.
         jr  <- dplyr::distinct(jr, .rid, .keep_all = TRUE)
-        pos <- match(jr$.rid, has_coords)
-        for (k in seq_len(n_lvl)) {
-          vals <- as.character(jr[[admin_cols[k]]])
-          res[[canon_out[k]]][has_coords[pos]] <- vals
+        ord <- match(has_coords, jr$.rid)
+
+        # A geocode is trusted only if the service did not flag a partial match AND
+        # the assigned coarser admin units agree with the parent levels the analyst
+        # supplied. Trusted -> "geocoded" and names assigned; otherwise
+        # "geocoded_review" -> coordinates kept for inspection, names left untouched.
+        for (i in seq_along(has_coords)) {
+          rk   <- has_coords[i]
+          jrow <- ord[i]
+          if (is.na(jrow) || is.na(jr[[admin_cols[1L]]][jrow])) next  # outside all polygons
+
+          consistent <- TRUE
+          if (n_lvl > 1L) {
+            for (j in 2:n_lvl) {
+              claimed  <- key_norm[[j]][rk]
+              assigned <- .eri_normalize_name(jr[[admin_cols[j]]][jrow])
+              if (!is.na(claimed) && !is.na(assigned) && !identical(claimed, assigned)) {
+                consistent <- FALSE
+              }
+            }
+          }
+
+          if (isTRUE(res$.partial[rk]) || !consistent) {
+            res$.status[rk] <- "geocoded_review"
+          } else {
+            for (k in seq_len(n_lvl)) {
+              res[[canon_out[k]]][rk] <- as.character(jr[[admin_cols[k]]][jrow])
+            }
+            res$.status[rk] <- "geocoded"
+          }
         }
-        # A point inside a polygon resolves the finest level; mark it geocoded.
-        resolved <- has_coords[!is.na(res[[canon_out[1L]]][has_coords])]
-        res$.status[resolved] <- "geocoded"
       }
     }
   }
@@ -593,15 +644,21 @@ eri_spatial_reconcile <- function(data,
   out[[coord_cols[1L]]] <- out$.lon
   out[[coord_cols[2L]]] <- out$.lat
   out[[status_col]]     <- out$.status
-  out <- out[, setdiff(names(out), c(canon_out, ".lon", ".lat", ".status")), drop = FALSE]
+  out <- out[, setdiff(names(out), c(canon_out, ".lon", ".lat", ".status", ".partial")), drop = FALSE]
 
   n_keys <- nrow(keys)
   n_m    <- sum(res$.status == "matched")
   n_g    <- sum(res$.status == "geocoded")
+  n_r    <- sum(res$.status == "geocoded_review")
   n_u    <- sum(res$.status == "unresolved")
   cli::cli_alert_success(
-    "Reconciled {n_keys} distinct localit{?y/ies}: {n_m} matched, {n_g} geocoded, {n_u} unresolved."
+    "Reconciled {n_keys} distinct localit{?y/ies}: {n_m} matched, {n_g} geocoded, {n_r} need review, {n_u} unresolved."
   )
+  if (n_r > 0L) {
+    cli::cli_alert_warning(
+      "{n_r} geocode{?s} flagged {.val geocoded_review} (low-confidence or parent mismatch) -- verify before use."
+    )
+  }
   tibble::as_tibble(out)
 }
 

--- a/man/eri_spatial_reconcile.Rd
+++ b/man/eri_spatial_reconcile.Rd
@@ -41,8 +41,9 @@ wrong matches.}
 finest level. \code{0} (default) requires an exact normalized match.}
 
 \item{status_col}{\code{chr} Name of the status column added to the result.
-Default \code{"reconcile_status"}; values are \code{"matched"}, \code{"geocoded"}, or
-\code{"unresolved"}.}
+Default \code{"reconcile_status"}; values are \code{"matched"}, \code{"geocoded"},
+\code{"geocoded_review"} (geocoded but low-confidence or parent-inconsistent --
+verify before use), or \code{"unresolved"}.}
 
 \item{coord_cols}{\code{chr} length-2 names for the longitude and latitude columns
 added to the result. Default \code{c("longitude", "latitude")}. Populated for any
@@ -53,8 +54,8 @@ that fall outside every polygon still record their coordinates).}
 }
 \value{
 A tibble: \code{data} with \code{loc_cols} replaced by their canonical values
-where reconciled (originals kept where unresolved), plus the two \code{coord_cols}
-and \code{status_col}.
+where confidently reconciled (originals kept where unresolved or flagged
+\code{"geocoded_review"}), plus the two \code{coord_cols} and \code{status_col}.
 }
 \description{
 A thin, opt-in \strong{data-sourcing} helper that maps messy, free-text locality
@@ -77,6 +78,16 @@ address built from \code{loc_cols} (+ \code{country_name}), then assigned a cano
 admin unit by point-in-polygon via \code{\link[=eri_spatial_join]{eri_spatial_join()}}. Set
 \code{method = NULL} to skip geocoding entirely (match-only).
 }
+
+A geocode is only \strong{trusted} (status \code{"geocoded"}, names assigned) when the
+service did not flag a partial/low-confidence match \emph{and} the assigned coarser
+admin units agree with the parent levels supplied in \code{loc_cols}. Otherwise the
+row is flagged \code{"geocoded_review"}: its coordinates are recorded for inspection
+but the analyst's names are left untouched. This guards against geocoders that
+"best-guess" a fabricated or unmatched locality into a plausible nearby point
+(issue #145). The partial-match signal is currently read from the \code{"google"}
+method; methods that do not expose one rely on the parent-consistency check
+alone.
 
 Only the place-name address strings are sent to the geocoder; no data records
 leave the machine. The \code{"google"} method is the most accurate but requires

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -423,17 +423,49 @@ test_that("eri_spatial_reconcile records NA coords as unresolved", {
   expect_true(is.na(out$longitude))
 })
 
+test_that("eri_spatial_reconcile flags a low-confidence (partial) geocode for review", {
+  skip_no_sf()
+  local_mocked_bindings(
+    .eri_geocode = function(addresses, ...) {
+      tibble::tibble(address = addresses, longitude = 0.5, latitude = 0.5, partial = TRUE)
+    },
+    .package = "erifunctions"
+  )
+  df  <- tibble::tibble(loc = "El Rincon", mun = "Juan de Herrera", prov = "San Juan")
+  out <- eri_spatial_reconcile(df, recon_cols$loc_cols, recon_shp(), recon_cols$admin_cols)
+  expect_equal(out$reconcile_status, "geocoded_review")
+  expect_equal(out$loc, "El Rincon")   # names NOT overwritten on a flagged geocode
+  expect_equal(out$longitude, 0.5)     # coordinates still recorded for inspection
+})
+
+test_that("eri_spatial_reconcile flags a parent-inconsistent geocode for review", {
+  skip_no_sf()
+  # Point falls in Jínova (mun "Juan de Herrera"), but the analyst claimed "San Juan".
+  local_mocked_bindings(
+    .eri_geocode = function(addresses, ...) {
+      tibble::tibble(address = addresses, longitude = 0.5, latitude = 0.5, partial = FALSE)
+    },
+    .package = "erifunctions"
+  )
+  df  <- tibble::tibble(loc = "Somewhere", mun = "San Juan", prov = "San Juan")
+  out <- eri_spatial_reconcile(df, recon_cols$loc_cols, recon_shp(), recon_cols$admin_cols)
+  expect_equal(out$reconcile_status, "geocoded_review")
+  expect_equal(out$mun, "San Juan")    # claimed parent kept, not overwritten
+})
+
 test_that("eri_spatial_reconcile resolves a boundary point to a single row", {
   skip_no_sf()
   # x = 1 lies on the shared edge of Jínova (0-1) and Las Zanjas (1-2): the
   # point-in-polygon join matches both, but the result must stay one row per input.
   local_mocked_bindings(
     .eri_geocode = function(addresses, ...) {
-      tibble::tibble(address = addresses, longitude = 1, latitude = 0.5)
+      tibble::tibble(address = addresses, longitude = 1, latitude = 0.5, partial = FALSE)
     },
     .package = "erifunctions"
   )
-  df  <- tibble::tibble(loc = "Edge", mun = "Juan de Herrera", prov = "San Juan")
+  # Parent levels left NA so the parent-consistency check (which polygon a boundary
+  # point dedups to is arbitrary) does not interfere with the single-row assertion.
+  df  <- tibble::tibble(loc = "Edge", mun = NA_character_, prov = NA_character_)
   out <- eri_spatial_reconcile(df, recon_cols$loc_cols, recon_shp(), recon_cols$admin_cols)
   expect_equal(nrow(out), 1L)
   expect_equal(out$reconcile_status, "geocoded")


### PR DESCRIPTION
Closes #145. Follow-up to #134/#143, prompted by live testing.

## Problem

A geocoder does **not** return NA for a fabricated/unmatched locality when the query carries valid parent context — it best-guesses to the parent and returns a real point. That point lands inside a valid polygon, so the row was silently marked `"geocoded"`, giving false confidence. Verified live: `"Zzqxfakeplace 99999, San Juan, ..., Dominican Republic"` geocoded to the San Juan municipality centroid.

## Fix

A geocode is **trusted** (status `"geocoded"`, names assigned in place) only when BOTH:
1. **Geocoder confidence** — the service did not flag a partial/low-confidence match. Google sets `partial_match = TRUE` exactly for these guesses (verified live: `TRUE` for nonsense, `NA` for real places); `.eri_geocode()` now requests `full_results = TRUE` for `google` and returns a `partial` column.
2. **Parent consistency** (method-agnostic, covers keyless `osm`) — the assigned coarser admin units agree (normalized) with the parent levels the analyst supplied.

Otherwise the row is flagged with a new status **`"geocoded_review"`**: coordinates are kept for inspection, but the analyst''s names are left untouched. The summary reports a review count and warns when any rows are flagged.

## Live verification

```
✔ Reconciled 3 distinct localities: 1 matched, 1 geocoded, 1 need review, 0 unresolved.
! 1 geocode flagged "geocoded_review" (low-confidence or parent mismatch) -- verify before use.

                  loc      mun     prov  longitude latitude  reconcile_status
1        Los Jovillos     Azua     Azua         NA       NA          matched
2            San Juan San Juan San Juan    -71.231    18.81         geocoded
3 Zzqxfakeplace 99999 San Juan San Juan    -71.231    18.81  geocoded_review   <- nonsense, now flagged
```

## Tests / checks

- New offline tests for both flag paths (partial-match and parent-inconsistent), using a mocked `.eri_geocode`. `.eri_geocode()` returning `partial` is tolerated-if-absent so prior mocks keep working.
- Boundary-point test adjusted (NA parent levels) so the new consistency check doesn''t interact with the dedup assertion.
- `devtools::document()` regenerated the `.Rd`. Spatial suite: **0 failures, 72 pass** locally.

## Note for analysts

`"geocoded_review"` means "the geocoder returned a point but we are not confident in the name" — these are exactly the rows to eyeball (mirrors the manual geocode fixups in the original `dr_irs` script). Trusted assignments are `"matched"` and `"geocoded"`.