### PR TITLE
docs: clarify data/schema vocabulary; ADR-0011 plans unified naming (#175 phase 1)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # erifunctions (development version)
 
+## Docs: one vocabulary for addressing data and schemas
+
+- A new README section ("How data is addressed") names the four path axes — `country` / `disease` /
+  `data_type` / `layer` — and clarifies that a DQ **schema key** (e.g. `malaria_case`, passed to
+  `load_dq_schema()`) is *not* a `data_type`. `eri_data_path()`'s error now says so explicitly when a
+  schema key is passed where a `data_type` belongs. This is Phase 1 of
+  [ADR-0011](docs/adr/0011-unified-schema-naming.md); the bundled schema names will be unified to one
+  convention in a follow-up (#175). Fixes the user-facing half of a fresh-user red-team finding.
+
 ## Improvement: `eri_spatial_reconcile()` surfaces the geocoded admin unit for review
 
 - The function now returns one `geocoded_<admin_col>` column per admin level, holding the admin units

--- a/R/dal.R
+++ b/R/dal.R
@@ -840,9 +840,10 @@ eri_data_path <- function(country, disease, data_type, layer, filename = NULL) {
   valid_layers <- c("raw", "staged", "processed")
 
   if (!data_type %in% valid_types) {
-    cli::cli_abort(
-      "{.arg data_type} must be one of {.val {valid_types}}, not {.val {data_type}}."
-    )
+    cli::cli_abort(c(
+      "{.arg data_type} must be one of {.val {valid_types}}, not {.val {data_type}}.",
+      "i" = "{.arg data_type} is the storage-layer category (how the data arrives), not a DQ schema key like {.val malaria_case}. The program goes in {.arg disease} (e.g. {.val malaria})."
+    ))
   }
   if (!layer %in% valid_layers) {
     cli::cli_abort(

--- a/README.md
+++ b/README.md
@@ -121,6 +121,33 @@ data/{country}/{disease}/{data_type}/{layer}/
 
 `eri_approve()` is the explicit human gate. Nothing reaches `processed/` without it.
 
+### How data is addressed (vocabulary)
+
+A path has **four independent parts**, and it helps to keep them straight:
+
+| Part | What it is | Examples |
+|---|---|---|
+| `country` | the country | `dr`, `ht`, `uga` |
+| `disease` | the program | `malaria`, `lf`, `oncho` |
+| `data_type` | **how the data arrives / its storage category** | `surveillance`, `cmr`, `odk` |
+| `layer` | pipeline stage | `raw`, `staged`, `processed` |
+
+A common stumble: **a DQ schema key is _not_ the `data_type`.** `load_dq_schema(country, disease)`
+takes a **schema key** in its `disease` slot — e.g. `"malaria_case"` — which is finer-grained than the
+program. So the case-level malaria schema validates data stored at `dr/malaria/**surveillance**/…`:
+
+```r
+schema <- load_dq_schema("dr", "malaria_case")                    # a schema key
+path   <- eri_data_path("dr", "malaria", "surveillance", "processed")  # data_type = surveillance
+#>        "dr/malaria/surveillance/processed"
+```
+
+> **Heads up:** the bundled schema-key names are currently inconsistent (some prefixed by country
+> code, some by full country name, some carrying survey-type suffixes like `_case`/`_mda`/`_tas`).
+> A unified naming convention is planned — see
+> [ADR-0011](docs/adr/0011-unified-schema-naming.md). Until then, if `load_dq_schema()` can't find a
+> key it lists every available one to copy from.
+
 ### Data catalog
 
 Every file promoted by `eri_approve()` is automatically registered in `_catalog/data_catalog.yaml`. Query it to see what data exists on the system:

--- a/docs/adr/0011-unified-schema-naming.md
+++ b/docs/adr/0011-unified-schema-naming.md
@@ -63,9 +63,10 @@ The detailed key list and the exact `load_dq_schema()` signature (keep two-arg v
 ## Consequences
 
 - **Easier:** one mental model — `country / disease / data_type / layer` for paths, and a predictable
-  `{code}_{disease}[_{variant}]` schema key that *declares* its `data_type`. A fresh analyst can go
-  from a QC'd extract to its approved location without insider knowledge, which is the exact gap that
-  motivated this ADR.
+  schema **filename** `{country_code}_{disease}[_{variant}].yaml` (the country code comes from the
+  separate `country` argument; the key slot is `{disease}[_{variant}]`) whose contents *declare* their
+  `data_type`. A fresh analyst can go from a QC'd extract to its approved location without insider
+  knowledge, which is the exact gap that motivated this ADR.
 - **Harder / accepted:** Phase 2 is a breaking rename of bundled assets. We accept a one-release
   deprecation window and the churn of updating guides + the two internal callers. Doing it now (little
   real data, two callers) is deliberately cheaper than doing it later.

--- a/docs/adr/0011-unified-schema-naming.md
+++ b/docs/adr/0011-unified-schema-naming.md
@@ -1,0 +1,83 @@
+# ADR-0011 — One vocabulary for addressing data and schemas
+
+- **Status:** Accepted (phased — interim docs shipped; rename to follow)
+- **Date:** 2026-06-27
+
+## Context
+
+A fresh-user red-team run (the Epidemiologist persona) got stuck going from "I quality-checked a
+`malaria_case` extract" to "now pull the approved version for analysis." The root cause is **vocabulary
+drift across three independent axes that share words**:
+
+- `eri_data_path(country, disease, data_type, layer)` builds `{country}/{disease}/{data_type}/{layer}`,
+  where `data_type ∈ {surveillance, cmr, odk}` is the *storage-layer category* and `disease` is the
+  *program* (`malaria`). (`R/dal.R:838`)
+- `load_dq_schema(country, disease)` takes a **schema key** in its `disease` slot — e.g.
+  `"malaria_case"` — which is finer-grained than the program and is **not** a `data_type`.
+  (`R/dq.R`)
+
+So `eri_data_path("dr", "malaria", "malaria_case", …)` errors (`malaria_case` is not a `data_type`),
+and there is no documented or machine-readable link saying "the `malaria_case` schema validates
+`dr/malaria/surveillance/…`."
+
+The bundled schema files make this worse by mixing **four** naming conventions at once
+(`inst/schemas/`):
+
+- country **code** prefixes — `dr_malaria_case.yaml`, `ht_lf_tas.yaml`, `ug_rb_mda.yaml`;
+- **full country name** prefixes — `dominican_republic_malaria.yaml`, `haiti_malaria.yaml`
+  (so `load_dq_schema("dr", "malaria")` fails but `load_dq_schema("haiti", "malaria")` works);
+- **disease in the country slot** — `schisto_mda.yaml`, `sth_prevalence.yaml` (no country at all);
+- survey-type **suffixes** — `_case`, `_mda`, `_tas`, `_prevalence` — that are a fourth concept
+  again (the validation variant), distinct from both `disease` and `data_type`.
+
+Only `R/dal.R` and `R/dq.R` call `load_dq_schema()` internally, and the system holds very little real
+`processed/` data yet, so the cost of fixing this is near its lifetime minimum **now**.
+
+## Decision
+
+Adopt **one consistent vocabulary** for addressing both data and schemas, in two phases.
+
+**Phase 1 — clarity, no behavior change (shipped with this ADR).**
+- Document the four path axes and the separate schema-key concept (README "How data is addressed").
+- `eri_data_path()`'s error now states that `data_type` is the storage-layer category, not a schema
+  key, and that the program belongs in `disease`.
+- `load_dq_schema()` already lists every available schema key when one is not found (ADR-precursor
+  work, #176).
+
+**Phase 2 — the unified convention (planned; tracked by #175).**
+1. **Country is always the ERI country code** (`dr`, `ht`, `uga`, …) — retire full-name files and the
+   disease-in-country-slot files; dedup the resulting collisions (e.g. `dominican_republic_malaria` and
+   `dr_malaria_case` reconcile to one canonical schema).
+2. **Schema keys follow one pattern** — `{disease}[_{variant}]` (variant ∈ `case`/`mda`/`tas`/
+   `prevalence`/…) — so a key is always "program, optionally narrowed to a survey type."
+3. **Each schema declares what it validates** via a machine-readable `data_type:` (and `disease:`)
+   field in its YAML, so the schema↔`data_type` link is real, not folklore. A small accessor exposes
+   it, letting tooling bridge a schema to its `eri_data_path()` location automatically.
+4. **Deprecation, not breakage:** old filenames keep working for one release via thin shims that load
+   the renamed file and emit a one-time deprecation warning; the guides and any internal callers move
+   to the new keys in the same cycle.
+
+The detailed key list and the exact `load_dq_schema()` signature (keep two-arg vs. add an explicit
+`variant`/`data_type` arg) are settled at implementation time, against this ADR.
+
+## Consequences
+
+- **Easier:** one mental model — `country / disease / data_type / layer` for paths, and a predictable
+  `{code}_{disease}[_{variant}]` schema key that *declares* its `data_type`. A fresh analyst can go
+  from a QC'd extract to its approved location without insider knowledge, which is the exact gap that
+  motivated this ADR.
+- **Harder / accepted:** Phase 2 is a breaking rename of bundled assets. We accept a one-release
+  deprecation window and the churn of updating guides + the two internal callers. Doing it now (little
+  real data, two callers) is deliberately cheaper than doing it later.
+- **Not doing:** collapsing `data_type` and the schema variant into a single field — they are genuinely
+  different (`surveillance` is *how data arrives*; `case` is *which validation applies*). The unified
+  convention keeps them distinct but consistently named, and links them with the new `data_type:`
+  field rather than overloading one token.
+
+## References
+
+- #175 — the umbrella issue (Phase 2 migration tracker).
+- #176 — `load_dq_schema()` now enumerates valid keys (Phase 1 discoverability precursor).
+- CLAUDE.md "Core model" and "Guardrail: global vs local" — this is the canonical "solve the general
+  problem and record the decision" case.
+- `docs/roadmap.md` — Phase 5 DA-breadth / onboarding work consumes this vocabulary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0008](0008-baked-azure-auth-defaults.md) | Baked-in Azure auth defaults; interactive AAD as the zero-config default | Accepted |
 | [0009](0009-research-data-lifecycle.md) | Research-data lifecycle: Azure is the source, the project is the versioned working copy | Accepted |
 | [0010](0010-odk-repeat-group-tables.md) | ODK repeat groups land as a relational set of tables, approved together | Accepted |
+| [0011](0011-unified-schema-naming.md) | One vocabulary for addressing data and schemas (unified schema naming) | Accepted (phased) |


### PR DESCRIPTION
Phase 1 of **#175** (the umbrella issue stays open to track the Phase 2 rename).

Fresh-user (Epi) finding: three axes share words, so going from a QC'd `malaria_case` extract to its approved location dead-ends. `eri_data_path("dr","malaria","malaria_case",…)` errors because `malaria_case` is a **schema key**, not a `data_type`, and nothing documented the link.

**This PR (Phase 1 — clarity, no behavior change):**
- **README "How data is addressed"** — names the four path axes (`country`/`disease`/`data_type`/`layer`) and a table, then shows that a DQ schema key (`malaria_case`) is finer-grained than the program and validates `dr/malaria/**surveillance**/…`.
- **`eri_data_path()` error** now says it directly:
  ```
  `data_type` must be one of "surveillance", "cmr", and "odk", not "malaria_case".
  ℹ `data_type` is the storage-layer category (how the data arrives), not a DQ schema
    key like "malaria_case". The program goes in `disease` (e.g. "malaria").
  ```
- **ADR-0011** records the committed decision (per the maintainer) to unify the bundled schema naming in Phase 2 — the names currently mix country-code prefixes, full country names, disease-in-the-country-slot (`schisto_mda`), and survey-type suffixes — behind one convention, with a machine-readable `data_type:` field per schema and one-release deprecation shims. Doing it now is deliberately cheap: little real data, only `dal.R`/`dq.R` call `load_dq_schema()`.

**Verification:** verified the new error on Eli's exact call; `test-dal.R` green (33); no test asserted the old error text. Indexed ADR-0011.