### PR TITLE
fix: eri_onboard_cmr creates the canonical rblf/cmr directories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # erifunctions (development version)
 
+## Fix: `eri_onboard_cmr()` creates the canonical `rblf/cmr/` directories
+
+- `eri_onboard_cmr()` now creates CMR Azure directories at `{country}/rblf/cmr/{raw,staged,processed}/`
+  — the location `eri_stage_cmr()` and `eri_approve()` actually use — instead of per-disease folders
+  like `{country}/{disease}/cmr/`, which never matched the pipeline. The `diseases` argument is
+  replaced by `create_dirs` (logical): CMR for the RB-expansion programmes is filed under the combined
+  `rblf` code (RB + LF), not split by disease.
+
 ## Documentation: a monthly CMR upload guide for data analysts
 
 - **New article — "Uploading and processing a monthly country report (CMR)"**

--- a/R/onboarding.R
+++ b/R/onboarding.R
@@ -527,13 +527,16 @@ eri_onboard_cmr <- function(
 
   if (isTRUE(create_dirs)) {
     data_con <- .onboarding_resolve_con(data_con)
-    tryCatch(
+    created  <- tryCatch(
       .onboarding_create_azure_dirs(country_code, "rblf", data_con, data_types = "cmr"),
       error = function(e) {
         cli::cli_warn("Could not create CMR directories: {conditionMessage(e)}")
+        character(0)
       }
     )
-    cli::cli_alert_success("CMR Azure directories created under {.path {cmr_dir}/}.")
+    if (length(created) > 0L) {
+      cli::cli_alert_success("CMR Azure directories created under {.path {cmr_dir}/}.")
+    }
   }
 
   cli::cli_inform(c(

--- a/R/onboarding.R
+++ b/R/onboarding.R
@@ -471,29 +471,32 @@ eri_onboard_country <- function(
 #' @param country_code `chr` Short country code (e.g. `"uga"`).
 #' @param country_name `chr` Full country name (e.g. `"Uganda"`).
 #' @param language `chr` CMR template language (`"en"` or `"fr"`). Default `"en"`.
-#' @param diseases `chr` vector Disease codes for which to create CMR blob directories.
-#'   If `NULL`, no Azure directories are created.
+#' @param create_dirs `lgl` If `TRUE`, create the canonical CMR Azure directories
+#'   `{country_code}/rblf/cmr/{raw,staged,processed}/` in the `data/` blob -- the
+#'   location [eri_stage_cmr()] and [eri_approve()] use. CMR for the RB-expansion
+#'   programmes is filed under the combined `rblf` code (RB + LF), not per disease.
+#'   Default `FALSE`.
 #' @param path `chr` Directory to write the schema YAML into. Default is the current
 #'   working directory.
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
-#'   Ignored when `dry_run = TRUE` or `diseases` is `NULL`.
+#'   Ignored when `dry_run = TRUE` or `create_dirs = FALSE`.
 #' @param dry_run `lgl` If `TRUE`, print a plan but do not write files or create Azure
 #'   directories. Default `FALSE`.
 #' @returns Invisibly, the path to the written schema file (or `NULL` in dry-run mode).
 #' @examples
 #' \dontrun{
-#' eri_onboard_cmr("uga", "Uganda", diseases = c("oncho", "lf"))
+#' eri_onboard_cmr("uga", "Uganda", create_dirs = TRUE)
 #' eri_onboard_cmr("tcd", "Chad", language = "fr", dry_run = TRUE)
 #' }
 #' @export
 eri_onboard_cmr <- function(
     country_code,
     country_name,
-    language  = "en",
-    diseases  = NULL,
-    path      = getwd(),
-    data_con  = NULL,
-    dry_run   = FALSE
+    language    = "en",
+    create_dirs = FALSE,
+    path        = getwd(),
+    data_con    = NULL,
+    dry_run     = FALSE
 ) {
   country_code <- tolower(trimws(country_code))
   language     <- tolower(trimws(language))
@@ -503,17 +506,16 @@ eri_onboard_cmr <- function(
 
   schema_filename <- paste0(country_code, "_cmr_schema.yaml")
   schema_path     <- file.path(path, schema_filename)
+  cmr_dir         <- paste(country_code, "rblf", "cmr", sep = "/")
 
   if (dry_run) {
     cli::cli_inform(c(
       "i" = "Dry run -- nothing will be written or created.",
       " " = "Would write: {.path {schema_path}}"
     ))
-    if (!is.null(diseases)) {
-      for (dis in diseases) {
-        for (layer in c("raw", "staged", "processed")) {
-          cli::cli_inform("    Would create: {.path {country_code}/{dis}/cmr/{layer}/}")
-        }
+    if (isTRUE(create_dirs)) {
+      for (layer in c("raw", "staged", "processed")) {
+        cli::cli_inform("    Would create: {.path {cmr_dir}/{layer}/}")
       }
     }
     return(invisible(NULL))
@@ -523,17 +525,15 @@ eri_onboard_cmr <- function(
   writeLines(yaml_content, schema_path)
   cli::cli_alert_success("CMR schema template written to {.path {schema_path}}.")
 
-  if (!is.null(diseases) && length(diseases) > 0L) {
+  if (isTRUE(create_dirs)) {
     data_con <- .onboarding_resolve_con(data_con)
-    for (dis in diseases) {
-      tryCatch(
-        .onboarding_create_azure_dirs(country_code, dis, data_con, data_types = "cmr"),
-        error = function(e) {
-          cli::cli_warn("Could not create CMR dirs for {dis}: {conditionMessage(e)}")
-        }
-      )
-    }
-    cli::cli_alert_success("CMR Azure directories created for: {.val {diseases}}.")
+    tryCatch(
+      .onboarding_create_azure_dirs(country_code, "rblf", data_con, data_types = "cmr"),
+      error = function(e) {
+        cli::cli_warn("Could not create CMR directories: {conditionMessage(e)}")
+      }
+    )
+    cli::cli_alert_success("CMR Azure directories created under {.path {cmr_dir}/}.")
   }
 
   cli::cli_inform(c(

--- a/man/eri_onboard_cmr.Rd
+++ b/man/eri_onboard_cmr.Rd
@@ -8,7 +8,7 @@ eri_onboard_cmr(
   country_code,
   country_name,
   language = "en",
-  diseases = NULL,
+  create_dirs = FALSE,
   path = getwd(),
   data_con = NULL,
   dry_run = FALSE
@@ -21,14 +21,17 @@ eri_onboard_cmr(
 
 \item{language}{\code{chr} CMR template language (\code{"en"} or \code{"fr"}). Default \code{"en"}.}
 
-\item{diseases}{\code{chr} vector Disease codes for which to create CMR blob directories.
-If \code{NULL}, no Azure directories are created.}
+\item{create_dirs}{\code{lgl} If \code{TRUE}, create the canonical CMR Azure directories
+\verb{\{country_code\}/rblf/cmr/\{raw,staged,processed\}/} in the \verb{data/} blob -- the
+location \code{\link[=eri_stage_cmr]{eri_stage_cmr()}} and \code{\link[=eri_approve]{eri_approve()}} use. CMR for the RB-expansion
+programmes is filed under the combined \code{rblf} code (RB + LF), not per disease.
+Default \code{FALSE}.}
 
 \item{path}{\code{chr} Directory to write the schema YAML into. Default is the current
 working directory.}
 
 \item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.
-Ignored when \code{dry_run = TRUE} or \code{diseases} is \code{NULL}.}
+Ignored when \code{dry_run = TRUE} or \code{create_dirs = FALSE}.}
 
 \item{dry_run}{\code{lgl} If \code{TRUE}, print a plan but do not write files or create Azure
 directories. Default \code{FALSE}.}
@@ -43,7 +46,7 @@ locally, then submit it to the package via a pull request when ready.
 }
 \examples{
 \dontrun{
-eri_onboard_cmr("uga", "Uganda", diseases = c("oncho", "lf"))
+eri_onboard_cmr("uga", "Uganda", create_dirs = TRUE)
 eri_onboard_cmr("tcd", "Chad", language = "fr", dry_run = TRUE)
 }
 }

--- a/tests/testthat/test-onboarding.R
+++ b/tests/testthat/test-onboarding.R
@@ -102,7 +102,7 @@ test_that("eri_onboard_cmr create_dirs makes the canonical rblf/cmr directories"
     .onboarding_create_azure_dirs = function(country_code, disease, data_con,
                                              data_types = "surveillance") {
       captured <<- list(disease = disease, data_types = data_types)
-      character(0)
+      paste(country_code, disease, data_types, c("raw", "staged", "processed"), sep = "/")
     },
     .package = "erifunctions"
   )
@@ -111,6 +111,21 @@ test_that("eri_onboard_cmr create_dirs makes the canonical rblf/cmr directories"
   # CMR is filed under the combined rblf code, matching eri_stage_cmr / eri_approve.
   expect_equal(captured$disease, "rblf")
   expect_equal(captured$data_types, "cmr")
+  unlink(out)
+})
+
+test_that("eri_onboard_cmr does not touch Azure when create_dirs is FALSE (default)", {
+  tmp    <- tempdir()
+  called <- FALSE
+
+  local_mocked_bindings(
+    get_azure_storage_connection  = function(...) "mock_con",
+    .onboarding_create_azure_dirs = function(...) { called <<- TRUE; character(0) },
+    .package = "erifunctions"
+  )
+
+  out <- eri_onboard_cmr("uga", "Uganda", path = tmp)   # create_dirs defaults to FALSE
+  expect_false(called)
   unlink(out)
 })
 

--- a/tests/testthat/test-onboarding.R
+++ b/tests/testthat/test-onboarding.R
@@ -93,6 +93,27 @@ test_that("eri_onboard_cmr writes a YAML file with correct structure", {
   unlink(out_path)
 })
 
+test_that("eri_onboard_cmr create_dirs makes the canonical rblf/cmr directories", {
+  tmp <- tempdir()
+  captured <- NULL
+
+  local_mocked_bindings(
+    .onboarding_resolve_con = function(...) "mock_con",
+    .onboarding_create_azure_dirs = function(country_code, disease, data_con,
+                                             data_types = "surveillance") {
+      captured <<- list(disease = disease, data_types = data_types)
+      character(0)
+    },
+    .package = "erifunctions"
+  )
+
+  out <- eri_onboard_cmr("uga", "Uganda", create_dirs = TRUE, path = tmp)
+  # CMR is filed under the combined rblf code, matching eri_stage_cmr / eri_approve.
+  expect_equal(captured$disease, "rblf")
+  expect_equal(captured$data_types, "cmr")
+  unlink(out)
+})
+
 test_that("eri_onboard_cmr uses french_cmr template for language fr", {
   tmp <- tempdir()
 

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -121,10 +121,10 @@ eri_stage_cmr("uga")
 the two programmes these reports cover. Only the registered RB-expansion countries —
 `eth`, `nga`, `sdn`, `ssd`, `uga`, `mad`, `tcd` — can be staged.)
 
-> **Heads-up on the `rblf` coordinate.** Registered RB-expansion CMR always uses
-> `disease = "rblf"` (so the paths are `{country}/rblf/cmr/…` and you approve with
-> `eri_approve(country, "rblf", "cmr", period)`). If you scaffold a brand-new country's CMR with
-> `eri_onboard_cmr()`, you choose its disease folder — match it to how that country's data is filed.
+> **Heads-up on the `rblf` coordinate.** CMR always uses `disease = "rblf"` — the combined RB + LF
+> programme code — so the paths are `{country}/rblf/cmr/…` and you approve with
+> `eri_approve(country, "rblf", "cmr", period)`. Scaffolding a new country's CMR with
+> `eri_onboard_cmr(create_dirs = TRUE)` creates those same `{country}/rblf/cmr/` folders.
 
 ## 3. Parse each sheet {#parse}
 

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -190,23 +190,25 @@ Fix the schema and re-run until you get the clean ✔. That is the green light t
 ## 3. Onboard a CMR country {#cmr}
 
 **Case Management Reports (CMR)** are the monthly Excel returns from country programs. Onboarding one
-writes a CMR schema template and (when you pass `diseases =`) the CMR folders. Dry-run it first:
+writes a CMR schema template and (when you pass `create_dirs = TRUE`) the CMR folders. CMR lives under
+the combined **`rblf`** disease code (RB + LF — the programmes these reports cover), matching where
+[`eri_stage_cmr()`](da-cmr-guide.html) and `eri_approve()` put it. Dry-run it first:
 
 ```{r cmr-dry}
-eri_onboard_cmr("atlantis", "Atlantis", diseases = c("malaria"), dry_run = TRUE)
+eri_onboard_cmr("atlantis", "Atlantis", create_dirs = TRUE, dry_run = TRUE)
 #> ℹ Dry run -- nothing will be written or created.
 #>   Would write: atlantis_cmr_schema.yaml
-#>     Would create: atlantis/malaria/cmr/raw/
-#>     Would create: atlantis/malaria/cmr/staged/
-#>     Would create: atlantis/malaria/cmr/processed/
+#>     Would create: atlantis/rblf/cmr/raw/
+#>     Would create: atlantis/rblf/cmr/staged/
+#>     Would create: atlantis/rblf/cmr/processed/
 ```
 
 Then for real:
 
 ```{r cmr-real}
-eri_onboard_cmr("atlantis", "Atlantis", diseases = c("malaria"))
+eri_onboard_cmr("atlantis", "Atlantis", create_dirs = TRUE)
 #> ✔ CMR schema template written to atlantis_cmr_schema.yaml.
-#> ✔ CMR Azure directories created for: malaria.
+#> ✔ CMR Azure directories created under atlantis/rblf/cmr/.
 #> ℹ Next steps:
 #>   1. Open atlantis_cmr_schema.yaml and uncomment the sheets your country uses.
 #>   2. Match field_code_prefix to the #tag_ row in your CMR Excel file.
@@ -260,7 +262,7 @@ Practice run — remove everything you created. Delete the Azure namespace and t
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
-# Deletes atlantis/malaria/surveillance/* and atlantis/malaria/cmr/* in one go.
+# Deletes atlantis/malaria/surveillance/* and atlantis/rblf/cmr/* in one go.
 AzureStor::delete_storage_dir(con, "atlantis", recursive = TRUE, confirm = FALSE)
 
 # Remove the local schema templates.


### PR DESCRIPTION
## What & why

Surfaced by review-agent on the CMR guide (#166): `eri_onboard_cmr()` created CMR Azure dirs at `{country}/{disease}/cmr/` (looping a `diseases` arg), but the CMR pipeline — `eri_stage_cmr()` and `eri_approve()` — hardcodes `{country}/rblf/cmr/`. So the onboarded folders **never matched** where CMR data actually lands. CMR for the RB-expansion programmes is one multi-sheet monthly file under the combined `rblf` code (RB + LF), not split by disease.

## Fix
- Replace the misleading `diseases` parameter with **`create_dirs`** (logical). When TRUE, create `{country}/rblf/cmr/{raw,staged,processed}/` — byte-for-byte what `eri_stage_cmr`/`eri_approve` use.
- Only report success when directories were actually created (matches `eri_onboard_country`).
- Updated the onboarding guide §3 + its clean-up comment, the CMR guide's `rblf` note, roxygen + `@examples`, `man/`, and NEWS. Added tests (locks `disease="rblf"`/`data_types="cmr"`; `create_dirs=FALSE` skips Azure).

`eri_onboard_cmr` is `experimental` and the `diseases` arg only just shipped, so the signature change is safe.

## Validation
- `devtools::document()` + `devtools::test()` — **FAIL 0 | PASS 1150** (+ the 2 new onboarding tests)
- both affected vignettes knit; `review-agent` — no blockers (its two suggestions applied)

## Files
`R/onboarding.R`, `man/eri_onboard_cmr.Rd`, `tests/testthat/test-onboarding.R`, `vignettes/da-onboard-guide.Rmd`, `vignettes/da-cmr-guide.Rmd`, `NEWS.md`.