### PR TITLE
fix: eri_catalog_query() distinguishes no-match filter from empty catalog (#173)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # erifunctions (development version)
 
+## Fix: `eri_catalog_query()` no longer says "Catalog is empty" for a no-match filter
+
+- A filtered `eri_catalog_query()` that matches nothing now reports *"No catalog entries match the
+  specified filters"* — even when the catalog itself happens to have no entries — instead of the old
+  *"Catalog is empty."*, which could make a filtered lookup look like it had wiped the shared catalog.
+  An unfiltered query on a truly empty catalog now reads *"The data catalog has no entries yet."*
+  Fixes a fresh-user red-team finding (#173).
+
 ## Fix: cleaner console output from `eri_read()` and the file-writing helpers
 
 - `eri_read()` no longer prints `readr`'s column-specification block when reading a CSV (it now reads

--- a/R/catalog.R
+++ b/R/catalog.R
@@ -208,11 +208,6 @@ eri_catalog_query <- function(
     last_verified_at = character()
   )
 
-  if (length(catalog$entries) == 0L) {
-    cli::cli_inform("Catalog is empty.")
-    return(empty_result)
-  }
-
   entries <- catalog$entries
 
   if (!is.null(country))
@@ -227,7 +222,15 @@ eri_catalog_query <- function(
     entries <- Filter(function(e) identical(e$period, period), entries)
 
   if (length(entries) == 0L) {
-    cli::cli_inform("No catalog entries match the specified filters.")
+    # Distinguish "your filter matched nothing" from "the whole catalog is empty"
+    # so a filtered query never implies the shared catalog was wiped.
+    any_filter <- !is.null(country) || !is.null(disease) ||
+      !is.null(data_type) || !is.null(layer) || !is.null(period)
+    if (any_filter) {
+      cli::cli_inform("No catalog entries match the specified filters.")
+    } else {
+      cli::cli_inform("The data catalog has no entries yet.")
+    }
     return(empty_result)
   }
 

--- a/R/catalog.R
+++ b/R/catalog.R
@@ -275,7 +275,9 @@ eri_catalog_verify <- function(data_con = NULL) {
 
   if (length(catalog$entries) == 0L) {
     cli::cli_inform("Catalog is empty -- nothing to verify.")
-    return(eri_catalog_query(data_con = data_con))
+    # Reuse the typed empty tibble from query, but suppress its own info line
+    # so verify prints a single, unambiguous message.
+    return(suppressMessages(eri_catalog_query(data_con = data_con)))
   }
 
   now <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")

--- a/tests/testthat/test-catalog.R
+++ b/tests/testthat/test-catalog.R
@@ -113,6 +113,43 @@ test_that("eri_catalog_query returns empty typed tibble when catalog is empty", 
   expect_true("last_verified_at" %in% names(out))
 })
 
+test_that("eri_catalog_query: empty catalog with no filters reports 'no entries yet'", {
+  local_mocked_bindings(
+    storage_file_exists = function(...) FALSE,
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  expect_message(eri_catalog_query(), "no entries yet")
+})
+
+test_that("eri_catalog_query: a no-match filter reports 'no match', not an empty catalog", {
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  # Empty catalog + a filter: must NOT imply the shared catalog was wiped.
+  local_mocked_bindings(
+    storage_file_exists = function(...) FALSE,
+    .package = "AzureStor"
+  )
+  expect_message(eri_catalog_query(country = "atlantis"), "match the specified filters")
+
+  # Non-empty catalog + a filter that matches nothing: same message.
+  stored <- make_catalog(make_entry(country = "uga",
+                                     path = "uga/oncho/surveillance/processed/f1.parquet"))
+  local_mocked_bindings(
+    storage_file_exists = function(...) TRUE,
+    storage_download = function(container, src, dest, ...) yaml::write_yaml(stored, dest),
+    .package = "AzureStor"
+  )
+  expect_message(eri_catalog_query(country = "atlantis"), "match the specified filters")
+})
+
 test_that("eri_catalog_query filters by country", {
   e1 <- make_entry(country = "uga", path = "uga/oncho/surveillance/processed/f1.parquet")
   e2 <- make_entry(country = "nga", disease = "lf", path = "nga/lf/surveillance/processed/f2.parquet")


### PR DESCRIPTION
Fixes #173.

Fresh-user finding: after cleaning up her sandbox, the DA ran `eri_catalog_query(country = "atlantis")` and saw **"Catalog is empty."** — which could make a fresh analyst think a *filtered* lookup had wiped the shared team catalog.

The two messages already existed, but the whole-catalog-empty check ran **before** filters were applied, so it pre-empted the no-match message whenever the catalog happened to have no entries.

**Fix:** apply the filters first, then pick the message by whether any filter was supplied:
- filtered query, no matches (catalog empty *or* not) → *"No catalog entries match the specified filters."*
- unfiltered query, empty catalog → *"The data catalog has no entries yet."*

So a filtered query never implies the catalog was wiped. Adds 3 regression tests; `test-catalog.R` green (28).