### PR TITLE
ci: reliably trigger GitHub Pages build after pkgdown deploy

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,6 +11,7 @@ name: pkgdown
 
 permissions:
   contents: write
+  pages: write
 
 jobs:
   pkgdown:
@@ -48,3 +49,13 @@ jobs:
           clean: false
           branch: gh-pages
           folder: pkgdown_site
+
+      # The push above is authored by GITHUB_TOKEN, and GitHub suppresses the
+      # implicit legacy Pages build for GITHUB_TOKEN-authored pushes (loop
+      # prevention). Without this, gh-pages updates but the live CDN never
+      # rebuilds. Explicitly request a Pages build so the deploy is reliable.
+      - name: Trigger GitHub Pages build
+        if: github.event_name != 'pull_request'
+        run: gh api --method POST repos/${{ github.repository }}/pages/builds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The `pkgdown` workflow deploys by pushing the built site to `gh-pages` with `GITHUB_TOKEN`. GitHub suppresses the implicit *legacy* Pages build for `GITHUB_TOKEN`-authored pushes (loop prevention), so the branch updates but the live CDN sometimes never rebuilds.

Concretely: after #157 merged, `gh-pages` had `articles/da-ingest-guide.html` but the live site 404'd it — no `pages build and deployment` ran for the June-25 push. It only went live after a manual `POST /pages/builds`.

## Fix
- Add `pages: write` permission.
- After the deploy step, explicitly request a Pages build via `gh api --method POST repos/${{ github.repository }}/pages/builds`, guarded to non-PR events.

Workflow-only change; keeps the existing `gh-pages` branch model and needs no repo-settings change. Every deploy now reliably refreshes the published site.

## Alternative considered
Migrating to the modern `actions/deploy-pages` flow (Source = GitHub Actions) is more robust long-term but requires a one-time repo settings change; opted for the minimal, settings-free fix.