### PR TITLE
Fix Mermaid lifecycle diagram rendering on pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -15,6 +15,25 @@ template:
     base_font: { google: "Source Sans 3" }
     heading_font: { google: "Source Serif 4" }
     code_font: { google: "Source Code Pro" }
+  # Render Mermaid diagrams in articles. A raw <div class="mermaid"> in the .Rmd passes
+  # through pandoc untouched; this loads Mermaid.js and renders those divs, themed to brand.
+  includes:
+    after_body: |
+      <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: 'base',
+          themeVariables: {
+            primaryColor: '#eaeef4',
+            primaryTextColor: '#001737',
+            primaryBorderColor: '#001737',
+            lineColor: '#00873f',
+            fontFamily: 'Source Sans 3, system-ui, sans-serif'
+          }
+        });
+        mermaid.run();
+      </script>
 
 navbar:
   bg: secondary

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -36,7 +36,7 @@ We will run a small study twice. First on an **initial dataset** (automatic-tran
 only), then we will simulate **"new data arriving"** by expanding to the full dataset and
 re-running — exactly the situation you hit when a fresh extract lands months into a project.
 
-```mermaid
+<div class="mermaid">
 flowchart LR
     A["Start a project<br/>(scaffold + GitHub)"] --> B["Add data<br/>+ metadata"]
     B --> C["Source data<br/>into the project"]
@@ -47,7 +47,7 @@ flowchart LR
     G --> H["New data arrives<br/>(re-upload + re-pull)"]
     H --> D
     F --> Z["Clean up"]
-```
+</div>
 
 The golden rule that shapes everything:
 


### PR DESCRIPTION
The lifecycle diagram in the epi research guide rendered as raw text: a fenced ```mermaid block in an .Rmd is knit by pandoc into a highlighted *code* block, which Mermaid.js never touches.

**Fix:** emit a raw `<div class="mermaid">` (pandoc passes raw HTML through verbatim) and load + run Mermaid.js via a pkgdown `template.includes.after_body` script, themed to the Carter Center palette (navy text/borders, green arrows, Source Sans font).

Docs/config only. Vignette still knits; `_pkgdown.yml` parses. The rendered result is verifiable on the deployed site after merge.