### PR TITLE
docs: fresh-user red-team feedback (DA + Epi personas) + issues #170-#178

### DIFF
--- a/docs/feedback/da-feedback-2026-06-26.md
+++ b/docs/feedback/da-feedback-2026-06-26.md
@@ -1,0 +1,155 @@
+# DA fresh-user red-team feedback — "Dana" — 2026-06-26
+
+Persona: brand-new ERI Data Analyst, competent R *user* (tidyverse, reads CSV/Excel), **not** a
+package developer. Today she moves blob files in **Azure Storage Explorer (the GUI)**. The point of
+this exercise: find every moment she'd reach for Storage Explorer or base R instead of an `eri_*`
+function. Run was live and hands-on against the real Azure `data` blob and the live ODK Central server
+(`rblf.tccodk.org`), on sandboxes only (`atlantis/malaria`, `uga/demo`) with synthetic data. Everything
+created was cleaned up and verified gone. No package file was edited.
+
+This is the **first** red-team run; `docs/feedback/red-team-learnings.md` was empty, so nothing was
+de-duplicated against prior findings.
+
+---
+
+## Headline
+
+**Yes — a fresh DA can do the whole job relying on `erifunctions`, and it's genuinely good.** I ran the
+full arc end-to-end (connect → onboard → ingest two surveillance extracts → CMR parse → ODK simple +
+repeat forms → logs triage → cleanup) and every core step worked on the first try, matched its guide
+almost exactly, and produced the audit trail it promised. The friction is real but narrow: it is
+concentrated in **cleanup** (the guides teach me to drop out of `erifunctions` into raw `AzureStor` to
+delete things, even though `eri_delete()`/`eri_dir_delete()` exist), in **identity** (my approval logs
+were stamped with my Windows username, silently, because nothing told me `ERI_ANALYST_ID` was unset),
+and in a few **cosmetic-but-scary** output issues (success messages and routine info print in alarming
+red; a `readr` column-spec dump erupts in the middle of a clean DQ run). None of these blocked me, but
+the cleanup one is the difference between "I trust erifunctions for the whole lifecycle" and "I delete
+in Storage Explorer because the docs told me to."
+
+---
+
+## The Storage-Explorer-temptation log
+
+Every moment I (Dana) wanted to drop out of `erifunctions`, and whether an `eri_*` path actually exists.
+
+| # | What I wanted to do | Did I reach for SE / base R? | Does an `eri_*` function exist? | Verdict |
+|---|---|---|---|---|
+| 1 | **Delete my sandbox** (`atlantis`, `uga/demo`) at cleanup | **Yes — the guides told me to.** Every cleanup section uses `AzureStor::delete_storage_dir(...)` / `delete_storage_file(...)` | **YES — `eri_dir_delete()` and `eri_delete()` are exported** and even write a session log | **Worst offender.** The docs actively push me out of the package for the one operation Storage Explorer is *best* at. If the guides used `eri_dir_delete()`, I'd never open SE. |
+| 2 | Upload the practice ODK form and submit 2–3 fake entries (ODK guide §1) | Yes — went to the ODK Central **web UI** (Enketo) | No (and correctly so — that's ODK Central's job) | Acceptable, but a brand-new DA with *no* forms is stuck at step 1 of the ODK guide before touching R. Worth a one-line "this part is web-only" flag up top. |
+| 3 | Practice the **CMR stage→approve** loop on my sandbox | Tempted to just upload to the `projects` blob via SE and poke around | `eri_stage_cmr()` exists but **refuses sandbox countries** ("atlantis is not registered for CMR staging") | The guide is honest that these steps are "illustrations," but it means the *most consequential* CMR steps can't be rehearsed safely. I could only `eri_ingest_cmr()` (parse). |
+| 4 | Confirm a file actually landed in `staged/` / `raw/` after a write | Briefly wanted to "just look in SE" | `eri_list()` exists and worked | Resolved by the package. No real pull. |
+| 5 | Inspect the approval log / operation log YAML after approving | Wanted to open the `.yaml` in SE to read who-approved-what | Partial: `eri_logs()` surfaces operation logs; the per-period `*_approval_log.yaml` is named in output but there's no `eri_*` to *print* it | Minor pull. `eri_logs()` covered 90%; reading the actual approval-log contents still implies SE/`eri_read`. |
+| 6 | Move the messy raw file around / re-stage after fixing flags | None — `eri_write()` to the staged path was obvious | `eri_write()` + `eri_data_path()` | Delightfully in-package. |
+
+**Net:** only #1 is a case where an `eri_*` function exists *and the docs steer me away from it*. That
+is the highest-value fix in this report.
+
+---
+
+## Findings
+
+### [major] Cleanup guides teach raw `AzureStor::delete_storage_dir()` instead of `eri_dir_delete()`
+- **Doing:** Cleaning up sandboxes at the end of every guide.
+- **Happened:** Every "Clean up" section calls `AzureStor::delete_storage_dir(con, "atlantis", recursive = TRUE, confirm = FALSE)` and `AzureStor::delete_storage_file(...)`.
+- **Expected:** An `eri_*` function for the most basic file-and-folder operation a DA does. There **is** one: `eri_dir_delete()` and `eri_delete()` are exported (`R/dal.R`, `NAMESPACE`), and they call `.eri_log_session()` so the delete is **audited** — unlike the raw AzureStor calls, which leave no erifunctions trail.
+- **Where:** `vignettes/da-onboard-guide.Rmd` §6, `da-ingest-guide.Rmd` §8, `da-odk-guide.Rmd` §5, `da-logs-guide.Rmd` §5 (all "Clean up").
+- **Fix (doc):** Replace the `AzureStor::` cleanup calls with `eri_dir_delete("atlantis", azcontainer = data_con)` / `eri_delete("schemas/atlantis_malaria.yaml", azcontainer = data_con)`. This keeps a DA inside `erifunctions` for the single operation she's most tempted to do in Storage Explorer, and gains an audit log for free.
+- **Fix (feature, optional):** If `eri_dir_delete()` needs a `recursive`/`confirm` arg to match `delete_storage_dir`, surface it; verify it deletes non-empty namespaces in one call.
+
+### [major] Analyst identity silently falls back to the OS username in approval/audit logs
+- **Doing:** Approving extracts and CMR; reading the approval banner.
+- **Happened:** Every approval printed `Approver: NishantKishore` (my Windows login), not a `firstname.lastname` analyst id. `ERI_ANALYST_ID` was never set, and nothing warned me.
+- **Expected:** The README and connections guide both bill `ERI_ANALYST_ID` as the identity that "appears in approval and access logs." A fresh DA who doesn't set it will silently stamp the shared, governed audit trail with an arbitrary machine username — and never know.
+- **Where:** `R/dal.R`, `R/catalog.R`, `R/cmr.R`, `R/logs.R`, `R/odk*.R` all use `Sys.getenv("ERI_ANALYST_ID", unset = Sys.info()[["user"]])`. Surfaced in `eri_approve()` output.
+- **Fix (feature):** On the first governed write of a session, if `ERI_ANALYST_ID` is unset, emit a one-time `cli::cli_warn()`: *"ERI_ANALYST_ID is not set; approvals will be logged as '<osuser>'. Set it in .Renviron."* Cheap, and it protects the integrity of the audit trail.
+- **Fix (doc):** The connections guide's "confirm it works" section could include a `Sys.getenv("ERI_ANALYST_ID")` check alongside the Azure/ODK checks.
+
+### [minor] Success and routine-info messages render in alarming red (ANSI bold-red)
+- **Doing:** Every step.
+- **Happened:** `✔ Connected…`, `✔ Approved…`, `ℹ Operation log:…`, and even the DQ report all printed in **bold red** in my terminal. As a fresh user my first instinct on seeing red was "something broke."
+- **Expected:** Green/blue for success/info, red reserved for warnings/errors. This is almost certainly a `cli`/terminal theme interaction (Rscript on Windows PowerShell), but it materially undermines the "narration that reassures" design — a green ✔ that prints red reads as a failure.
+- **Where:** all `cli::cli_*` output; observed running `Rscript.exe` under PowerShell 7.
+- **Fix:** Confirm `cli` theme/`crayon` colour detection under non-RStudio Windows terminals; document the expected colours (or note that colour may be absent/odd in some terminals so users don't misread red ✔ as failure).
+
+### [minor] `readr` column-spec dump erupts in the middle of a clean DQ run
+- **Doing:** `eri_read()` of a CSV from `raw/`, then `run_dq_checks()`.
+- **Happened:** Between my steps, a full `Rows: 10 Columns: 5 / ── Column specification ── / Delimiter: "," / chr (2)… / ℹ Use spec()…` block printed (in red, per above). It looks like a problem; it's just `readr` being chatty.
+- **Expected:** `erifunctions` "renders its own output" — this raw `readr` noise breaks that. A DA can't tell it apart from a real message.
+- **Where:** `eri_read()` CSV path (`R/dal.R`); whatever calls `readr::read_csv()` without `show_col_types = FALSE`.
+- **Fix:** Pass `show_col_types = FALSE` (or wrap in `suppressMessages`) inside `eri_read()`'s CSV branch.
+
+### [minor] Top-level auto-printed `NULL`s clutter scripted output
+- **Doing:** Running guide steps as a script (not interactively).
+- **Happened:** `eri_dir_create()`, `eri_write()`, etc. auto-print `NULL` at top level, so my console had stray `NULL` lines between real output.
+- **Expected:** Invisible return for side-effecting writers. Interactive RStudio users won't see this; scripted/CI users (and `Rscript`) do.
+- **Where:** `eri_dir_create()`, `eri_write()`, `eri_upload()` return values.
+- **Fix:** `return(invisible(...))` on the side-effecting helpers.
+
+### [minor] CMR stage→approve loop cannot be rehearsed on a sandbox
+- **Doing:** Trying to run the *whole* CMR guide on `atlantis`, like I could for surveillance/ODK.
+- **Happened:** `eri_stage_cmr("atlantis", "202406")` errors: *"Country 'atlantis' is not registered for CMR staging."* (clean, well-worded error — good). Only `eri_ingest_cmr()` (offline parse) is runnable on a sandbox.
+- **Expected:** The surveillance and ODK guides let me practice the full gate end-to-end on a throwaway namespace; the CMR guide can only *show* me stage/approve. So the riskiest CMR steps are the ones I never get to rehearse.
+- **Where:** `vignettes/da-cmr-guide.Rmd` §2/§4; `eri_stage_cmr()` country allow-list.
+- **Fix (doc):** Add a short "you can't sandbox the stage/approve steps — here's a dry-run or a read-only walkthrough instead" note, OR (feature) let `eri_ingest_cmr()` → `eri_write(staged)` → `eri_approve(country,"rblf","cmr",period)` be demoed against a sandbox country the way surveillance is, decoupling the gate from the `projects`-blob fetch.
+
+### [minor] "Catalog is empty" message prints even for a *filtered* query that simply has no matches
+- **Doing:** Verifying cleanup with `eri_catalog_query(country = "atlantis", ...)`.
+- **Happened:** Output said **"Catalog is empty."** — but the catalog is *not* empty system-wide; my *filter* just matched nothing. A fresh DA might think they nuked the whole team catalog.
+- **Where:** `eri_catalog_query()` empty-result message (`R/catalog.R`).
+- **Fix:** Distinguish "no entries match your filter" from "the catalog is empty."
+
+### [polish] `eri_list()` returns full paths in `name`, not leaf filenames
+- **Doing:** Listing `uga/demo/odk/raw` after sync.
+- **Happened:** The `name` column was `uga/demo/odk/raw/eri_test_river_repeat.parquet` (full path), whereas the guides' example outputs read like leaf names. Not wrong — `full_names = TRUE` is the documented default — just a small mismatch with the guide's illustrative output.
+- **Fix (doc):** Make the guide outputs match, or mention `full_names = FALSE` for leaf names.
+
+### [polish] `renv` "project is out-of-sync" warning greets every command
+- **Doing:** Every single `Rscript` invocation.
+- **Happened:** `- The project is out-of-sync -- use 'renv::status()' for details.` printed before all my output. As a fresh user told to use `renv`, this nags me to "fix" something that isn't my problem.
+- **Note:** This is a dev-checkout artifact (I ran `devtools::load_all()` in the repo), not what an installed-package user sees, so it's low priority — but a brand-new DA following the install-with-renv instructions could hit a cousin of it and worry.
+
+---
+
+## What worked / delighted (don't regress these)
+
+- **Azure was genuinely zero-config.** Cached token, browser-free, `eri_list("")` returned a tibble first try. The "nothing to configure" promise held.
+- **The onboarding dry-run is exactly right.** `dry_run = TRUE` printed the *entire* footprint (one local file + three folders) before touching anything. That's the confidence a non-developer needs.
+- **The schema validate loop is a joy.** Empty tibble = valid; fat-fingering `numeric`→`numbr` produced a precise per-row tibble *and* a readable warning. I knew exactly what to fix.
+- **The DQ flags table is the star of the show.** `result$flags` told me *row, column, value, issue* for the age-250 and unknown-district cases. The corrections-vs-flags distinction ("we fixed what's safe; you decide the rest") is the right mental model and it's taught well.
+- **The ODK repeat-group story is excellent.** `download_odk_form(tables = TRUE)` returned both parent and child tables, `eri_odk_sync()` wrote one parquet each, and the `PARENT_KEY`→`KEY` join worked verbatim from the guide. Nothing was silently dropped, exactly as promised.
+- **`eri_logs()` is a real shared backlog.** I made a DQ-flag log and a deliberate approve-failure; `eri_logs()` listed both, `status = "error"` filtered, `eri_logs_resolve()` dropped the "needs attention" count from 2→1 while keeping the record. This is the feature that would actually let me cover for an out-of-office teammate.
+- **Error messages are humane.** "Country 'atlantis' is not registered for CMR staging. ℹ Registered countries: …" and "No staged files found matching '2024-09'…" both told me what was wrong *and* what's valid. That's better than most production R packages.
+- **Cleanup verified clean.** After teardown, `atlantis` was gone from the top level, only the real `uga/LF` remained under `uga` (my `uga/demo` removed), no `demo` form was active in the registry, and the soft-delete (deregister) correctly preserved an inactive registry record.
+
+---
+
+## Top 5 changes that would most improve my day (ranked)
+
+1. **Use `eri_dir_delete()` / `eri_delete()` in every guide's cleanup section** instead of raw `AzureStor::`. This is the only place the docs send me to Storage Explorer for something the package already does — and it loses the audit log. (major, doc-only, trivial)
+2. **Warn once when `ERI_ANALYST_ID` is unset** before stamping a governed approval with my OS username. Protects the shared audit trail. (major, small feature)
+3. **Tame the scary output:** suppress `readr`'s column-spec dump inside `eri_read()`, and verify success ✔ messages aren't rendering as bold red in non-RStudio terminals. (minor, makes the whole package *feel* trustworthy)
+4. **Tell me up front which steps can't be sandboxed** — ODK form upload/submission (web-only) and the CMR stage→approve loop (registered countries only) — so I'm not stuck wondering. (minor, doc)
+5. **Fix the "Catalog is empty" message** to distinguish a no-match filter from a truly empty catalog. (minor, prevents a panic)
+
+---
+
+## Issue-ready list
+
+- **Guides delete sandboxes with raw AzureStor instead of `eri_dir_delete()`** — Replace `AzureStor::delete_storage_dir/file` in all four DA guides' Clean-up sections with `eri_dir_delete()`/`eri_delete()`; keeps DAs in-package and audited.
+- **Warn when `ERI_ANALYST_ID` is unset** — Governed writes silently fall back to the OS username (e.g. `NishantKishore`) in approval/access logs; emit a one-time `cli_warn` on first governed write of a session.
+- **Suppress `readr` column-spec output in `eri_read()`** — A CSV read prints a full `readr` spec dump mid-pipeline, looking like an error during a clean DQ run; pass `show_col_types = FALSE`.
+- **Success/info `cli` messages render bold-red under Windows/PowerShell** — Verify `cli`/crayon colour detection so green ✔ doesn't read as a failure to fresh users; document expected colours.
+- **Side-effecting helpers auto-print `NULL` in scripts** — `eri_dir_create()`/`eri_write()`/`eri_upload()` should `invisible()` their return to avoid stray `NULL` lines in scripted/CI runs.
+- **CMR stage→approve can't be rehearsed on a sandbox** — `eri_stage_cmr()` rejects non-registered countries, so the riskiest CMR steps are undemonstrable on `atlantis`; add a doc note or a sandbox-friendly demo path.
+- **`eri_catalog_query()` says "Catalog is empty" for a no-match filter** — Distinguish "no entries match your filter" from "the catalog is empty" to avoid implying the shared catalog was wiped.
+- **ODK & CMR guides should flag web-only/registered-only steps up front** — Brand-new DAs hit "upload the form in the web UI" (ODK §1) and "registered countries only" (CMR) with no warning; call these out before the steps.
+- **`eri_list()` full-path vs leaf-name mismatch with guide outputs** — Either align the guide example outputs or mention `full_names = FALSE`.
+
+---
+
+## Prior learnings re-confirmed / fixed
+
+None — this is the first red-team run; `docs/feedback/red-team-learnings.md` was empty. This report
+should seed its "Known findings" index. The durable pattern worth carrying forward: **the API is
+strong and the guides are good; the remaining friction is (a) docs steering users out of the package
+for delete, (b) silent identity fallback, and (c) cosmetic output that reads as failure.**

--- a/docs/feedback/epi-feedback-2026-06-26.md
+++ b/docs/feedback/epi-feedback-2026-06-26.md
@@ -1,0 +1,197 @@
+# Epi fresh-user red-team feedback — "Eli" — 2026-06-26
+
+Persona: brand-new ERI epidemiologist, R-for-analysis, not a data engineer. Ran live, hands-on,
+on synthetic/in-memory data only (no real country/research data pulled). R 4.5.2,
+`devtools::load_all('.')`. Live keyless OSM geocode used. No Azure namespace created; temp scripts
+removed; no package file edited.
+
+---
+
+## Headline
+
+**Yes — I'd actually use `erifunctions` for the two core epi jobs (reconcile + anomaly QC).** Both
+worked first try, matched the guides exactly, and did things I'd otherwise hand-roll badly: the
+offline string-match (case/accent/typo) and the geocode **trust guard** (`geocoded_review` when the
+geocoded point disagrees with my claimed parent) are genuinely better than my usual `fuzzyjoin` +
+hand `st_join`. The anomaly detectors (`pct_change`, `gaps`) are framed in epi terms and gave clear,
+named errors. **What would make me bail isn't the analysis machinery — it's the vocabulary.** The
+single biggest wall is that the *same concept* ("what kind of data is this?") is spelled three
+different ways across the README country table, `load_dq_schema()`, and `eri_data_path()` /
+`eri_catalog_query()`. The moment I try to go from "I QC'd a malaria extract" to "now pull the
+approved version for analysis," I'm guessing magic strings with no error message to guide me. Fix the
+vocabulary and the stale README reference, surface the review-resolving details the functions already
+compute, and I'd never hand-roll a geocode or QC script again.
+
+---
+
+## The do-it-myself-instead log (priority section)
+
+Every moment I felt the pull to drop out of `erifunctions`:
+
+1. **Resolving a `geocoded_review` row.** The function tells me MIT is `geocoded_review` and gives me
+   coordinates, but **not which admin unit the point actually landed in.** To decide "is MIT really
+   across the county line, or was the county mis-entered?" I have to take the lon/lat and run my own
+   `sf::st_join` against the boundary. That is the exact "bail to sf" the team wants to prevent — and
+   the function already did the point-in-polygon internally to set the status; it just doesn't return
+   the answer. → *no `eri_*` surfacing exists for this; it's discarded.*
+2. **Going from a QC'd extract to the approved data for analysis.** I QC'd `data_type="malaria_case"`,
+   but `eri_data_path()` / `eri_catalog_query()` only accept `data_type ∈ {surveillance, cmr, odk}`.
+   I had no way to know `malaria_case` maps to `surveillance`. My instinct: forget the catalog, ask a
+   colleague for the blob path and `eri_read()` it directly (or just get a CSV). → *`eri_catalog_query`
+   exists but the vocabulary mismatch makes it unusable without insider knowledge.*
+3. **Loading the right schema.** README says DR's program is `malaria`; `load_dq_schema("dr","malaria")`
+   **errors**. I only got the working call (`"malaria_case"`) by copying the guide verbatim. If I'd
+   typed the disease from the README table, I'd have given up on `load_dq_schema()` and eyeballed the
+   data. → *function exists; the disease string the README documents doesn't work.*
+4. **Acting on a `run_dq_checks` flag.** The printed report says "1 flag … 1 row [species]" but not
+   *which* value or row. My reflex was `filter(cases, species != "P. vivax")` by hand. (The detail
+   *is* in `result$flags`, but nothing in the printed output tells a fresh user to look there.) →
+   *data exists; not surfaced in the report.*
+
+The good news: I never once wanted to hand-roll the geocoder itself or the gap/spike detection — those
+are compelling enough to keep me in the package.
+
+---
+
+## Findings
+
+### [major] Geocode review status doesn't tell me what to review
+- **Doing:** Pass-2 OSM reconcile; `MIT` came back `geocoded_review` (parent mismatch).
+- **Happened:** Result columns are `longitude, latitude, reconcile_status` only. My supplied (wrong)
+  `county = "Suffolk"` is kept; the geocoder's *opinion* (the point fell in Cambridge/Middlesex) — the
+  very reason the row was flagged — is not returned.
+- **Expected:** A column with the admin unit(s) the geocoded point fell into (e.g.
+  `geocoded_adm3`/`geocoded_adm2`), so I can confirm/fix without re-doing the point-in-polygon myself.
+- **Where:** `eri_spatial_reconcile()`; guide `epi-reconcile-guide.Rmd` §3–4. The guide *narrates* the
+  Cambridge/Middlesex answer but the output doesn't expose it.
+- **Fix:** Return the matched-polygon admin columns (prefixed, e.g. `geocoded_*`) for geocoded rows,
+  at least for `geocoded_review`. The function already computes this internally.
+
+### [major] "data_type" vocabulary is inconsistent across the system
+- **Doing:** Light sourcing reasoning — from a QC'd `malaria_case` extract to pulling approved data.
+- **Happened:** `eri_data_path("dr","malaria","malaria_case","national","processed")` →
+  `` `data_type` must be one of "surveillance", "cmr", and "odk", not "malaria_case" ``. So the
+  layer-path/catalog `data_type` vocabulary (`surveillance|cmr|odk`) is different from the schema-side
+  vocabulary (`malaria_case`), with no documented crosswalk.
+- **Expected:** One consistent notion of "data type," or an explicit, documented mapping
+  (`malaria_case → surveillance`) right where an epi would need it (the sourcing section / catalog
+  help).
+- **Where:** `eri_data_path()`, `eri_catalog_query()` vs `load_dq_schema()`; README "Core concepts"
+  and function reference.
+- **Fix:** Document the crosswalk prominently and accept the schema-level type where users naturally
+  have it, or have the error list the valid values *and* hint the mapping.
+
+### [major] README disease vocabulary doesn't match what `load_dq_schema()` accepts
+- **Doing:** Trying to load the DR malaria schema using the disease name from the README country table.
+- **Happened:** README "Supported countries" lists DR program = **`malaria`**, but
+  `load_dq_schema("dr","malaria")` → `No schema found for "dr"/"malaria"`. The working string is
+  `"malaria_case"`, discoverable only by copying the guide.
+- **Expected:** The disease name documented in the README works, or the error lists the valid
+  disease keys for that country.
+- **Where:** README "Supported countries"; `load_dq_schema()` error path; `inst/schemas/`.
+- **Fix:** Align the documented disease vocabulary with schema keys, and make the "no schema" error
+  enumerate available `country/disease` pairs.
+
+### [minor] README function reference is stale for the research lifecycle
+- **Doing:** Orienting from the README before opening the flagship epi-research guide.
+- **Happened:** README "Research projects" table lists `eri_research_init` and `eri_research_resume`
+  but **not** `eri_research_scaffold`, `eri_research_tag`, or `eri_research_status` — all of which
+  exist and are the ones the epi-research guide actually uses. As a fresh user I couldn't tell whether
+  `init` or `scaffold` is the real entry point, or that tagging/status exist at all.
+- **Expected:** README reference matches the guide and the exported namespace.
+- **Where:** README §"Research projects"; vignette `epi-research-guide.Rmd` §1, §7, §10.
+- **Fix:** Regenerate/sync the README table from the exported `eri_research_*` set; pick one entry
+  point (`init` vs `scaffold`) as canonical and note the relationship.
+
+### [minor] `load_dq_schema()` example reads as if "malaria_case" is a data_type, but it's the `disease` arg
+- **Doing:** Reading the DQ guide call `load_dq_schema("dr", "malaria_case", azcontainer = NULL)`.
+- **Happened:** The signature is `load_dq_schema(country, disease, azcontainer)` — so `"malaria_case"`
+  is positionally the **disease**. The surrounding prose (and the README's path model) frames
+  `malaria_case` as a *data type*. Conceptually whiplash; compounds the vocabulary findings above.
+- **Where:** `epi-dq-guide.Rmd` §1; README "Core concepts".
+- **Fix:** Name the argument in examples (`disease = "malaria_case"`) and add one sentence clarifying
+  that the schema key is a `disease`, distinct from the layer-path `data_type`.
+
+### [polish] `dq_report()` summary doesn't surface the offending value / row
+- **Doing:** Reading `run_dq_checks()` output to act on the species typo.
+- **Happened:** Printed report says `1 row [species]` — no value, no row index. The detail is in
+  `result$flags` (row 4, "P.vivax"), but nothing tells a fresh user to look there.
+- **Expected:** Either show the bad value(s) inline (e.g. `P.vivax (row 4)`) or a one-line pointer:
+  "see `result$flags` for row-level detail."
+- **Where:** `dq_report()` / the print method; `epi-dq-guide.Rmd` §2.
+- **Fix:** Print a few example offending values, or add the `result$flags` pointer.
+
+---
+
+## Epi-meaningfulness
+
+Mostly strong. Where it landed in my terms:
+- `reconcile_status` values (`matched` / `geocoded` / `geocoded_review` / `unresolved`) map cleanly to
+  an epi decision: *trust and roll up* vs *call someone before using*. The §4 status table is exactly
+  how I'd want it framed. The trust guard ("kept your names, didn't silently correct") respects that
+  *I* own the judgement call — excellent.
+- `structural_gap` for a missing reporting week is the right concept: it correctly distinguishes
+  "no report" from "zero cases," which is the difference between a fake dip and a real one in a curve.
+- `pct_change` reporting the spike *and* its rebound (week 5 up, week 6 down) is honest and matched
+  how I'd reason about a double-entry vs a real cluster.
+
+Where I had to translate (engineering leaking through):
+- "`data_type`" means two different things (schema key vs layer token) — pure package-internals
+  vocabulary I had to reverse-engineer (see majors above).
+- A `geocoded_review` row gives me a status but withholds the admin unit it disagreed with — I have to
+  translate coordinates back into "which county" myself.
+- "1 flag for review" is engineer-terse; an epi wants the value to fix.
+
+---
+
+## What worked / delighted
+
+- **Offline string match** fixed `boston`→`Boston` and the typo `Cambrige`→`Cambridge`, and rewrote
+  the *whole* hierarchy to canonical spelling. Zero network, instant, correct.
+- **The geocode trust guard.** `geocoded_review` firing on the MIT parent mismatch — and *not*
+  silently overwriting my county — is the single best design choice I saw. It earns trust.
+- **Clear, named errors.** `` `value_col` "cases" not found in data `` told me exactly what I did
+  wrong. Optional `year_col` degraded gracefully instead of erroring. This is what keeps me in the
+  package instead of bailing.
+- **Guides are runnable as written.** Every command in the reconcile and DQ guides produced the
+  documented output verbatim, on synthetic data, offline (plus one live geocode). That is rare and
+  builds confidence fast.
+- **`result$flags`** carries proper row-level detail once you know it's there.
+
+---
+
+## Top 5 changes that would most improve my day (ranked)
+
+1. **Unify the "data_type"/disease vocabulary** (or document the crosswalk loudly) so I can get from a
+   QC'd extract to the approved data without guessing magic strings. *(majors #2, #3)*
+2. **Return the geocoder's admin unit on `geocoded_review` rows** so I can resolve a review without
+   hand-rolling `st_join`. *(major #1)*
+3. **Fix the README "No schema" / disease-name mismatch** and make the error enumerate valid
+   `country/disease` keys. *(major #3)*
+4. **Sync the README research-lifecycle reference** with the real `eri_research_*` functions. *(minor)*
+5. **Surface the offending value in `dq_report()`** (or point to `result$flags`). *(polish)*
+
+---
+
+## Issue-ready list
+
+- **`eri_spatial_reconcile()`: return geocoded admin unit for review rows** — Add `geocoded_*` admin
+  columns so users can resolve `geocoded_review` without a manual point-in-polygon.
+- **Unify or document the `data_type` vocabulary** — Schema key (`malaria_case`) vs layer/catalog
+  token (`surveillance`) diverge with no crosswalk; document the mapping in catalog/sourcing help and
+  improve the `eri_data_path()` error.
+- **`load_dq_schema()` disease vocabulary mismatch** — README lists DR program `malaria` but loader
+  needs `malaria_case`; align docs and make the "No schema found" error list valid keys.
+- **README research-lifecycle reference is stale** — Add `eri_research_scaffold/_tag/_status`; clarify
+  `init` vs `scaffold` as the entry point.
+- **DQ guide: name the `disease` arg in `load_dq_schema()` examples** — Use `disease = "malaria_case"`
+  and a sentence distinguishing schema `disease` from layer `data_type`.
+- **`dq_report()`: surface offending values/rows** — Print example bad values or a pointer to
+  `result$flags` so a fresh user knows where the actionable detail lives.
+
+---
+
+### Prior-learnings check
+
+Read `docs/feedback/red-team-learnings.md` — it is the empty template (no prior runs). Nothing to
+re-confirm or dedup; this run is among the first. All findings above are new.

--- a/docs/feedback/red-team-learnings.md
+++ b/docs/feedback/red-team-learnings.md
@@ -56,6 +56,26 @@ Status legend: ⬜ open · 🔧 in progress · ✅ fixed. Update when a fix land
 | [#177](https://github.com/thecartercenter/erifunctions/issues/177) | F12,F14 | Guides flag non-sandboxable/web-only steps; `eri_list()` output |
 | [#178](https://github.com/thecartercenter/erifunctions/issues/178) | F13 | `dq_report()` surface offending value/row |
 
+### Resolution (all shipped 2026-06-27)
+
+Every issue from the first run was fixed and merged — findings F1–F14 are **resolved** (future runs
+should treat them as closed and only re-flag a regression):
+
+| Issue | PR | Outcome |
+|-------|----|---------|
+| #170 | #180 | Guides clean up via `eri_dir_delete()`/`eri_delete()` (6 vignettes) |
+| #172 | #181 | `eri_read()` quietened; side-effecting writers `invisible()`; red-✔ confirmed an stderr artifact, not a bug |
+| #173 | #182 | `eri_catalog_query()` "no match" vs "empty catalog" |
+| #178 | #183 | `dq_report()` shows example offending values + `result$flags` pointer |
+| #176 | #184 | `load_dq_schema()` enumerates valid keys; README research reference synced |
+| #177 | #185 | ODK/CMR non-sandboxable steps flagged; `eri_list()` `full_names` noted |
+| #171 | #186 | One-time `ERI_ANALYST_ID`-unset warning; identity centralised in `.eri_analyst_id()` |
+| #174 | #187 | `eri_spatial_reconcile()` returns `geocoded_*` admin units for review rows |
+| #175 | #188 | **Phase 1** (docs + `eri_data_path` error + ADR-0011); **Phase 2** schema-naming rename still open under #175 |
+
+Every PR passed the `review-agent` and CI; review nits were folded in before merge. The only
+carried-forward item is the **#175 Phase 2** schema-naming migration (ADR-0011).
+
 ## Durable lessons / patterns
 
 - **The API and guides are strong; the friction is at the edges.** Both fresh users completed their

--- a/docs/feedback/red-team-learnings.md
+++ b/docs/feedback/red-team-learnings.md
@@ -1,0 +1,76 @@
+# Red-team learnings (cumulative)
+
+Persistent memory for the fresh-user red-team agents ([`da-fresh-user`](../../.claude/agents/da-fresh-user.md)
+and [`epi-fresh-user`](../../.claude/agents/epi-fresh-user.md)). Each run **reads this first** to avoid
+re-reporting known items, and we append the durable lessons here after each round so future runs build
+on prior findings rather than starting cold.
+
+How to use this file:
+- **Before a run:** the agent reads the "Known findings" table and skips/cross-references anything
+  already captured; it still re-confirms whether prior items are fixed.
+- **After a run:** the orchestrator appends new durable learnings (patterns, recurring confusions,
+  decisions made) — not every one-off nit, just what should shape the next run and the docs/API
+  direction.
+
+## Run log
+
+| Date | Persona | Report | Headline result |
+|------|---------|--------|-----------------|
+| 2026-06-26 | Dana (DA) | [da-feedback-2026-06-26](da-feedback-2026-06-26.md) | A fresh DA *can* do the whole job on erifunctions; friction is narrow — cleanup, identity, scary output. |
+| 2026-06-26 | Eli (Epi) | [epi-feedback-2026-06-26](epi-feedback-2026-06-26.md) | An epi *would* use reconcile + anomaly QC; the wall is vocabulary drift + stale README, not the analysis machinery. |
+
+## Known findings (de-dup index)
+
+Status legend: ⬜ open · 🔧 in progress · ✅ fixed. Update when a fix lands.
+
+| # | Severity | Area | Finding | Persona | Status |
+|---|----------|------|---------|---------|--------|
+| F1 | major | docs | Guide Clean-up sections use raw `AzureStor::delete_storage_dir/file` instead of the exported, audited `eri_dir_delete()`/`eri_delete()` (6 vignettes). The one place docs steer users out of the package. | Dana | ⬜ |
+| F2 | major | code | `ERI_ANALYST_ID` silently falls back to the OS username when unset; governed approval/access logs get stamped with an arbitrary machine login, no warning. | Dana | ⬜ |
+| F3 | major | code | `eri_spatial_reconcile()` returns `geocoded_review` + coords but not the admin unit the point fell in (computed internally, discarded) — forces a manual `sf::st_join`. | Eli | ⬜ |
+| F4 | major | docs+code | "data_type" vocabulary diverges: schema side uses `malaria_case` (`load_dq_schema`), layer/catalog side accepts only `surveillance\|cmr\|odk` (`eri_data_path`/`eri_catalog_query`), no crosswalk. Blocks QC'd→approved sourcing path. | Eli | ⬜ |
+| F5 | major | docs | README "Supported countries" lists DR/HT program as `malaria`, but the loader needs `malaria_case` (`load_dq_schema("dr","malaria")` errors). Schema files also double-named (`dominican_republic_malaria.yaml` + `dr_malaria_case.yaml`). "No schema" error doesn't enumerate valid keys. | Eli | ⬜ |
+| F6 | minor | code | `eri_read()` CSV path leaks `readr` column-spec dump mid-pipeline (no `show_col_types = FALSE`). | Dana | ⬜ |
+| F7 | minor | code | Side-effecting writers (`eri_dir_create`/`eri_write`/`eri_upload`) auto-print `NULL` in scripts (no `invisible()`). | Dana | ⬜ |
+| F8 | minor | code | Success/info `cli` messages render bold-red under Rscript+PowerShell on Windows — green ✔ reads as failure. | Dana | ⬜ |
+| F9 | minor | code | `eri_catalog_query()` prints "Catalog is empty" for a no-match *filter*, implying the shared catalog was wiped. | Dana | ⬜ |
+| F10 | minor | docs | README research-lifecycle reference stale: omits `eri_research_scaffold/_tag/_status`; `init` vs `scaffold` entry point ambiguous. | Eli | ⬜ |
+| F11 | minor | docs | `load_dq_schema()` examples pass `"malaria_case"` positionally as `disease` while prose frames it as a data_type — name the arg + one clarifying sentence. | Eli | ⬜ |
+| F12 | minor | docs | ODK & CMR guides don't flag non-sandboxable steps up front (ODK form upload = web-only; CMR stage→approve = registered countries only). | Dana | ⬜ |
+| F13 | polish | code | `dq_report()` summary says "1 row [species]" without the offending value/row; detail in `result$flags` but nothing points there. | Eli | ⬜ |
+| F14 | polish | docs | `eri_list()` returns full paths in `name` (documented `full_names=TRUE` default) while guide example outputs read as leaf names. | Dana | ⬜ |
+
+## Issues filed (2026-06-26 run)
+
+14 findings → 9 deduped issues:
+
+| Issue | Findings | Title |
+|-------|----------|-------|
+| [#170](https://github.com/thecartercenter/erifunctions/issues/170) | F1 | Guides use raw `AzureStor::delete_*` instead of `eri_dir_delete()`/`eri_delete()` |
+| [#171](https://github.com/thecartercenter/erifunctions/issues/171) | F2 | Warn when `ERI_ANALYST_ID` is unset before stamping governed logs |
+| [#172](https://github.com/thecartercenter/erifunctions/issues/172) | F6,F7,F8 | Fresh-user output hygiene (`eri_read` readr dump, `NULL` auto-print, red success) |
+| [#173](https://github.com/thecartercenter/erifunctions/issues/173) | F9 | `eri_catalog_query()` "no match" vs "Catalog is empty" |
+| [#174](https://github.com/thecartercenter/erifunctions/issues/174) | F3 | `eri_spatial_reconcile()` return geocoded admin unit for review rows |
+| [#175](https://github.com/thecartercenter/erifunctions/issues/175) | F4 | Unify/document the `data_type` vocabulary crosswalk |
+| [#176](https://github.com/thecartercenter/erifunctions/issues/176) | F5,F10,F11 | README/doc vocabulary drift; enumerate valid schema keys |
+| [#177](https://github.com/thecartercenter/erifunctions/issues/177) | F12,F14 | Guides flag non-sandboxable/web-only steps; `eri_list()` output |
+| [#178](https://github.com/thecartercenter/erifunctions/issues/178) | F13 | `dq_report()` surface offending value/row |
+
+## Durable lessons / patterns
+
+- **The API and guides are strong; the friction is at the edges.** Both fresh users completed their
+  core jobs first-try on synthetic data with guides that ran verbatim. Neither wanted to hand-roll the
+  *core* machinery (DQ engine, anomaly detectors, ODK sync, geocode trust guard). Future runs should
+  push harder on the *seams* — cleanup, identity, sourcing/vocabulary, output legibility — not the
+  happy paths, which are solid.
+- **The #1 "bail out of the package" trigger is the docs themselves** (F1: cleanup teaches AzureStor).
+  When auditing for the "rely on erifunctions, not AzureStor/base R" goal, grep the guides for
+  `AzureStor::`/`sf::`/`readr::` calls that have an `eri_*` equivalent — doc-level leaks matter as much
+  as missing functions.
+- **Vocabulary drift is the epi's main wall** (F4/F5/F11): the same concept ("kind of data") is spelled
+  three ways across README / `load_dq_schema` / `eri_data_path`. Worth a single source-of-truth pass.
+- **"Looks broken" ≠ "is broken"** (F6/F8): cosmetic output (red ✔, readr dumps, stray `NULL`) erodes
+  a non-developer's trust even when nothing failed. Cheap to fix, high trust payoff.
+- **Functions that compute an answer then discard it** are a recurring "bail to sf/base-R" source (F3:
+  reconcile does point-in-polygon then drops the polygon; F13: DQ knows the bad value then hides it).
+  Surfacing already-computed detail is high-value and low-cost.


### PR DESCRIPTION
## What

Two cold-context **fresh-user persona agents** — a Data Analyst ("Dana", Storage-Explorer user) and an Epidemiologist ("Eli", analysis-first) — ran the guides end-to-end **live** as brand-new users, on synthetic data in throwaway sandboxes, to find every point where the docs or API would push them back to raw `AzureStor` / base R instead of an `eri_*` function. No package code was touched; all sandboxes were cleaned up.

This PR captures the durable outputs:
- `docs/feedback/da-feedback-2026-06-26.md` — DA report
- `docs/feedback/epi-feedback-2026-06-26.md` — Epi report
- `docs/feedback/red-team-learnings.md` — cumulative learnings index (run log, de-dup finding table F1–F14, finding→issue map, durable patterns) that future red-team runs read first

## Headline

**Both personas completed their core jobs first-try**, with guides that ran verbatim — the machinery (DQ engine, anomaly detectors, ODK repeat-group sync, geocode trust guard) is compelling. Friction is concentrated at the **seams**:
- **The docs themselves are the #1 "leave the package" trigger** — six guide Clean-up sections teach `AzureStor::delete_*` even though `eri_dir_delete()`/`eri_delete()` exist and are audited (#170).
- **Silent identity fallback** — `ERI_ANALYST_ID` unset ⇒ governed audit logs stamped with the OS username, no warning (#171).
- **Vocabulary drift** is the epi's main wall — `data_type` means `malaria_case` (schema) vs `surveillance` (layer/catalog) with no crosswalk, and README disease names don't match the loader (#175, #176).
- **Cosmetic output reads as failure** — red `✔`, `readr` dumps, stray `NULL` (#172).
- **Computed-then-discarded answers** force hand-rolled `sf`/`filter` — reconcile hides the geocoded admin unit (#174), `dq_report()` hides the offending value (#178).

## Filed issues
14 findings → 9 deduped issues: **#170–#178** (mapping in the learnings index).

## Note
The two reusable persona definitions live in `.claude/agents/{da,epi}-fresh-user.md`, which is **gitignored**, so they're local-only (durable for future sessions on this machine, not in the repo). Say the word if you'd like them force-added so the team can re-run the personas.