### PR TITLE
Zero-config interactive Azure auth + ADLS Gen2 directory fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # erifunctions (development version)
 
+## Azure access: zero-config interactive auth + ADLS Gen2 fixes
+
+- `get_azure_storage_connection()` ships working defaults for interactive (browser) auth, so analysts
+  and epidemiologists configure nothing: `app_id` defaults to Microsoft's first-party Azure CLI public
+  client and `tenant_id` / `resource_endpoint` to the team's Entra tenant and the `eridev` ADLS
+  endpoint. All remain overridable via the existing `ERIFUNCTIONS_*` env vars; the service-principal
+  secret stays env-only. One Microsoft sign-in covers Azure Storage (and, later, Microsoft Graph).
+- Fixed research-project directory creation on **ADLS Gen2**: paths with a trailing slash returned
+  `HTTP 400 (request URI is invalid)` and intermediate parents were not created. New internal
+  `.eri_ensure_azure_dir()` trims trailing slashes and creates each missing parent level; all
+  `R/research.R` directory sites use it.
+- `eri_research_scaffold()` normalizes a trailing slash in `dest`, and its partial-failure message now
+  explains how to recover (finish `eri_research_init()` in place, or `unlink()` + re-scaffold).
+
 ## V2 Phase 1 -- dr_irs vertical slice (in progress)
 
 - `eri_research_tag()` -- bind a frozen data snapshot, the analysis git commit, the input

--- a/R/dal.R
+++ b/R/dal.R
@@ -1,5 +1,21 @@
 # DAL - Data Access Layer
 
+# Defaults for interactive (browser) auth so analysts/Epis configure nothing. None of these
+# are secrets: a tenant id and a storage-account URL are non-sensitive identifiers (access is
+# gated by AAD + RBAC). The service-principal *secret* is the only credential that must never
+# be committed, and it stays in env vars. All three below are overridable via env var.
+#
+# - app_id: Microsoft's first-party Azure CLI public client -- pre-consented in every tenant
+#   and able to get delegated tokens for BOTH Azure Storage (https://storage.azure.com/) and
+#   Microsoft Graph (SharePoint/Teams), so one interactive login covers every resource.
+# - tenant_id: the TCC ERI (RB/LF/SCH/MAL) Entra tenant.
+# - resource_endpoint: the `eridev` ADLS Gen2 (Data Lake) endpoint where the ERI team works.
+#   AzureStor auto-detects ADLS from the `dfs.` host; the same account's blob API would be at
+#   https://eridev.blob.core.windows.net/ if a blob endpoint is ever needed.
+.ERI_DEFAULT_APP_ID            <- "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+.ERI_DEFAULT_TENANT_ID         <- "16decddb-28ac-4bea-8fc9-5844aadea669"
+.ERI_DEFAULT_RESOURCE_ENDPOINT <- "https://eridev.dfs.core.windows.net/"
+
 #### 1) Utility functions ####
 
 #' Validate connection to Azure
@@ -7,10 +23,13 @@
 #' Generate token which connects to TCC Azure resources and
 #' validates that the individual still has access.
 #'
-#' @param app_id `str` Application ID. Defaults to `Sys.getenv("ERIFUNCTIONS_APP_ID")`.
-#' @param tenant_id `str` ID of the Azure tenant. Defaults to `Sys.getenv("ERIFUNCTIONS_TENANT_ID")`.
-#' @param resource_endpoint `str` URL used to connect to the Azure resource.
-#' Defaults to `Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT")`.
+#' @param app_id `str` Application (client) ID. Defaults to the `ERIFUNCTIONS_APP_ID` env var,
+#' or -- when unset -- Microsoft's first-party Azure CLI public client
+#' (`"04b07795-8ddb-461a-bbee-02f9e1bf7b46"`), so interactive auth works with no per-user setup.
+#' @param tenant_id `str` Azure tenant. Defaults to the `ERIFUNCTIONS_TENANT_ID` env var, or the
+#' TCC ERI Entra tenant when unset.
+#' @param resource_endpoint `str` Storage endpoint URL. Defaults to the
+#' `ERIFUNCTIONS_RESOURCE_ENDPOINT` env var, or the team `eridev` ADLS endpoint when unset.
 #' @param storage_name `str` Name of the storage blob.
 #' Defaults to `Sys.getenv("ERIFUNCTIONS_STORAGE_NAME")`.
 #' @param auth `str` Authorization type defaults to `"authorization_code"`,
