### PR TITLE
docs: render guide Mermaid diagrams vertically (TD not LR)

### DIFF
--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -40,7 +40,7 @@ full loop end-to-end and leave no trace.
 
 ```{=html}
 <div class="mermaid">
-flowchart LR
+flowchart TD
     A["Surveillance file arrives"] --> B["Store as-received in raw/"]
     B --> C["Run DQ checks against a schema"]
     C --> D["Fix flags, write cleaned data to staged/"]

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -38,7 +38,7 @@ re-running — exactly the situation you hit when a fresh extract lands months i
 
 ```{=html}
 <div class="mermaid">
-flowchart LR
+flowchart TD
     A["Start a project"] --> B["Add data + metadata"]
     B --> C["Source the data"]
     C --> D["Analyse (your code)"]


### PR DESCRIPTION
Both guide flowcharts used `flowchart LR` (left-to-right), which compressed the full pipeline into a tiny, hard-to-read horizontal strip. Switch the epi-research-guide and da-ingest-guide diagrams to `flowchart TD` (top-down) so the nodes render larger and the steps read top-to-bottom.

One-word change in each diagram's `{=html}` raw block; single-line labels and dotted-edge syntax unchanged (per the known Mermaid gotchas).