### PR TITLE
feat: dq_report() shows example offending values + pointer to result$flags (#178)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # erifunctions (development version)
 
+## Improvement: `dq_report()` shows the offending values, not just counts
+
+- The "Flags Requiring Review" section now prints up to three example offending values with their row
+  numbers for each issue — e.g. `not in allowed_values: 2 rows [species] (e.g. P.vivax (row 4);
+  P.ovale (row 2))` — with a `+N more` suffix when there are more, and a closing pointer to
+  `result$flags` for the full row-level detail. Previously it printed only a count and column, so an
+  analyst had to open `result$flags` to see *what* to fix. Fixes a fresh-user red-team finding (#178).
+
 ## Fix: `eri_catalog_query()` no longer says "Catalog is empty" for a no-match filter
 
 - A filtered `eri_catalog_query()` that matches nothing now reports *"No catalog entries match the

--- a/R/dq.R
+++ b/R/dq.R
@@ -1103,7 +1103,8 @@ dq_report <- function(result) {
         # sees *what* to fix without digging into result$flags.
         k    <- min(3L, n)
         val  <- sub$value[seq_len(k)]
-        val[is.na(val) | val == ""] <- "<NA>"
+        val[is.na(val)] <- "<NA>"
+        val[val == ""]  <- "<empty>"
         ex   <- paste0(val, " (row ", sub$row[seq_len(k)], ")", collapse = "; ")
         more <- if (n > k) paste0(", +", n - k, " more") else ""
         cli::cli_bullets(c("!" = "{issue}: {n} row{?s} [{cols}] (e.g. {ex}{more})"))

--- a/R/dq.R
+++ b/R/dq.R
@@ -1096,10 +1096,20 @@ dq_report <- function(result) {
     if (nrow(row_flags) > 0) {
       by_issue <- sort(table(row_flags$issue), decreasing = TRUE)
       for (issue in names(by_issue)) {
-        n    <- by_issue[[issue]]
-        cols <- paste(unique(row_flags$column[row_flags$issue == issue]), collapse = ", ")
-        cli::cli_bullets(c("!" = "{issue}: {n} row{?s} [{cols}]"))
+        sub  <- row_flags[row_flags$issue == issue, ]
+        n    <- nrow(sub)
+        cols <- paste(unique(sub$column), collapse = ", ")
+        # Show up to 3 offending values with their row numbers, so the analyst
+        # sees *what* to fix without digging into result$flags.
+        k    <- min(3L, n)
+        val  <- sub$value[seq_len(k)]
+        val[is.na(val) | val == ""] <- "<NA>"
+        ex   <- paste0(val, " (row ", sub$row[seq_len(k)], ")", collapse = "; ")
+        more <- if (n > k) paste0(", +", n - k, " more") else ""
+        cli::cli_bullets(c("!" = "{issue}: {n} row{?s} [{cols}] (e.g. {ex}{more})"))
       }
+      cli::cli_text("")
+      cli::cli_alert_info("See {.code result$flags} for the full row-level detail.")
     }
   }
 

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -366,3 +366,41 @@ test_that("add_anomaly_spatial skips admin2 when name_field not in schema", {
   expect_equal(call_count, 1L)
   expect_equal(nrow(out), 0L)
 })
+
+test_that("dq_report surfaces example offending values and points to result$flags", {
+  result <- list(
+    data = tibble::tibble(a = 1:10),
+    log  = tibble::tibble(row = integer(), column = character(), original_value = character(),
+                          corrected_value = character(), rule = character(), action = character()),
+    flags = tibble::tibble(
+      row    = c(4L, 2L),
+      column = c("species", "species"),
+      value  = c("P.vivax", "P.ovale"),
+      issue  = c("not in allowed_values", "not in allowed_values")
+    )
+  )
+
+  # collapse + squash whitespace so a wrapped line never splits a token
+  out <- gsub("[[:space:]]+", " ", paste(cli::cli_fmt(dq_report(result)), collapse = " "))
+
+  expect_true(grepl("P.vivax", out, fixed = TRUE))        # the offending value
+  expect_true(grepl("row 4",   out, fixed = TRUE))        # and its row number
+  expect_true(grepl("result$flags", out, fixed = TRUE))   # pointer to detail
+})
+
+test_that("dq_report truncates the example list with a '+N more' suffix", {
+  result <- list(
+    data = tibble::tibble(a = 1:10),
+    log  = tibble::tibble(row = integer(), column = character(), original_value = character(),
+                          corrected_value = character(), rule = character(), action = character()),
+    flags = tibble::tibble(
+      row    = 1:6,
+      column = rep("epiweek", 6),
+      value  = as.character(60:65),
+      issue  = rep("out of range", 6)
+    )
+  )
+
+  out <- gsub("[[:space:]]+", " ", paste(cli::cli_fmt(dq_report(result)), collapse = " "))
+  expect_true(grepl("+3 more", out, fixed = TRUE))   # 6 rows, 3 shown
+})

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -378,8 +378,10 @@ result2
 #> • "District": 1 correction (correction)
 #>
 #> ── Flags Requiring Review (2 total) ──
-#> ! Value not in allowed_values list: 1 row [District]
-#> ! Value outside expected range [0, 120]: 1 row [Age]
+#> ! Value not in allowed_values list: 1 row [District] (e.g. Atlantica (row 2))
+#> ! Value outside expected range [0, 120]: 1 row [Age] (e.g. 250 (row 3))
+#>
+#> ℹ See `result$flags` for the full row-level detail.
 ```
 
 This time there are **two flags**. The schema fixed what it safely could, but it will not guess about

--- a/vignettes/epi-dq-guide.Rmd
+++ b/vignettes/epi-dq-guide.Rmd
@@ -95,7 +95,9 @@ result
 #> ✔ No corrections applied.
 #>
 #> ── Flags Requiring Review (1 total) ──
-#> ! Value not in allowed_values list: 1 row [species]
+#> ! Value not in allowed_values list: 1 row [species] (e.g. P.vivax (row 4))
+#>
+#> ℹ See `result$flags` for the full row-level detail.
 ```
 
 One flag — a mistyped species. Useful, but it tells you nothing about whether the *epidemiology* makes


### PR DESCRIPTION
Fixes #178.

Fresh-user (Epi) finding: `dq_report()` printed `1 row [species]` — no value, no row, no hint where the detail lived — so the reflex was to `filter()` the data by hand.

Now each issue in "Flags Requiring Review" shows up to **three offending values with their row numbers**, a `+N more` suffix when truncated, and a closing pointer:

```
! out of range: 3 rows [epiweek] (e.g. 99 (row 7); 100 (row 9); 53 (row 3))
! not in allowed_values: 2 rows [species] (e.g. P.vivax (row 4); P.ovale (row 2))

ℹ See `result$flags` for the full row-level detail.
```

`$flags` always carries `row, column, value, issue` (`.dq_log_flag`), so the values are always available. Adds 2 tests (example values + pointer; `+N more` truncation) via `cli::cli_fmt()`. `test-dq.R` green (60). No `#>` output in the vignettes needed updating.