@@ -33,9 +52,9 @@
 #'
 #' @export
 get_azure_storage_connection <- function(
-    tenant_id = Sys.getenv("ERIFUNCTIONS_TENANT_ID"),
-    app_id = Sys.getenv("ERIFUNCTIONS_APP_ID"),
-    resource_endpoint = Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT"),
+    tenant_id = Sys.getenv("ERIFUNCTIONS_TENANT_ID", unset = .ERI_DEFAULT_TENANT_ID),
+    app_id = Sys.getenv("ERIFUNCTIONS_APP_ID", unset = .ERI_DEFAULT_APP_ID),
+    resource_endpoint = Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT", unset = .ERI_DEFAULT_RESOURCE_ENDPOINT),
     storage_name = Sys.getenv("ERIFUNCTIONS_STORAGE_NAME"),
     auth = "authorization_code",
     creds_yaml_path = NULL,

--- a/R/research.R
+++ b/R/research.R
@@ -13,6 +13,25 @@
 }
 
 #' @keywords internal
+#' Ensure an Azure directory exists, creating any missing parents.
+#'
+#' ADLS Gen2 rejects a trailing slash in directory operations (HTTP 400, "the request URI is
+#' invalid") and does not reliably create intermediate parents, so we strip trailing slashes
+#' and create each level of the path that is missing. On flat blob storage these are cheap
+#' no-ops. Use this instead of a bare `create_storage_dir()` for any nested research path.
+.eri_ensure_azure_dir <- function(data_con, path) {
+  parts <- strsplit(sub("/+$", "", path), "/", fixed = TRUE)[[1]]
+  parts <- parts[nzchar(parts)]
+  for (i in seq_along(parts)) {
+    level <- paste(parts[seq_len(i)], collapse = "/")
+    if (!AzureStor::storage_dir_exists(data_con, level)) {
+      AzureStor::create_storage_dir(data_con, level)
+    }
+  }
+  invisible(sub("/+$", "", path))
+}
+
+#' @keywords internal
 .eri_research_yaml_path <- function(path) file.path(path, "research.yaml")
 
 #' @keywords internal
