### PR TITLE
feat: eri_spatial_reconcile() returns geocoded admin units for review (#174)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # erifunctions (development version)
 
+## Improvement: `eri_spatial_reconcile()` surfaces the geocoded admin unit for review
+
+- The function now returns one `geocoded_<admin_col>` column per admin level, holding the admin units
+  the geocoded point fell into (point-in-polygon). They are filled for every geocoded row that landed
+  inside a polygon — **including `geocoded_review` rows** — so a flagged row shows *exactly* what its
+  geocoded location disagreed with, and you can resolve it without re-running a spatial join by hand.
+  (`NA` for `matched`, `unresolved`, and outside-polygon rows.) Fixes a fresh-user red-team finding
+  (#174).
+
 ## Improvement: a one-time warning when `ERI_ANALYST_ID` is unset
 
 - Governed actions (approve, ingest, ODK sync, catalog/registry writes, research operations, log

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -610,7 +610,13 @@ eri_spatial_join <- function(data, lat_col, lon_col, shapefile, admin_cols = NUL
 #' @param ... Passed to [tidygeocoder::geocode()] (e.g. `min_time`, `api_options`).
 #' @returns A tibble: `data` with `loc_cols` replaced by their canonical values
 #'   where confidently reconciled (originals kept where unresolved or flagged
-#'   `"geocoded_review"`), plus the two `coord_cols` and `status_col`.
+#'   `"geocoded_review"`), plus the two `coord_cols`, the `status_col`, and one
+#'   `geocoded_<admin_col>` column per `admin_cols` level. The `geocoded_*` columns
+#'   hold the admin units the geocoded point fell into (point-in-polygon), filled
+#'   for every geocoded row that landed inside a polygon -- including
+#'   `"geocoded_review"` rows -- so you can see *what* a flagged row disagreed with
+#'   (and resolve it) without re-running the spatial join yourself. They are `NA`
+#'   for string-matched, unresolved, and outside-polygon rows.
 #' @examples
 #' \dontrun{
 #' dr_loc <- eri_spatial_load("dr", level = 4, cache = TRUE)
@@ -663,7 +669,11 @@ eri_spatial_reconcile <- function(data,
   if (length(coord_cols) != 2L) {
     cli::cli_abort("{.arg coord_cols} must be a length-2 character vector (longitude, latitude).")
   }
-  reserved <- c(coord_cols, status_col)
+  # Geocoded point-in-polygon admin units are returned in their own columns so the
+  # analyst can see where a geocode landed without the trust guard overwriting the
+  # names they supplied.
+  geocoded_cols <- paste0("geocoded_", admin_cols)
+  reserved <- c(coord_cols, status_col, geocoded_cols)
   clash    <- intersect(reserved, names(data))
   if (length(clash) > 0L) {
     cli::cli_abort(c(
@@ -709,6 +719,9 @@ eri_spatial_reconcile <- function(data,
   res$.lat     <- NA_real_
   res$.status  <- NA_character_
   res$.partial <- NA
+  # Where the geocoded point actually fell (point-in-polygon), per admin level.
+  geo_out <- paste0(".geo_", admin_cols)
+  for (k in seq_len(n_lvl)) res[[geo_out[k]]] <- NA_character_
 
   matched <- !is.na(match_idx)
   for (k in seq_len(n_lvl)) {
@@ -765,6 +778,13 @@ eri_spatial_reconcile <- function(data,
           jrow <- ord[i]
           if (is.na(jrow) || is.na(jr[[admin_cols[1L]]][jrow])) next  # outside all polygons
 
+          # Record where the geocoded point landed (all admin levels) for every
+          # polygon hit -- trusted *and* flagged -- so a geocoded_review row can be
+          # inspected without re-running the point-in-polygon by hand.
+          for (k in seq_len(n_lvl)) {
+            res[[geo_out[k]]][rk] <- as.character(jr[[admin_cols[k]]][jrow])
+          }
+
           # Any coarser level disagreeing with the analyst's claim flags the row.
           consistent <- TRUE
           if (n_lvl > 1L) {
@@ -801,7 +821,8 @@ eri_spatial_reconcile <- function(data,
   out[[coord_cols[1L]]] <- out$.lon
   out[[coord_cols[2L]]] <- out$.lat
   out[[status_col]]     <- out$.status
-  out <- out[, setdiff(names(out), c(canon_out, ".lon", ".lat", ".status", ".partial")), drop = FALSE]
+  for (k in seq_len(n_lvl)) out[[geocoded_cols[k]]] <- out[[geo_out[k]]]
+  out <- out[, setdiff(names(out), c(canon_out, geo_out, ".lon", ".lat", ".status", ".partial")), drop = FALSE]
 
   n_keys <- nrow(keys)
   n_m    <- sum(res$.status == "matched")

--- a/man/eri_spatial_reconcile.Rd
+++ b/man/eri_spatial_reconcile.Rd
@@ -55,7 +55,13 @@ that fall outside every polygon still record their coordinates).}
 \value{
 A tibble: \code{data} with \code{loc_cols} replaced by their canonical values
 where confidently reconciled (originals kept where unresolved or flagged
-\code{"geocoded_review"}), plus the two \code{coord_cols} and \code{status_col}.
+\code{"geocoded_review"}), plus the two \code{coord_cols}, the \code{status_col}, and one
+\verb{geocoded_<admin_col>} column per \code{admin_cols} level. The \verb{geocoded_*} columns
+hold the admin units the geocoded point fell into (point-in-polygon), filled
+for every geocoded row that landed inside a polygon -- including
+\code{"geocoded_review"} rows -- so you can see \emph{what} a flagged row disagreed with
+(and resolve it) without re-running the spatial join yourself. They are \code{NA}
+for string-matched, unresolved, and outside-polygon rows.
 }
 \description{
 A thin, opt-in \strong{data-sourcing} helper that maps messy, free-text locality

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -513,6 +513,8 @@ test_that("eri_spatial_reconcile matches exactly without geocoding", {
   expect_equal(out$loc, "Jínova")           # replaced in place with canonical
   expect_equal(out$cases, 3L)               # untouched columns preserved
   expect_true(all(is.na(c(out$longitude, out$latitude))))
+  # string-matched rows were never geocoded, so the geocoded_* columns are NA
+  expect_true(all(is.na(c(out$geocoded_adm4_name, out$geocoded_adm3_name, out$geocoded_adm2_name))))
 })
 
 test_that("eri_spatial_reconcile scopes matching by coarser levels", {
@@ -552,6 +554,7 @@ test_that("eri_spatial_reconcile geocodes the unmatched and assigns admin units"
   expect_equal(out$loc, "Jínova")           # assigned by point-in-polygon
   expect_equal(out$longitude, 0.5)
   expect_equal(out$latitude, 0.5)
+  expect_equal(out$geocoded_adm4_name, "Jínova")   # also surfaced explicitly
 })
 
 test_that("eri_spatial_reconcile marks geocoded-but-outside points unresolved", {
@@ -611,6 +614,10 @@ test_that("eri_spatial_reconcile flags a parent-inconsistent geocode for review"
   out <- eri_spatial_reconcile(df, recon_cols$loc_cols, recon_shp(), recon_cols$admin_cols)
   expect_equal(out$reconcile_status, "geocoded_review")
   expect_equal(out$mun, "San Juan")    # claimed parent kept, not overwritten
+  # ...but the geocoder's opinion is now surfaced so the review is actionable:
+  expect_equal(out$geocoded_adm4_name, "Jínova")
+  expect_equal(out$geocoded_adm3_name, "Juan de Herrera")  # the disagreeing unit
+  expect_equal(out$geocoded_adm2_name, "San Juan")
 })
 
 test_that("eri_spatial_reconcile resolves a boundary point to a single row", {

--- a/vignettes/epi-reconcile-guide.Rmd
+++ b/vignettes/epi-reconcile-guide.Rmd
@@ -165,13 +165,31 @@ Three different outcomes for the three residual rows:
 - **`Zzqxborough Nowhere` → `unresolved`.** The geocoder returned nothing. No coordinates, nothing
   changed.
 
+You don't have to take "Cambridge/Middlesex" on faith. `eri_spatial_reconcile()` returns the admin
+units the geocoded point actually fell into as `geocoded_<admin_col>` columns — so a flagged row tells
+you *exactly* what it disagreed with, with no manual `sf::st_join()` to re-derive it:
+
+```{r inspect-review}
+result[result$reconcile_status == "geocoded_review",
+       c("locality", "county", "geocoded_adm3_name", "geocoded_adm2_name")]
+#> # A tibble: 1 × 4
+#>   locality county  geocoded_adm3_name geocoded_adm2_name
+#>   <chr>    <chr>   <chr>              <chr>
+#> 1 MIT      Suffolk Cambridge          Middlesex
+```
+
+Your `county` is still **Suffolk** (untouched — the trust guard never overwrote it), but
+`geocoded_adm2_name` shows the point landed in **Middlesex**. That side-by-side is the whole conflict,
+ready for you to confirm or fix. (These columns are `NA` for `matched`, `unresolved`, and
+outside-polygon rows.)
+
 ## 4. What the statuses mean — and what to do {#statuses}
 
 | `reconcile_status` | What happened | What you do |
 |---|---|---|
 | `matched` | Name matched the boundary (offline) | Trust it — canonical name assigned |
 | `geocoded` | Geocoded **and** the admin parents agree with your data | Trust it — canonical name + coordinates assigned |
-| `geocoded_review` | Geocoded, but the assigned admin unit **disagrees** with your claim (or the service flagged low confidence) | **Inspect.** Coordinates kept; names left untouched. Confirm or fix before using |
+| `geocoded_review` | Geocoded, but the assigned admin unit **disagrees** with your claim (or the service flagged low confidence) | **Inspect** the `geocoded_*` columns to see what it disagreed with. Coordinates kept; names left untouched. Confirm or fix before using |
 | `unresolved` | No match, and either no geocode result **or** a point that fell outside every boundary (such rows may still carry coordinates) | Chase the source, or exclude with a note |
 
 The golden habit: **`matched` and `geocoded` are safe to roll up; `geocoded_review` and `unresolved`


### PR DESCRIPTION
Fixes #174.

Fresh-user (Epi) top finding: a `geocoded_review` row returned `longitude`/`latitude`/`reconcile_status` but **not the admin unit the geocoded point fell into** — even though the trust guard computes exactly that (point-in-polygon) to decide the status. So resolving a flag meant taking the coords and running your own `sf::st_join()` — the bail-to-sf the package aims to prevent.

**Fix:** `eri_spatial_reconcile()` now returns one `geocoded_<admin_col>` column per `admin_cols` level, holding the point-in-polygon admin assignment. Filled for **every** geocoded row that landed inside a polygon — trusted *and* `geocoded_review` — so a flagged row is self-explanatory:

```
locality county  geocoded_adm3_name geocoded_adm2_name
MIT      Suffolk Cambridge          Middlesex
```

Your `county` stays **Suffolk** (the trust guard never overwrites it), but `geocoded_adm2_name = Middlesex` is the conflict, ready to confirm or fix. `NA` for `matched`, `unresolved`, and outside-polygon rows. The new columns are added to the reserved-name clash check.

**Verification:** extended the existing `geocoded_review`/`geocoded`/`matched` tests to assert the new columns (e.g. the parent-inconsistent row now surfaces `geocoded_adm3_name = "Juan de Herrera"`); `document()` + full `devtools::test()` green (**FAIL 0 | PASS 1179**). Updated `epi-reconcile-guide.Rmd` with an inspection chunk + status-table note; guide knits clean.