### PR TITLE
fix: load_dq_schema lists valid keys on miss; sync README research reference (#176)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # erifunctions (development version)
 
+## Fix: friendlier schema discovery and an accurate research-function reference
+
+- `load_dq_schema()` now **lists the available bundled schema keys** when it cannot find the one you
+  asked for — so `load_dq_schema("dr", "malaria")` points you to `dr_malaria_case` instead of a bare
+  "No schema found." error.
+- The README's research-projects reference now includes `eri_research_scaffold()`,
+  `eri_research_status()`, and `eri_research_tag()` (previously omitted) and clarifies
+  `eri_research_scaffold()` (a new standalone project *repository*, ADR-0006) vs `eri_research_init()`
+  (initialise a project in the current directory).
+- The DQ guide names the `disease` argument in `load_dq_schema()` examples and notes that the schema
+  key (e.g. `malaria_case`) is distinct from the layer-path `data_type`. Fresh-user findings (#176).
+  (The deeper `data_type`-vs-schema-key vocabulary unification is tracked in #175.)
+
 ## Improvement: `dq_report()` shows the offending values, not just counts
 
 - The "Flags Requiring Review" section now prints up to three example offending values with their row

--- a/R/dq.R
+++ b/R/dq.R
@@ -934,10 +934,15 @@ add_anomaly_spatial <- function(data, schema, azcontainer = NULL) {
 #' in the `data` Azure container (or in `inst/schemas/` locally).
 #' The container name is read from `ERIFUNCTIONS_DATA_STORAGE_NAME` (default `"data"`).
 #'
+#' `country` and `disease` are simply the two halves of that filename stem. The
+#' bundled set currently mixes conventions (e.g. `dr_malaria_case`,
+#' `dominican_republic_malaria`, `ht_lf_tas`), so when a name is not found the
+#' error lists every available bundled schema to copy from.
+#'
 #' @param country `str` Country identifier matching the schema filename prefix
-#'   (e.g., `"dominican_republic"`, `"haiti"`).
-#' @param disease `str` Disease name matching the schema filename suffix
-#'   (e.g., `"malaria"`).
+#'   (e.g., `"dr"`, `"dominican_republic"`, `"haiti"`).
+#' @param disease `str` Disease/schema key matching the schema filename suffix
+#'   (e.g., `"malaria_case"`, `"lf_tas"`).
 #' @param azcontainer Azure container object from [get_azure_storage_connection()].
 #'   Defaults to the `data` container via `ERIFUNCTIONS_DATA_STORAGE_NAME`.
 #'   Pass `NULL` to use only the locally bundled schema files.
@@ -976,7 +981,11 @@ load_dq_schema <- function(
   local_path <- system.file(schema_path, package = "erifunctions")
   if (!nzchar(local_path)) {
     schema_dir <- system.file("schemas", package = "erifunctions")
-    available  <- sort(sub("\\.ya?ml$", "", list.files(schema_dir, pattern = "\\.ya?ml$")))
+    available  <- if (nzchar(schema_dir)) {
+      sort(sub("\\.ya?ml$", "", list.files(schema_dir, pattern = "\\.ya?ml$")))
+    } else {
+      character()
+    }
     msg <- c(
       "No schema found for {.val {country}}/{.val {disease}}.",
       "i" = "Looked for a bundled schema named {.file {basename(schema_path)}}."

--- a/R/dq.R
+++ b/R/dq.R
@@ -975,7 +975,20 @@ load_dq_schema <- function(
 
   local_path <- system.file(schema_path, package = "erifunctions")
   if (!nzchar(local_path)) {
-    cli::cli_abort("No schema found for {.val {country}}/{.val {disease}}.")
+    schema_dir <- system.file("schemas", package = "erifunctions")
+    available  <- sort(sub("\\.ya?ml$", "", list.files(schema_dir, pattern = "\\.ya?ml$")))
+    msg <- c(
+      "No schema found for {.val {country}}/{.val {disease}}.",
+      "i" = "Looked for a bundled schema named {.file {basename(schema_path)}}."
+    )
+    if (length(available)) {
+      msg <- c(msg, "i" = paste(
+        "Available bundled schemas: {.val {available}}.",
+        "Pass the {.arg country}/{.arg disease} that make up one",
+        "(e.g. {.code load_dq_schema(\"dr\", \"malaria_case\")})."
+      ))
+    }
+    cli::cli_abort(msg)
   }
   yaml::read_yaml(local_path)
 }

--- a/README.md
+++ b/README.md
@@ -227,14 +227,21 @@ eri_catalog_verify()
 
 | Function | What it does |
 |---|---|
-| `eri_research_init(project_name, country, disease, description)` | Scaffold a new research project locally and in Azure |
+| `eri_research_scaffold(name, country, disease, description)` | Create a **standalone research-project repository** (ADR-0006) at `dest/name/` — a full repo skeleton that depends on erifunctions |
+| `eri_research_init(project_name, country, disease, description)` | Initialise a research project **in the current directory** (local `data/`/`figs/`/`outputs/` + `research.yaml`, registered in Azure) |
 | `eri_research_resume()` | Re-read `research.yaml` and print session summary |
+| `eri_research_status(check_remote)` | Report what data the project depends on and whether any of it is stale |
 | `eri_research_log(note)` | Append a timestamped lab notebook entry to `research.yaml` |
 | `eri_research_list()` | List all research projects in Azure |
 | `eri_research_pull(country, disease, data_type)` | Pull canonical or reference data into the project with provenance |
 | `eri_research_upload_figure(local_path, caption)` | Upload a figure to Azure outputs and record in manifest |
 | `eri_research_upload_output(obj, filename)` | Serialize and upload an R object to Azure outputs |
 | `eri_research_snapshot(label)` | Freeze the local `data/` directory to a timestamped Azure snapshot |
+| `eri_research_tag(label, description)` | Freeze a reproducible, citable version of the project (tag + optional snapshot) |
+
+`eri_research_scaffold()` vs `eri_research_init()`: **scaffold** stands up a new, separate project
+*repository* (the ADR-0006 way — its own git repo); **init** initialises a project in a directory you
+are already in. Most new studies start with `eri_research_scaffold()`.
 
 ### Template management
 

--- a/man/load_dq_schema.Rd
+++ b/man/load_dq_schema.Rd
@@ -13,10 +13,10 @@ load_dq_schema(
 }
 \arguments{
 \item{country}{\code{str} Country identifier matching the schema filename prefix
-(e.g., \code{"dominican_republic"}, \code{"haiti"}).}
+(e.g., \code{"dr"}, \code{"dominican_republic"}, \code{"haiti"}).}
 
-\item{disease}{\code{str} Disease name matching the schema filename suffix
-(e.g., \code{"malaria"}).}
+\item{disease}{\code{str} Disease/schema key matching the schema filename suffix
+(e.g., \code{"malaria_case"}, \code{"lf_tas"}).}
 
 \item{azcontainer}{Azure container object from \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}.
 Defaults to the \code{data} container via \code{ERIFUNCTIONS_DATA_STORAGE_NAME}.
@@ -33,6 +33,11 @@ falls back to the schema bundled with the package.
 Schema files are YAML documents stored at \verb{schemas/<country>_<disease>.yaml}
 in the \code{data} Azure container (or in \verb{inst/schemas/} locally).
 The container name is read from \code{ERIFUNCTIONS_DATA_STORAGE_NAME} (default \code{"data"}).
+
+\code{country} and \code{disease} are simply the two halves of that filename stem. The
+bundled set currently mixes conventions (e.g. \code{dr_malaria_case},
+\code{dominican_republic_malaria}, \code{ht_lf_tas}), so when a name is not found the
+error lists every available bundled schema to copy from.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -404,3 +404,15 @@ test_that("dq_report truncates the example list with a '+N more' suffix", {
   out <- gsub("[[:space:]]+", " ", paste(cli::cli_fmt(dq_report(result)), collapse = " "))
   expect_true(grepl("+3 more", out, fixed = TRUE))   # 6 rows, 3 shown
 })
+
+test_that("load_dq_schema error enumerates available bundled schemas", {
+  expect_error(
+    load_dq_schema("dr", "nonexistent_disease", azcontainer = NULL),
+    "Available bundled schemas"
+  )
+  # the helpful list includes the real key the user is probably after
+  expect_error(
+    load_dq_schema("dr", "nonexistent_disease", azcontainer = NULL),
+    "dr_malaria_case"
+  )
+})

--- a/vignettes/epi-dq-guide.Rmd
+++ b/vignettes/epi-dq-guide.Rmd
@@ -59,7 +59,10 @@ case. It has three planted problems — a species typo, a **case spike**, and a 
 kinds of thing a real extract hides:
 
 ```{r extract}
-schema <- load_dq_schema("dr", "malaria_case", azcontainer = NULL)
+# The `disease` argument is the *schema key* (here "malaria_case", the case-level
+# malaria schema) — more specific than the "malaria" program in the country table,
+# and separate from the layer-path data_type (surveillance/cmr/odk).
+schema <- load_dq_schema("dr", disease = "malaria_case", azcontainer = NULL)
 
 # A tiny helper to make `n` identical case rows for a province/week.
 mk <- function(province, week, n, species = "P. vivax") {


### PR DESCRIPTION
Addresses #176 (the design-free parts; the deeper vocabulary unification stays in #175).

Fresh-user (Epi) findings about README/doc vocabulary drift:

**1. `load_dq_schema()` "No schema found" now enumerates valid keys (F5, code).** Typing the README's program name (`load_dq_schema("dr","malaria")`) failed with a bare error; the real key is `malaria_case`. Now:
```
No schema found for "dr"/"malaria".
ℹ Looked for a bundled schema named 'dr_malaria.yaml'.
ℹ Available bundled schemas: "dominican_republic_malaria", "dr_lf_mda", "dr_lf_tas",
  "dr_malaria_case", "haiti_malaria", ... Pass the `country`/`disease` that make up
  one (e.g. `load_dq_schema("dr", "malaria_case")`).
```

**2. README research-projects reference synced (F10, doc).** Added the three exported-but-undocumented functions — `eri_research_scaffold()`, `eri_research_status()`, `eri_research_tag()` — and a note clarifying `scaffold` (a new **standalone project repository**, ADR-0006) vs `init` (initialise in the current directory).

**3. DQ guide names the `disease` arg (F11, doc).** `load_dq_schema("dr", disease = "malaria_case", ...)` plus a one-line clarification that the schema key is distinct from the layer-path `data_type`.

**Deferred to #175:** the program-name↔schema-key reconciliation (e.g. should `load_dq_schema` accept `malaria`? why do `dr_malaria_case.yaml` and `dominican_republic_malaria.yaml` both exist?) and the `data_type` crosswalk are a vocabulary *design* decision, tracked there.

Adds a regression test; `test-dq.R` green (62). Guide knits clean.