### PR TITLE
fix: quieter eri_read() and invisible side-effecting writers (#172)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # erifunctions (development version)
 
+## Fix: cleaner console output from `eri_read()` and the file-writing helpers
+
+- `eri_read()` no longer prints `readr`'s column-specification block when reading a CSV (it now reads
+  with `show_col_types = FALSE` / suppresses the message on both the local and Azure paths), so a read
+  no longer erupts with engine noise in the middle of a pipeline.
+- The side-effecting helpers (`eri_write()`, `eri_upload()`, `eri_dir_create()`, `eri_delete()`,
+  `eri_dir_delete()`) now return **invisibly**, so scripted / `Rscript` runs no longer print stray
+  `NULL` lines between steps. Both fixes come from the fresh-user red-team (#172).
+
 ## Docs: guides clean up with `eri_dir_delete()`/`eri_delete()`, not raw AzureStor
 
 - Every guide's "Clean up" section now tears down its sandbox with the exported `eri_dir_delete()` /

--- a/R/dal.R
+++ b/R/dal.R
@@ -319,7 +319,7 @@ erifunctions_io <- function(
         cli::cli_li(obj_names)
         return(invisible())
       } else if (endsWith(file_loc, ".csv")) {
-        return(readr::read_csv(file_loc))
+        return(readr::read_csv(file_loc, show_col_types = FALSE))
       } else if (endsWith(file_loc, ".qs2")) {
         return(qs2::qs_read(file_loc))
       } else if (endsWith(file_loc, ".xlsx") || endsWith(file_loc, ".xls")) {
@@ -397,7 +397,9 @@ erifunctions_io <- function(
     }
   }
 
-  return(NULL)
+  # Side-effecting ops (write/upload/delete/create.dir/delete.dir) fall through to
+  # here; return invisibly so they don't print a stray `NULL` in scripts/Rscript.
+  return(invisible(NULL))
 }
 
 #' Helper function to read and write key data to the Azure environment
@@ -535,7 +537,7 @@ azure_io <- function(
 
     if (endsWith(file_loc, ".csv")) {
 
-      return(suppressWarnings(AzureStor::storage_read_csv(azcontainer, file_loc, ...)))
+      return(suppressMessages(suppressWarnings(AzureStor::storage_read_csv(azcontainer, file_loc, ...))))
 
     } else if (endsWith(file_loc, ".rda")) {
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -537,6 +537,9 @@ azure_io <- function(
 
     if (endsWith(file_loc, ".csv")) {
 
+      # suppressMessages (rather than show_col_types = FALSE) silences readr's
+      # column-spec dump without risking a duplicate-arg clash: storage_read_csv()
+      # forwards `...` to readr, so a caller may already pass show_col_types here.
       return(suppressMessages(suppressWarnings(AzureStor::storage_read_csv(azcontainer, file_loc, ...))))
 
     } else if (endsWith(file_loc, ".rda")) {


### PR DESCRIPTION
Fixes #172.

Fresh-user output-hygiene fixes — a clean run no longer *looks* broken to a non-developer.

**1. `eri_read()` readr column-spec dump (F6).** Reading a CSV erupted with `Rows:.. -- Column specification -- ..` mid-pipeline. Now:
- local path (`R/dal.R:322`): `readr::read_csv(file_loc, show_col_types = FALSE)`
- Azure path (`R/dal.R:538`): `suppressMessages(...)` around `storage_read_csv()` (which forwards `...` to readr).

**2. Stray `NULL` from side-effecting writers (F7).** `erifunctions_io()`'s write/upload/delete/create.dir/delete.dir ops fell through to `return(NULL)`, so `eri_write()`/`eri_upload()`/`eri_dir_create()`/`eri_delete()`/`eri_dir_delete()` auto-printed `NULL` in scripts. Changed the fall-through to `return(invisible(NULL))` — one change covers all of them.

**3. Success `cli` messages render red (F8) — by design, no change.** Verified `cli::cli_alert_success()` writes to **stderr** (`Rscript -e '...' 2>/dev/null` drops it). The red is the terminal/Rscript coloring stderr, not a package defect — in interactive R / RStudio these render green. Rerouting cli to stdout would pollute data pipelines, so this is intentionally left as-is.

**Verification:** live round-trip on a throwaway Azure path confirmed no readr block and no stray `NULL`; `devtools::test()` green (**FAIL 0 | PASS 1159**).