### PR TITLE
docs: flag non-sandboxable / web-only steps; note eri_list full_names (#177)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # erifunctions (development version)
 
+## Docs: flag the steps you can't rehearse on a sandbox
+
+- The ODK guide now says up front that creating the project, uploading the form, and submitting
+  practice entries happen in the ODK Central **web interface**, not in R.
+- The CMR guide spells out that there is **no throwaway-sandbox path** for `eri_stage_cmr()` /
+  approve (they require a registered RB-expansion country); only the parsing step is hands-on.
+- The connections guide notes that `eri_list()`'s `name` column holds the **full path** and that
+  `full_names = FALSE` returns just the leaf filenames. Fresh-user findings (#177).
+
 ## Fix: friendlier schema discovery and an accurate research-function reference
 
 - `load_dq_schema()` now **lists the available bundled schema keys** when it cannot find the one you

--- a/vignettes/connections-guide.Rmd
+++ b/vignettes/connections-guide.Rmd
@@ -79,6 +79,10 @@ eri_list("", azcontainer = data_con)
 #> …
 ```
 
+The `name` column holds the **full path** from the container root (so a deeper listing like
+`eri_list("uga/demo/odk/raw", …)` returns `uga/demo/odk/raw/<file>` names); pass `full_names = FALSE`
+for just the leaf filenames.
+
 > **For automation / CI (headless).** A scheduled job has no browser. Set a **service principal** —
 > `ERIFUNCTIONS_SP_CLIENT_ID` and `ERIFUNCTIONS_SP_CLIENT_SECRET` in the environment (or pass
 > `creds_yaml_path=`) — and `get_azure_storage_connection()` signs in non-interactively instead. The

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -53,8 +53,10 @@ library(erifunctions)
 
 > **A note on the examples below.** The upload, stage, and approve steps run against the live Azure
 > `projects`/`data` blobs and real, registered countries — so the outputs for those are shown as
-> illustrations rather than run here. The **parsing** step is run for real on a small **synthetic**
-> example report that ships with the package, so its output is exactly what you'll see.
+> illustrations rather than run here. Unlike the surveillance and ODK guides, there is **no
+> throwaway-sandbox path** for stage/approve: `eri_stage_cmr()` only accepts a registered RB-expansion
+> country (it rejects a made-up one). The **parsing** step *is* run for real on a small **synthetic**
+> example report that ships with the package, so that output is exactly what you'll see.
 
 ## 1. Where the report comes in {#arrives}
 

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -79,6 +79,10 @@ library(erifunctions)
 
 ## 1. Begin — create your practice form {#begin}
 
+> **Heads up — this first step happens in your browser, not in R.** Creating the `test` project,
+> uploading the form, and submitting practice entries are all done in the ODK Central **web
+> interface**. `erifunctions` takes over from *Connect* (below) once there is data on the server.
+
 ### Put a form on the server
 
 The package ships a tiny practice form — a mock vector-surveillance "river prospection" survey. Find


### PR DESCRIPTION
Fixes #177.

Fresh-user (DA) findings that fresh users hit steps they can't rehearse, with no heads-up:

- **ODK guide** — added an up-front callout that creating the `test` project, uploading the form, and submitting practice entries all happen in the **ODK Central web interface**, not in R; `erifunctions` takes over from *Connect*.
- **CMR guide** — strengthened the existing note to say explicitly there is **no throwaway-sandbox path** for `eri_stage_cmr()` / approve (they require a registered RB-expansion country); only the parsing step is hands-on.
- **Connections guide** — noted that `eri_list()`'s `name` column holds the **full path** from the container root, and `full_names = FALSE` returns just the leaf filenames (verified against `R/dal.R:260-263`).

Doc-only; all three vignettes knit-parse clean.