### PR TITLE
docs: guides clean up via eri_dir_delete()/eri_delete() not raw AzureStor (#170)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # erifunctions (development version)
 
+## Docs: guides clean up with `eri_dir_delete()`/`eri_delete()`, not raw AzureStor
+
+- Every guide's "Clean up" section now tears down its sandbox with the exported `eri_dir_delete()` /
+  `eri_delete()` instead of `AzureStor::delete_storage_dir()` / `delete_storage_file()`. These keep an
+  analyst inside `erifunctions` for the one operation most likely to send them to Azure Storage
+  Explorer, and they record the delete in the session log (the raw AzureStor calls do not). Fixes the
+  fresh-user red-team's top finding (#170).
+
 ## Feature: ODK forms with repeat groups are now captured in full
 
 - ODK Central exports a form with **repeat groups** as multiple tables — a parent table (one row per

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,9 @@
 ## Docs: guides clean up with `eri_dir_delete()`/`eri_delete()`, not raw AzureStor
 
 - Every guide's "Clean up" section now tears down its sandbox with the exported `eri_dir_delete()` /
-  `eri_delete()` instead of `AzureStor::delete_storage_dir()` / `delete_storage_file()`. These keep an
+  `eri_delete()` instead of `AzureStor::delete_storage_dir()` / `delete_storage_file()`. This keeps an
   analyst inside `erifunctions` for the one operation most likely to send them to Azure Storage
-  Explorer, and they record the delete in the session log (the raw AzureStor calls do not). Fixes the
-  fresh-user red-team's top finding (#170).
+  Explorer, rather than dropping to raw blob calls. Fixes the fresh-user red-team's top finding (#170).
 
 ## Feature: ODK forms with repeat groups are now captured in full
 

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -444,12 +444,12 @@ You ran this for practice, so remove everything it created and leave no trace. T
 
 ```{r cleanup}
 # Delete the entire sandbox namespace (raw + staged + processed + logs).
-# recursive = TRUE is required to delete a non-empty directory; confirm = FALSE
-# skips the interactive prompt.
-AzureStor::delete_storage_dir(data_con, "atlantis", recursive = TRUE, confirm = FALSE)
+# eri_dir_delete() removes a non-empty directory in one call and records the
+# delete in your erifunctions session log (raw AzureStor calls do not).
+eri_dir_delete("atlantis", azcontainer = data_con)
 
 # Delete the schema you published.
-AzureStor::delete_storage_file(data_con, "schemas/atlantis_malaria.yaml", confirm = FALSE)
+eri_delete("schemas/atlantis_malaria.yaml", azcontainer = data_con)
 
 # Remove the two catalog entries (the catalog is shared, so tidy up after yourself).
 eri_catalog_remove("atlantis/malaria/surveillance/processed/atlantis_malaria_2024-01.parquet",

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -444,8 +444,8 @@ You ran this for practice, so remove everything it created and leave no trace. T
 
 ```{r cleanup}
 # Delete the entire sandbox namespace (raw + staged + processed + logs).
-# eri_dir_delete() removes a non-empty directory in one call and records the
-# delete in your erifunctions session log (raw AzureStor calls do not).
+# eri_dir_delete() removes a non-empty directory recursively in one call; using
+# the erifunctions helpers (not raw AzureStor) keeps every step in the package.
 eri_dir_delete("atlantis", azcontainer = data_con)
 
 # Delete the schema you published.

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -181,6 +181,7 @@ If you ran this in the sandbox, remove the `atlantis` namespace (this deletes it
 
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
+# eri_dir_delete() removes the namespace (logs and all) recursively, in-package.
 eri_dir_delete("atlantis", azcontainer = con)
 ```
 

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -181,7 +181,7 @@ If you ran this in the sandbox, remove the `atlantis` namespace (this deletes it
 
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
-AzureStor::delete_storage_dir(con, "atlantis", recursive = TRUE, confirm = FALSE)
+eri_dir_delete("atlantis", azcontainer = con)
 ```
 
 > **Real logs are not disposable.** The error and data-quality trail across real countries is how the

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -472,7 +472,7 @@ eri_odk_deregister(project_id = project_id, form_id = "eri_test_river_repeat",
 
 ```{r cleanup-azure}
 # Delete the whole uga/demo sandbox namespace (raw + staged + processed + logs).
-# eri_dir_delete() removes it recursively and logs the delete in your session trail.
+# eri_dir_delete() removes it recursively — the in-package path, no Storage Explorer.
 eri_dir_delete("uga/demo", azcontainer = data_con)
 ```
 

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -472,7 +472,8 @@ eri_odk_deregister(project_id = project_id, form_id = "eri_test_river_repeat",
 
 ```{r cleanup-azure}
 # Delete the whole uga/demo sandbox namespace (raw + staged + processed + logs).
-AzureStor::delete_storage_dir(data_con, "uga/demo", recursive = TRUE, confirm = FALSE)
+# eri_dir_delete() removes it recursively and logs the delete in your session trail.
+eri_dir_delete("uga/demo", azcontainer = data_con)
 ```
 
 Finally, in the ODK Central web interface, delete the test form (Form ▸ ⋯ ▸ Delete) from your `test`

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -262,8 +262,9 @@ Practice run — remove everything you created. Delete the Azure namespace and t
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
-# Deletes atlantis/malaria/surveillance/* and atlantis/rblf/cmr/* in one go
-# (recursive, and logged in your erifunctions session trail).
+# Deletes atlantis/malaria/surveillance/* and atlantis/rblf/cmr/* in one go,
+# recursively — the in-package path, so you stay in erifunctions instead of
+# dropping to raw AzureStor / Storage Explorer.
 eri_dir_delete("atlantis", azcontainer = con)
 
 # Remove the local schema templates.

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -262,8 +262,9 @@ Practice run — remove everything you created. Delete the Azure namespace and t
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
-# Deletes atlantis/malaria/surveillance/* and atlantis/rblf/cmr/* in one go.
-AzureStor::delete_storage_dir(con, "atlantis", recursive = TRUE, confirm = FALSE)
+# Deletes atlantis/malaria/surveillance/* and atlantis/rblf/cmr/* in one go
+# (recursive, and logged in your erifunctions session trail).
+eri_dir_delete("atlantis", azcontainer = con)
 
 # Remove the local schema templates.
 unlink(c("atlantis_malaria_schema.yaml", "atlantis_cmr_schema.yaml",

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -471,12 +471,10 @@ Azure. This deletes the project folder, all snapshots and tags, and the artifact
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
-# recursive = TRUE is required to delete a non-empty directory in Azure;
-# confirm = FALSE just skips the interactive prompt.
-AzureStor::delete_storage_dir(con, "research/mtcars_study",
-                              recursive = TRUE, confirm = FALSE)
-AzureStor::delete_storage_dir(con, "artifacts/study_data/mtcars_study_data",
-                              recursive = TRUE, confirm = FALSE)
+# eri_dir_delete() removes a non-empty directory in one call and records the
+# delete in your erifunctions session log.
+eri_dir_delete("research/mtcars_study", azcontainer = con)
+eri_dir_delete("artifacts/study_data/mtcars_study_data", azcontainer = con)
 ```
 
 Confirm nothing of yours remains, then delete the local folder:

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -471,8 +471,8 @@ Azure. This deletes the project folder, all snapshots and tags, and the artifact
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
-# eri_dir_delete() removes a non-empty directory in one call and records the
-# delete in your erifunctions session log.
+# eri_dir_delete() removes a non-empty directory recursively in one call — the
+# in-package path, so cleanup stays in erifunctions instead of raw AzureStor.
 eri_dir_delete("research/mtcars_study", azcontainer = con)
 eri_dir_delete("artifacts/study_data/mtcars_study_data", azcontainer = con)
 ```


### PR DESCRIPTION
Fixes #170.

The fresh-user DA red-team's top finding: every guide's "Clean up" section deleted its sandbox with `AzureStor::delete_storage_dir()` / `delete_storage_file()` — the one place the docs steered a Data Analyst *out* of erifunctions toward Azure Storage Explorer, and a path that leaves no erifunctions session-log trail.

This swaps all six occurrences (across `da-onboard`, `da-ingest`, `da-odk`, `da-logs`, `epi-research`) to the exported, audited `eri_dir_delete()` / `eri_delete()`.

**Verified** live that `eri_dir_delete()` removes a non-empty nested namespace recursively in one call (`azure_io("delete.dir")` → `delete_adls_dir(recursive = TRUE, confirm = FALSE)`): a two-subfolder sandbox went `exists: TRUE` → `FALSE`. All five changed vignettes knit-parse clean.

Doc-only; no code or signature change.