### PR TITLE
Restore multi-line labels in the lifecycle diagram

### DIFF
--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -39,13 +39,13 @@ re-running — exactly the situation you hit when a fresh extract lands months i
 ```{=html}
 <div class="mermaid">
 flowchart LR
-    A["Start a project<br/>(scaffold + GitHub)"] --> B["Add data<br/>+ metadata"]
-    B --> C["Source data<br/>into the project"]
-    C --> D["Analyse<br/>(your code)"]
-    D --> E["Save outputs<br/>+ figures"]
-    E --> F["Tag a version<br/>(citable freeze)"]
-    F -.->|weeks later| G["Resume<br/>+ check status"]
-    G --> H["New data arrives<br/>(re-upload + re-pull)"]
+    A["Start a project&lt;br/&gt;(scaffold + GitHub)"] --> B["Add data&lt;br/&gt;+ metadata"]
+    B --> C["Source data&lt;br/&gt;into the project"]
+    C --> D["Analyse&lt;br/&gt;(your code)"]
+    D --> E["Save outputs&lt;br/&gt;+ figures"]
+    E --> F["Tag a version&lt;br/&gt;(citable freeze)"]
+    F -.->|weeks later| G["Resume&lt;br/&gt;+ check status"]
+    G --> H["New data arrives&lt;br/&gt;(re-upload + re-pull)"]
     H --> D
     F --> Z["Clean up"]
 </div>


### PR DESCRIPTION
Tiny follow-up to #154. The diagram now renders, but the in-label line breaks were lost: the browser consumed the literal `<br/>` as break elements before Mermaid read the text. Escaping them (`&lt;br/&gt;`) keeps `<br/>` as literal label text, which Mermaid renders as a line break — restoring the intended two-line node labels. Verified the previous fix at the source (straight quotes, real arrows, preserved newlines) on the deployed page.