### PR TITLE
docs: onboarding guide (new country / disease / data type)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # erifunctions (development version)
 
+## Documentation: an onboarding guide for data analysts
+
+- **New article — "Onboarding a new country, disease, or data type"**
+  (`vignettes/da-onboard-guide.Rmd`). The prequel to the ingest and ODK guides: how a Data Analyst
+  stands up the DQ schema + `raw/staged/processed` folders for a new program before any data flows.
+  Covers all three scaffolding paths — `eri_onboard_country()` (surveillance), `eri_onboard_cmr()`
+  (CMR), and `eri_onboard_disease()` (NTD MDA + prevalence) — plus the `dry_run` preview and
+  `eri_schema_validate()` (valid + a broken→fixed example), on the `atlantis` sandbox. Complements the
+  existing "Adding a new program" vignette (which covers contributing a finished schema to the package).
+
 ## Documentation: a connections & authentication guide
 
 - **New article — "Connecting to Azure, ODK Central, SharePoint, and Teams"**

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ on the [documentation site](https://thecartercenter.github.io/erifunctions/artic
 | [A complete research workflow for epidemiologists](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | Epidemiologists running a study end-to-end — from a fresh project to a citable, reproducible result |
 | [Ingesting a surveillance dataset (raw → approved)](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | Data analysts taking a dataset through the raw → staged → approved pipeline, with a human approval gate |
 | [Working with ODK Central](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | Data analysts connecting to ODK Central to monitor a form, manage collectors, and pull submissions into the pipeline |
+| [Onboarding a new country / disease / data type](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | Data analysts standing up the schema + folders for a new program before any data flows |
 | [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract |
 | [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers |
 | [Spatial workflow](https://thecartercenter.github.io/erifunctions/articles/spatial-workflow.html) | Admin boundaries, population, and spatial joins/maps |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -52,6 +52,7 @@ articles:
   contents:
   - connections-guide
   - epi-research-guide
+  - da-onboard-guide
   - da-ingest-guide
   - da-odk-guide
   - dq-pipeline

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -22,7 +22,7 @@ This page is the **menu and the backlog**: what exists today, and what is still 
 | Data Analyst | Run a monthly country report | _planned_ | ⬜ Missing |
 | Data Analyst | Ingest → stage → approve a surveillance dataset | [`da-ingest-guide`](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | ✅ Shipped |
 | Data Analyst | Work with ODK Central (connect → monitor → manage → pull) | [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | ✅ Shipped |
-| Data Analyst | Onboard a new country / disease / data type | _planned_ | ⬜ Missing |
+| Data Analyst | Onboard a new country / disease / data type | [`da-onboard-guide`](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | ✅ Shipped |
 | Data Analyst | Triage the error / DQ log backlog | _planned_ | ⬜ Missing (function gap — Phase 5 `eri_logs()`) |
 | Epidemiologist | Reconcile free-text localities to admin units for sourcing | _planned_ (see the [spatial workflow](https://thecartercenter.github.io/erifunctions/articles/spatial-workflow.html) vignette for now) | ⬜ Missing |
 | Epidemiologist | Run the DQ pipeline on a new extract | _planned_ (see the [DQ pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) vignette for now) | ⬜ Missing |

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -1,0 +1,285 @@
+---
+title: "Onboarding a new country, disease, or data type (for data analysts)"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Onboarding a new country, disease, or data type (for data analysts)}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+Before any data can flow through `erifunctions`, the **space for it has to exist**: a data-quality
+schema that describes the data, and the `raw → staged → processed` folders it will move through. This
+guide is for a **Data Analyst** standing up that space for a new country, disease, or data type. It is
+the **prequel** to the [ingest](da-ingest-guide.html) and [ODK](da-odk-guide.html) guides — do this
+once, and those workflows have somewhere to land.
+
+We will practise on a make-believe country — **Atlantis** — so you can run every step and then delete
+it. Each `eri_onboard_*` function also has a **dry-run** mode, so you can always look before you touch
+anything.
+
+> **You can run this for real.** The commands work against the live Azure system; the final
+> [**Clean up**](#clean-up) removes everything you created. Real onboarding follows the exact same
+> steps with a real country name.
+
+## The golden rule
+
+> **Onboarding scaffolds; it doesn't finish for you.** `erifunctions` writes you a **schema template**
+> with the standard structure and `TODO` markers, and creates the Azure folders. *You* fill in the
+> disease-specific details, **validate** the schema, and submit it to the package. Nothing is
+> guessed — the template is a correct starting point you complete.
+
+```{=html}
+<div class="mermaid">
+flowchart TD
+    A["Onboard: scaffold schema + folders"] --> B["Fill in the TODO columns"]
+    B --> C["eri_schema_validate()"]
+    C --> D["Space is ready"]
+    D --> E["Ingest data / sync ODK"]
+    E --> F["DQ -> stage -> approve"]
+    D --> Z["Clean up the sandbox"]
+</div>
+```
+
+## Before you start {#before-you-start}
+
+1. **R and RStudio** installed.
+2. **The package** — `remotes::install_github("thecartercenter/erifunctions")`.
+3. **Azure access** — zero-config browser sign-in; see the
+   [connections guide](connections-guide.html) if this is your first time.
+
+```{r library}
+library(erifunctions)
+```
+
+## 1. Look before you leap: the dry run {#dry-run}
+
+Every onboarding command takes `dry_run = TRUE`, which **prints exactly what it would do** and changes
+nothing. Always start here:
+
+```{r dry-run}
+eri_onboard_country("atlantis", "Atlantis", "malaria", dry_run = TRUE)
+#> ℹ Dry run -- nothing will be written or created.
+#>   Would write: atlantis_malaria_schema.yaml
+#>   Would create Azure directories:
+#>     atlantis/malaria/surveillance/raw
+#>     atlantis/malaria/surveillance/staged
+#>     atlantis/malaria/surveillance/processed
+```
+
+That is the whole footprint: one local schema file, and the three-layer folders in Azure. No
+surprises.
+
+## 2. Onboard a surveillance country/disease {#surveillance}
+
+`eri_onboard_country()` is for **surveillance** data (case-level or weekly reporting). The arguments
+are the **country code**, the **full country name**, and the **disease**:
+
+```{r onboard-country}
+eri_onboard_country("atlantis", "Atlantis", "malaria")
+#> ✔ Schema template written to atlantis_malaria_schema.yaml.
+#> ✔ Created 3 Azure directories.
+#> ℹ Next steps:
+#>   1. Open atlantis_malaria_schema.yaml and fill in the TODO sections.
+#>   2. Run eri_schema_validate('atlantis_malaria_schema.yaml') to check your edits.
+#>   3. Submit the schema via a pull request to add it to the package:
+#>      inst/schemas/atlantis_malaria.yaml
+#>   4. Register any ODK forms with eri_odk_register().
+#>   5. Pin the package version in your project: renv::snapshot().
+```
+
+It did two things: wrote a local schema template, and created `atlantis/malaria/surveillance/{raw,
+staged,processed}/` in the data blob.
+
+### Fill in the template
+
+Open `atlantis_malaria_schema.yaml`. It is a **correct, structured starting point** — the standard
+sections are there, with `TODO` markers where your data is unique. Here it is **trimmed for
+readability** (your actual file also lists `aliases:` for each column and a few commented options like
+`time_grain` and `admin1_name_field`):
+
+```yaml
+country: Atlantis
+disease: malaria
+language: en
+
+admin:
+  admin1_col: Admin1
+  admin2_col: Admin2
+  admin1_spatial: spatial/atlantis/atlantis_admin1.shp
+  admin2_spatial: spatial/atlantis/atlantis_admin2.shp
+
+temporal:
+  year_col: Year
+  period_col: EpiWeek
+  max_gap: 2
+
+preprocessing:
+  - remove_smart_quotes
+  - drop_rows_missing_year
+
+columns:
+  Year:
+    required: true
+    type: numeric
+    range: [2000, 2035]
+  EpiWeek:
+    required: true
+    type: numeric
+    range: [1, 53]
+  Admin1:
+    required: true
+    type: categorical
+    # TODO: add allowed_values (list of valid admin1 names)
+  Admin2:
+    required: true
+    type: character
+
+  # TODO: add your disease-specific columns here
+  # CasesConfirmed:
+  #   required: false
+  #   type: numeric
+  #   range: [0, 1000000]
+
+consistency:
+  # TODO: add cross-field rules here
+```
+
+The schema structure — `columns` with `type`/`required`/`range`/`allowed_values`, the `temporal`
+block, `consistency` rules — is exactly what the data-quality engine reads. The
+[ingest guide](da-ingest-guide.html) shows what each rule *does* when data runs through it.
+
+### Validate your edits
+
+`eri_schema_validate()` checks the **structure** — required sections, valid column types, and that
+temporal/consistency rules reference columns that actually exist. Run it on the file you just edited:
+
+```{r validate-good}
+eri_schema_validate("atlantis_malaria_schema.yaml")
+#> ✔ Schema 'atlantis_malaria_schema.yaml' is valid.
+#> # A tibble: 0 × 3
+#> # ℹ 3 variables: issue_type <chr>, field <chr>, message <chr>
+```
+
+An **empty tibble means it's valid**. When something is off, you get a row per problem. Say you fat-
+finger two of the column types to `numbr`:
+
+```{r validate-bad}
+eri_schema_validate("atlantis_malaria_schema.yaml")
+#> ⚠ 2 issues found in 'atlantis_malaria_schema.yaml':
+#> ✖ Column 'Year' has invalid type 'numbr'. Valid: numeric, character, categorical, date.
+#> ✖ Column 'EpiWeek' has invalid type 'numbr'. Valid: numeric, character, categorical, date.
+
+# The returned tibble pinpoints each issue:
+#> # A tibble: 2 × 3
+#>   issue_type    field                message
+#>   <chr>         <chr>                <chr>
+#> 1 invalid_value columns.Year.type    Column 'Year' has invalid type 'numbr'. Valid: numeric, …
+#> 2 invalid_value columns.EpiWeek.type Column 'EpiWeek' has invalid type 'numbr'. Valid: numeric, …
+```
+
+Fix the schema and re-run until you get the clean ✔. That is the green light to use it.
+
+## 3. Onboard a CMR country {#cmr}
+
+**Case Management Reports (CMR)** are the monthly Excel returns from country programs. Onboarding one
+writes a CMR schema template and (when you pass `diseases =`) the CMR folders. Dry-run it first:
+
+```{r cmr-dry}
+eri_onboard_cmr("atlantis", "Atlantis", diseases = c("malaria"), dry_run = TRUE)
+#> ℹ Dry run -- nothing will be written or created.
+#>   Would write: atlantis_cmr_schema.yaml
+#>     Would create: atlantis/malaria/cmr/raw/
+#>     Would create: atlantis/malaria/cmr/staged/
+#>     Would create: atlantis/malaria/cmr/processed/
+```
+
+Then for real:
+
+```{r cmr-real}
+eri_onboard_cmr("atlantis", "Atlantis", diseases = c("malaria"))
+#> ✔ CMR schema template written to atlantis_cmr_schema.yaml.
+#> ✔ CMR Azure directories created for: malaria.
+#> ℹ Next steps:
+#>   1. Open atlantis_cmr_schema.yaml and uncomment the sheets your country uses.
+#>   2. Match field_code_prefix to the #tag_ row in your CMR Excel file.
+#>   3. Submit via pull request to: inst/schemas/cmr/atlantis.yaml
+#>   4. Test ingestion with eri_ingest_cmr('your_file.xlsx', country = 'atlantis').
+```
+
+A CMR template ships with the common report sheets commented out — uncomment the ones your country
+files, and make each sheet's `field_code_prefix` match the `#tag_` row in the Excel file. Then test
+with `eri_ingest_cmr()`.
+
+## 4. Onboard an NTD disease (MDA + prevalence) {#ntd}
+
+For an **NTD treatment/survey program**, `eri_onboard_disease()` scaffolds the two schemas that
+pattern needs — **MDA** (mass drug administration) and **prevalence**. Note the argument order here is
+**disease first, then country**:
+
+```{r onboard-disease}
+eri_onboard_disease("schisto", "atlantis")
+#> ✔ Schema skeleton written to atlantis_schisto_mda.yaml.
+#> ✔ Schema skeleton written to atlantis_schisto_prevalence.yaml.
+#> ℹ Next steps:
+#>   1. Open each file and fill in the TODO sections.
+#>   2. Run eri_schema_validate('<path>') to check your edits.
+#>   3. Submit via pull request to inst/schemas/.
+```
+
+These are **local-only** templates (no Azure folders) — an MDA schema with `year`, `round`,
+`target_pop`, `treated`, and a `TODO` for the geographic unit, and a matching prevalence schema. Fill,
+validate, and submit them exactly as in §2.
+
+> **Contributing the schema to the package — and disease analytics.** Submitting your finished schema
+> via pull request, the schema-validation test, and adding disease-specific analytics functions are
+> covered in depth in the [**Adding a new program**](adding-a-program.html) vignette. This guide gets
+> the space stood up; that one gets your schema merged.
+
+## 5. The space is ready {#ready}
+
+Once your schema validates and the folders exist, the country/disease/data-type is **live in the
+system**. You can now:
+
+- **Ingest a surveillance dataset** → the [ingest guide](da-ingest-guide.html).
+- **Pull from ODK Central** → the [ODK guide](da-odk-guide.html) (register a form for it, then sync).
+- **Make the schema official** → submit it to `inst/schemas/` via pull request so the whole team's
+  `load_dq_schema()` finds it.
+
+## 6. Clean up {#clean-up}
+
+Practice run — remove everything you created. Delete the Azure namespace and the local schema files:
+
+```{r cleanup}
+con <- get_azure_storage_connection(storage_name = "data")
+
+# Deletes atlantis/malaria/surveillance/* and atlantis/malaria/cmr/* in one go.
+AzureStor::delete_storage_dir(con, "atlantis", recursive = TRUE, confirm = FALSE)
+
+# Remove the local schema templates.
+unlink(c("atlantis_malaria_schema.yaml", "atlantis_cmr_schema.yaml",
+         "atlantis_schisto_mda.yaml", "atlantis_schisto_prevalence.yaml"))
+```
+
+> **Why deleting was fine here:** *Atlantis* is invented. **A real onboarded country is not torn down
+> casually** — once data lands in it, those folders are the home of real surveillance records. There
+> is deliberately no one-click "un-onboard" command; removing a real space is a considered, manual act.
+
+## What's next
+
+You have stood up a new space three ways — surveillance, CMR, and an NTD program — and validated the
+schemas. The data guides take it from here:
+
+- [Ingesting a surveillance dataset](da-ingest-guide.html)
+- [Working with ODK Central](da-odk-guide.html)
+- [Adding a new program](adding-a-program.html) — contribute your schema to the package.
+
+See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) for
+the full set, and the [reference](../reference/index.html) for every function grouped by purpose.


### PR DESCRIPTION
## What & why

The `docs/guides.md` DA row **"Onboard a new country / disease / data type"** — the **prequel** to the ingest and ODK guides. Before any data can flow, the country/disease/data-type *space* must exist (a DQ schema + the `raw/staged/processed` folders). `vignettes/da-onboard-guide.Rmd` stands that space up on the `atlantis` sandbox.

Covers all three scaffolding paths (per the agreed scope):
- **`eri_onboard_country()`** — surveillance: dry-run preview → schema + Azure dirs → fill TODOs → `eri_schema_validate()` (valid, then a broken→fixed example).
- **`eri_onboard_cmr()`** — CMR schema + folders.
- **`eri_onboard_disease()`** — NTD MDA + prevalence (local-only schemas; **disease-first** arg order).

Links to the existing **Adding a new program** vignette for contributing a finished schema to the package, and to the ingest/ODK guides for what happens once the space is ready.

## Accuracy
The dry-run previews, the generated surveillance schema, `eri_schema_validate()` output (valid + broken), and the `eri_onboard_country`/`eri_onboard_disease` output were all **captured live/offline** on a real machine. Only the `eri_onboard_cmr` real-run output is representative from source. Pure docs — no R changes.

## Validation
- `knitr::knit()` — parses clean
- `review-agent` — no blockers; its two findings (label the abridged schema YAML; "two column types" wording) are applied
- full render CI-gated

## Files
`vignettes/da-onboard-guide.Rmd` (new), `_pkgdown.yml`, `docs/guides.md`, `README.md`, `NEWS.md`.