@@ -113,9 +132,7 @@ eri_research_init <- function(
   .eri_research_write_manifest(manifest, path)
 
   data_con <- .eri_research_con(data_con)
-  if (!AzureStor::storage_dir_exists(data_con, azure_path)) {
-    AzureStor::create_storage_dir(data_con, azure_path)
-  }
+  .eri_ensure_azure_dir(data_con, azure_path)
 
   cli::cli_alert_success(
     "Research project {.val {project_name}} initialised at {.path {path}}."
@@ -414,9 +431,7 @@ eri_research_upload_figure <- function(
   azure_path <- paste0(manifest$azure_path, "outputs/figs/", filename)
 
   dir_path <- paste0(manifest$azure_path, "outputs/figs")
-  if (!AzureStor::storage_dir_exists(data_con, dir_path)) {
-    AzureStor::create_storage_dir(data_con, dir_path)
-  }
+  .eri_ensure_azure_dir(data_con, dir_path)
   AzureStor::storage_upload(data_con, local_path, azure_path)
 
   entry <- list(
@@ -469,9 +484,7 @@ eri_research_upload_output <- function(
 
   azure_path <- paste0(manifest$azure_path, "outputs/", filename)
   dir_path   <- paste0(manifest$azure_path, "outputs")
-  if (!AzureStor::storage_dir_exists(data_con, dir_path)) {
-    AzureStor::create_storage_dir(data_con, dir_path)
-  }
+  .eri_ensure_azure_dir(data_con, dir_path)
   AzureStor::storage_upload(data_con, tmp, azure_path)
 
   entry <- list(
@@ -723,9 +736,7 @@ eri_research_tag <- function(label, description = NULL, snapshot = NULL,
     outputs      = if (is.null(manifest$outputs)) list() else manifest$outputs
   )
 
-  if (!AzureStor::storage_dir_exists(data_con, tag_dir)) {
-    AzureStor::create_storage_dir(data_con, tag_dir)
-  }
+  .eri_ensure_azure_dir(data_con, tag_dir)
   tmp <- tempfile(fileext = ".yaml")
   withr::defer(unlink(tmp))
   yaml::write_yaml(tag_record, tmp)
@@ -793,6 +804,7 @@ eri_research_scaffold <- function(name, country, disease, description,
   if (missing(description) || !is.character(description) || length(description) != 1L || !nzchar(description)) {
     cli::cli_abort("{.arg description} must be a single non-empty string.")
   }
+  dest <- sub("[/\\\\]+$", "", dest)   # tolerate a trailing slash so we don't build `dest//name`
   repo_dir <- file.path(dest, name)
   if (dir.exists(repo_dir) && length(list.files(repo_dir, all.files = TRUE, no.. = TRUE)) > 0L) {
     cli::cli_abort("{.path {repo_dir}} already exists and is not empty.")
@@ -897,7 +909,7 @@ eri_research_scaffold <- function(name, country, disease, description,
     error = function(e) {
       cli::cli_abort(c(
         "Repo skeleton created at {.path {repo_dir}}, but research-project init failed: {conditionMessage(e)}",
-        "i" = "Resolve the cause (e.g. Azure credentials), then finish setup from inside the project."
+        "i" = "Fix the cause (often Azure auth/RBAC), then either finish in place by running {.fn eri_research_init} from the project dir, or start clean: {.code unlink('{repo_dir}', recursive = TRUE)} then re-run {.fn eri_research_scaffold}."
       ))
     }
   )

--- a/R/research.R
+++ b/R/research.R
@@ -12,13 +12,13 @@
   )
 }
 
-#' @keywords internal
 #' Ensure an Azure directory exists, creating any missing parents.
 #'
 #' ADLS Gen2 rejects a trailing slash in directory operations (HTTP 400, "the request URI is
 #' invalid") and does not reliably create intermediate parents, so we strip trailing slashes
 #' and create each level of the path that is missing. On flat blob storage these are cheap
 #' no-ops. Use this instead of a bare `create_storage_dir()` for any nested research path.
+#' @keywords internal
 .eri_ensure_azure_dir <- function(data_con, path) {
   parts <- strsplit(sub("/+$", "", path), "/", fixed = TRUE)[[1]]
   parts <- parts[nzchar(parts)]

--- a/docs/adr/0008-baked-azure-auth-defaults.md
+++ b/docs/adr/0008-baked-azure-auth-defaults.md
@@ -1,0 +1,53 @@
+# ADR-0008 — Baked-in Azure auth defaults; interactive AAD auth as the zero-config default
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+
+## Context
+
+`get_azure_storage_connection()` (`R/dal.R`) read `app_id`, `tenant_id`, and `resource_endpoint`
+from `ERIFUNCTIONS_*` environment variables with **no defaults**. A new analyst or epidemiologist
+therefore had to obtain and set four values before any package call worked, and an empty `app_id`
+failed with the opaque `AADSTS900144 (missing client_id)`. This surfaced immediately when driving
+the `dr_irs` Epi research workflow: a domain expert (not a developer) cannot get past login.
+
+These values are **not secrets**: a tenant GUID and a storage-account endpoint are discovery
+identifiers, and the application/client id is a public client. The only true secret is the
+service-principal credential (`ERIFUNCTIONS_SP_CLIENT_SECRET`), used solely for scripted/automated
+runs. The roadmap schedules interactive browser auth for Phase 2 ("confirmation of the Azure AD app
+registration / RBAC so all DAs/Epis can use interactive browser auth"); an Epi cannot use the
+package without it, so the interactive-auth *precondition* is brought forward here. This ADR records
+only that enablement — token-derived approver identity (ADR-0003) is still future work.
+
+## Decision
+
+Ship working defaults so interactive (browser) auth needs **zero per-user configuration**, all
+overridable via the existing `ERIFUNCTIONS_*` env vars:
+
+- `app_id` defaults to Microsoft's first-party **Azure CLI public client**
+  (`04b07795-8ddb-461a-bbee-02f9e1bf7b46`) — pre-consented in every tenant and able to obtain
+  delegated tokens for **both** Azure Storage (`https://storage.azure.com/`) and Microsoft Graph
+  (SharePoint/Teams), so one sign-in covers every resource the package touches.
+- `tenant_id` defaults to the ERI Entra tenant; `resource_endpoint` defaults to the `eridev` ADLS
+  Gen2 endpoint (the canonical store the team works in).
+- The **service-principal secret stays env-only** — no credential is ever baked into the package.
+
+Authorization remains enforced by **Azure RBAC** on the storage account: a user who lacks access
+gets a 403, surfaced by the package, rather than the package gating access itself.
+
+We chose the Azure CLI public client over registering a dedicated ERI app now because it works with
+no tenant-admin setup and is already pre-consented. A dedicated ERI app registration (app-specific
+consent, conditional-access scoping, branding) remains a possible future change; if adopted it is a
+one-line default swap plus this ADR's revision.
+
+## Consequences
+
+- **Easier:** an Epi installs the package and signs in with their normal Carter Center Microsoft
+  account — nothing in `.Renviron` is required. Removes the single biggest onboarding wall.
+- **Harder / accepted:** the tenant id and `eridev` endpoint are now visible in a public repo. They
+  are non-sensitive (RBAC-gated), so this is acceptable; revisit only if the security posture
+  changes. The default also ties the package to a Microsoft-owned client id until/unless a dedicated
+  ERI app registration replaces it.
+- **Not doing:** baking any secret into the package; implementing token-derived identity (ADR-0003,
+  still Phase 2). Per-user RBAC on the storage account is an Azure-admin prerequisite, not a package
+  change.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,6 +63,7 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 | [0005](adr/0005-pull-then-process.md) | Confirm pull-then-process; provenance via the pull entry points | "Pull-then-process vs push?" |
 | [0006](adr/0006-research-projects-as-repos.md) | Research projects are separate repos generated from a template, depending on erifunctions | "How to organise Epi analysis code?" |
 | [0007](adr/0007-research-aware-spatial-sourcing.md) | Research-aware spatial sourcing: a `cache` flag on `eri_spatial_load()` delegating to `eri_research_pull()` | Reproducible spatial inputs (Phase 1) |
+| [0008](adr/0008-baked-azure-auth-defaults.md) | Bake non-secret auth constants into the package; default to interactive AAD auth | Zero-config login (Phase 2 precondition, brought forward) |
 
 ---
 
@@ -130,6 +131,11 @@ and re-tag; re-pull the original tag on a clean checkout and reproduce its figur
 
 Implements ADR-0002/0003/0004 before multi-user surveillance pilots make concurrency and
 identity load-bearing.
+
+> **Update (2026-06-16):** the *interactive-auth enablement* half of ADR-0003 landed early —
+> zero-config browser auth via baked non-secret defaults ([ADR-0008](adr/0008-baked-azure-auth-defaults.md)) —
+> because epidemiologists couldn't use the package without it. Token-derived approver identity
+> (`.eri_token_identity()`, below) remains the Phase 2 work.
 - Concurrency-safe + rebuildable catalog/registries (`R/catalog.R`, `R/odk_registry.R`,
   `R/artifacts.R`); add `eri_catalog_rebuild()`.
 - `.eri_token_identity()`; `eri_approve()` uses verified identity.

--- a/man/get_azure_storage_connection.Rd
+++ b/man/get_azure_storage_connection.Rd
@@ -5,9 +5,10 @@
 \title{Validate connection to Azure}
 \usage{
 get_azure_storage_connection(
-  tenant_id = Sys.getenv("ERIFUNCTIONS_TENANT_ID"),
-  app_id = Sys.getenv("ERIFUNCTIONS_APP_ID"),
-  resource_endpoint = Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT"),
+  tenant_id = Sys.getenv("ERIFUNCTIONS_TENANT_ID", unset = .ERI_DEFAULT_TENANT_ID),
+  app_id = Sys.getenv("ERIFUNCTIONS_APP_ID", unset = .ERI_DEFAULT_APP_ID),
+  resource_endpoint = Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT", unset =
+    .ERI_DEFAULT_RESOURCE_ENDPOINT),
   storage_name = Sys.getenv("ERIFUNCTIONS_STORAGE_NAME"),
   auth = "authorization_code",
   creds_yaml_path = NULL,
@@ -15,12 +16,15 @@ get_azure_storage_connection(
 )
 }
 \arguments{
-\item{tenant_id}{\code{str} ID of the Azure tenant. Defaults to \code{Sys.getenv("ERIFUNCTIONS_TENANT_ID")}.}
+\item{tenant_id}{\code{str} Azure tenant. Defaults to the \code{ERIFUNCTIONS_TENANT_ID} env var, or the
+TCC ERI Entra tenant when unset.}
 
-\item{app_id}{\code{str} Application ID. Defaults to \code{Sys.getenv("ERIFUNCTIONS_APP_ID")}.}
+\item{app_id}{\code{str} Application (client) ID. Defaults to the \code{ERIFUNCTIONS_APP_ID} env var,
+or -- when unset -- Microsoft's first-party Azure CLI public client
+(\code{"04b07795-8ddb-461a-bbee-02f9e1bf7b46"}), so interactive auth works with no per-user setup.}
 
-\item{resource_endpoint}{\code{str} URL used to connect to the Azure resource.
-Defaults to \code{Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT")}.}
+\item{resource_endpoint}{\code{str} Storage endpoint URL. Defaults to the
+\code{ERIFUNCTIONS_RESOURCE_ENDPOINT} env var, or the team \code{eridev} ADLS endpoint when unset.}
 
 \item{storage_name}{\code{str} Name of the storage blob.
 Defaults to \code{Sys.getenv("ERIFUNCTIONS_STORAGE_NAME")}.}


### PR DESCRIPTION
## Why

Surfaced while driving the `dr_irs` epidemiologist research workflow end-to-end against the real `eridev` storage account:

1. **Auth wall.** Interactive login failed with `AADSTS900144 (missing client_id)` because `get_azure_storage_connection()` read `app_id`/`tenant_id`/`resource_endpoint` from env vars with no defaults — so a new Epi configures four `ERIFUNCTIONS_*` values before anything works. These are non-secret constants, so they belong in the package.
2. **ADLS Gen2 breakage.** `eri_research_init()` (and the other research dir sites) created Azure directories with a trailing slash, which ADLS Gen2 rejects (`HTTP 400 – request URI is invalid`), and did not create intermediate parents. This is latent on flat blob but breaks on `eridev` (hierarchical namespace).

## What

- **`get_azure_storage_connection()` defaults** (all overridable via the existing `ERIFUNCTIONS_*` env vars):
  - `app_id` → Microsoft's first-party **Azure CLI public client** (`04b07795-…`), pre-consented in every tenant and able to get delegated tokens for **both** Azure Storage and Microsoft Graph (SharePoint/Teams later) — one interactive sign-in covers everything.
  - `tenant_id` → the team Entra tenant; `resource_endpoint` → the `eridev` ADLS endpoint.
  - The **service-principal secret stays env-only** — no secrets in the package.
- **`.eri_ensure_azure_dir()`** (internal): trims trailing slashes and creates each missing parent level; all `R/research.R` directory-creation sites route through it.
- **`eri_research_scaffold()`**: normalizes a trailing slash in `dest`; partial-failure message now explains how to recover (finish `eri_research_init()` in place, or `unlink()` + re-scaffold).

## Notes

- The baked tenant ID + storage endpoint are **non-sensitive identifiers** (access is gated by AAD + RBAC); this repo is public and that is acceptable.
- Brings forward the interactive-auth half of **ADR-0003** / the Phase 2 auth-and-identity work, since Epis can't use the package without it.

## Testing

Exercised end-to-end on `eridev` while porting a real study: zero-config interactive sign-in, `eri_research_scaffold`, `eri_spatial_upload`/`eri_spatial_load(cache=TRUE)`, `eri_landscan_upload`/`eri_spatial_pop`, `eri_artifact_upload`/`eri_artifact_pull`, `eri_research_pull`, and `eri_research_upload_figure` all succeeded. `devtools::document()` regenerated `man/`. Full `R CMD check` runs in CI.