### PR TITLE
docs(adr): ADR-0012 — address data by source AND measure (5-axis model, supersedes ADR-0011)

### DIFF
--- a/docs/adr/0011-unified-schema-naming.md
+++ b/docs/adr/0011-unified-schema-naming.md
@@ -1,6 +1,7 @@
 # ADR-0011 — One vocabulary for addressing data and schemas
 
-- **Status:** Accepted (phased — interim docs shipped; rename to follow)
+- **Status:** Superseded by [ADR-0012](0012-source-measure-data-model.md) (Phase 1 docs shipped in
+  PR #188; the Phase 2 rename is replaced by ADR-0012's source/measure model)
 - **Date:** 2026-06-27
 
 ## Context

--- a/docs/adr/0012-source-measure-data-model.md
+++ b/docs/adr/0012-source-measure-data-model.md
@@ -1,0 +1,122 @@
+# ADR-0012 — Data is addressed by source *and* measure (the 5-axis model)
+
+- **Status:** Accepted — supersedes [ADR-0011](0011-unified-schema-naming.md)
+- **Date:** 2026-06-27
+
+## Context
+
+ADR-0011 set out to untangle DQ-schema *naming*. Working through it with the maintainer — and checking
+the claim against real data **structure** (never values) — revealed the naming mess is a symptom of a
+deeper modelling error: **the path's third axis is overloaded.**
+
+Today a canonical path is `data/{country}/{disease}/{data_type}/{layer}/` with
+`data_type ∈ {surveillance, cmr, odk}` (`eri_data_path()` `R/dal.R:838`). But those values describe
+**how the data arrives — its source/channel** — which is *orthogonal* to **what the data measures**.
+Two pieces of evidence settle it:
+
+- **One source fans out to many measures across diseases.** A single CMR
+  (`inst/schemas/cmr/uga.yaml`) has seven sheets that map to ~four measures — `treatment` (RB and SCH),
+  `mmdp` (LF), `training` (CDD/CS/MMDP), and `survey` — spanning oncho, SCH and LF.
+- **The same source + disease yields a different measure per country.** DR malaria *surveillance* is a
+  **case-level line-list** (one row per patient); Haiti malaria *surveillance* is **aggregate** facility
+  counts. So the measure is **not** derivable from `(source, disease)`.
+
+Maintainer-clarified domain reality:
+
+- **`surveillance`** — DR/Haiti, a direct Ministry-of-Health feed of a disease's own output:
+  `case` or `aggregate`.
+- **`programmatic`** — activity/coverage data: `treatment`, `mmdp`, `training`, `survey`; **spans
+  diseases** (split per disease on ingest). A country-team **CMR** is one *input format* of this source;
+  Haiti's MoH LF-MDA feed lands here too **without** being a CMR. The input format is recorded, not the
+  axis.
+- **`odk`** — study survey instruments (`tas`, `prevalence`, `entomology`); launched and live-monitored
+  off raw, then the DA cleans them into a **final analytic dataset that lives in the central store**
+  (processed), which the Epi sources for studies. ODK **is** in the governed pipeline.
+
+The overloaded axis is also why the bundled schemas are tangled (four naming conventions), why
+`eri_ingest()` is hard-coupled to a legacy pipeline registry and a `projects`-blob dual-write (so it
+can't run on sandbox data), and why a multi-disease CMR is crammed under a combined `rblf` code.
+
+## Decision
+
+Address governed data by **five orthogonal axes**, separating **source** from **measure**:
+
+```
+data/{country}/{disease}/{data_source}/{data_type}/{layer}/
+        dr    /  malaria /  surveillance /   case    / processed
+        ht    /   lf     /  programmatic /  treatment/ staged
+        dr    /   lf     /     odk       /    tas    / raw
+```
+
+| Axis | Meaning | Examples |
+|---|---|---|
+| `country` | country code | dr, ht, eth, uga |
+| `disease` | the disease | malaria, oncho, lf, sch, sth |
+| `data_source` | **channel / nature** | surveillance, programmatic, odk |
+| `data_type` | **the measure** | case, aggregate, treatment, mmdp, training, survey, tas, prevalence, entomology |
+| `layer` | pipeline stage | raw, staged, processed |
+
+1. **`data_source` is the channel**, with a `format` field recording the input shape
+   (`cmr`, a direct MoH feed, …). `programmatic` covers both a country-team CMR and a non-CMR MoH MDA
+   feed. `format` is **recorded metadata validated against the same registry** as the axes (not
+   free-text), so it cannot become a fourth drift axis; its exact contract is settled at implementation.
+2. **`data_type` is the measure**, first-class and in the path. One `(country, disease, data_source)`
+   may hold several measures.
+3. **Schema identity = `(country, disease, data_source, data_type)`**; the YAML carries
+   `country`/`disease`/`data_source`/`data_type`/`format`.
+4. **All sources flow `raw → staged → processed`.** A CMR ingest **splits** each sheet to its
+   `disease`+`measure` (`RB Treatment` → `uga/oncho/programmatic/treatment`). An ODK form's full
+   relational set (parent + repeat tables, [ADR-0010](0010-odk-repeat-group-tables.md)) lives under a
+   single `…/{disease}/odk/{data_type}/` namespace, with the **measure assigned at the form (parent)
+   level**; `raw`/`staged` preserve ADR-0010's lossless table set and joins stay **downstream, never on
+   ingest**, so the DA's cleaned `processed` analytic dataset is exactly that deliberate downstream
+   join. The combined `rblf` code and `.eri_schema_country_map` are retired.
+5. **`data_source` and `data_type` are extensible by data, not code.** Validation is driven by a small
+   registry / the schema set, so onboarding a new source or measure is a **data** change — not a core
+   edit (roadmap Phase 5; CLAUDE.md global-vs-local guardrail). "This country/disease/source/measure
+   doesn't exist yet" is a normal, expected gap.
+6. **General primitives; legacy/production specifics are thin adapters.** Every core operation works
+   over the five axes on *any* data, including a sandbox. `eri_ingest()` becomes the single general
+   ingest core; the `projects`-blob **dual-write** becomes an opt-in `mirror_pipeline = NULL` parameter
+   (default off, sandbox-safe); the `.eri_pipeline_registry`, `.eri_schema_country_map`, and
+   registered-country gates are **transitional adapters** removed at the Phase-3 hsp-mal cutover.
+   Source-specific entry points (CMR sheet-splitting, ODK) are thin adapters that prep input and call
+   the one core — none re-bakes a special case.
+
+## Consequences
+
+- **Easier:** one coherent addressing model where a measure is first-class; new sources/measures arrive
+  as data; the *real* `eri_ingest()` runs on sandbox data, so the guides can finally teach it; a
+  multi-disease CMR resolves to clean per-disease/measure outputs; ODK's analytic dataset is an ordinary
+  processed artifact the Epi can source.
+- **Harder / accepted:** this is a **breaking** change to the core path model — `eri_data_path()` gains
+  the `data_type` axis and renames the third slot to `data_source`, and every path-builder
+  (`eri_approve`, `eri_stage`, `eri_stage_cmr`, `eri_catalog_*`, `eri_odk_sync`, logs) threads the new
+  axis. Concretely: the **catalog entry schema** (`R/catalog.R`) splits its single `data_type` field
+  into `data_source` + `data_type`, `eri_catalog_query()`'s filter arguments change, and the op-log
+  path `{country}/{disease}/{data_type}/logs/` gains a segment. Per ADR-0002 the catalog is rebuildable,
+  so `eri_catalog_rebuild()` (and the migration) must read **both** the old 4-axis and new 5-axis
+  layouts during the cutover. The bundled schemas are restructured. We accept a large, **phased**
+  migration with deprecation shims because it is far cheaper now (little real `processed/` data, only
+  `dal.R`/`dq.R` call `load_dq_schema()` internally) than later.
+- **Not doing:** collapsing `data_source` and `data_type` back into one token; hard-coded source/measure
+  enums; keeping the `rblf` combined code or the `projects` dual-write inside the core.
+
+## Supersedes ADR-0011
+
+ADR-0011 correctly diagnosed the *naming* drift but modelled `data_type` as a single axis. Its **Phase 1
+docs** (the README "How data is addressed" section and the `eri_data_path()` error from PR #188) are
+partially right but must be updated to the source/measure split as part of the migration. ADR-0011's
+status is set to *Superseded by ADR-0012*.
+
+## References
+
+- #175 — the originating issue (now the migration tracker).
+- PR #188 — ADR-0011 Phase 1 (vocabulary docs to be updated).
+- `inst/schemas/cmr/uga.yaml` — the multi-measure CMR evidence.
+- `docs/roadmap.md` — Phase 3 (hsp-mal cutover, which retires the legacy adapters) and Phase 5
+  (onboarding without core edits, which the extensible registry serves).
+- [ADR-0010](0010-odk-repeat-group-tables.md) — the ODK relational-table set this model files under one
+  `odk/{measure}/` namespace (lossless set preserved; joins downstream).
+- CLAUDE.md "Core model" + "Guardrail: global vs local"; ADR-0002 (YAML metadata, rebuildable catalog),
+  ADR-0006 (research projects / the ODK study lifecycle).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,4 +48,5 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0008](0008-baked-azure-auth-defaults.md) | Baked-in Azure auth defaults; interactive AAD as the zero-config default | Accepted |
 | [0009](0009-research-data-lifecycle.md) | Research-data lifecycle: Azure is the source, the project is the versioned working copy | Accepted |
 | [0010](0010-odk-repeat-group-tables.md) | ODK repeat groups land as a relational set of tables, approved together | Accepted |
-| [0011](0011-unified-schema-naming.md) | One vocabulary for addressing data and schemas (unified schema naming) | Accepted (phased) |
+| [0011](0011-unified-schema-naming.md) | One vocabulary for addressing data and schemas (unified schema naming) | Superseded by ADR-0012 |
+| [0012](0012-source-measure-data-model.md) | Data is addressed by source *and* measure (the 5-axis path model) | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,6 +66,7 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 | [0008](adr/0008-baked-azure-auth-defaults.md) | Bake non-secret auth constants into the package; default to interactive AAD auth | Zero-config login (Phase 2 precondition, brought forward) |
 | [0009](adr/0009-research-data-lifecycle.md) | Azure is the source, the research project the versioned working copy; pulls archive + dedup, canonical writes gated | Reproducible research inputs (Phase 1) |
 | [0010](adr/0010-odk-repeat-group-tables.md) | ODK repeat groups land as a relational set of tables (one Parquet per export table), approved together | ODK repeat-form fidelity (Phase 4) |
+| [0012](adr/0012-source-measure-data-model.md) | Address data by 5 axes splitting data_source (channel) from data_type (measure); general ingest core + legacy adapters | Coherent data-addressing model (#175); supersedes ADR-0011 |
 
 ---
 
@@ -167,6 +168,10 @@ against existing Azure data as a simulation; validated against real uploads when
 - Define written **cutover criteria** (N consecutive periods of equivalence) as an ADR.
 - Harden `eri_ingest_cmr()` / `eri_stage()`; fold DQ failures into the log-triage surface
   (Phase 5).
+- **Retire the legacy adapters** that [ADR-0012](adr/0012-source-measure-data-model.md) isolates from
+  the general ingest core: the `projects`-blob dual-write (now the opt-in `mirror_pipeline` parameter),
+  `.eri_pipeline_registry`, `.eri_schema_country_map`, and the `rblf` combined code all come out at the
+  cutover, leaving `eri_ingest()` purely general over the 5-axis model.
 
 **Verification:** simulation run ingests an Azure-sourced (anomaly-injected) file both ways;
 `eri_compare()` reports parity or precise deltas; approval promotes with token identity;


### PR DESCRIPTION
**This is the design gate for the #175 work — please review/approve the model before I write any code.** Docs-only (one ADR + supersede + index/roadmap).

### What
Through working #175 with you (and checking real data *structure*, never values), the schema-naming tangle turned out to be a symptom of a deeper modelling error: the path's third axis (`data_type ∈ {surveillance,cmr,odk}`) conflates the data **source** with the **measure**. Evidence:
- One CMR fans out to ~4 measures (`treatment`/`mmdp`/`training`/`survey`) across 3 diseases (`inst/schemas/cmr/uga.yaml`).
- DR malaria surveillance is **case-level** while Haiti malaria surveillance is **aggregate** — same source+disease, different measure. So measure isn't derivable from (source, disease).

### The model (ADR-0012)
`data/{country}/{disease}/{data_source}/{data_type}/{layer}/`
- `data_source` = channel (`surveillance`, `programmatic`, `odk`), with a registry-validated `format` field (`cmr`, MoH feed…).
- `data_type` = the measure, first-class and in the path.
- Schema identity = `(country, disease, data_source, data_type)`; all sources flow raw→staged→processed; CMR splits per disease+measure; `rblf` retired.
- **Extensible by data, not code** — new source/measure is a registry entry, not a core edit.
- **General primitives, legacy as adapters** — `eri_ingest()` becomes a sandbox-runnable general core; the `projects` dual-write becomes opt-in `mirror_pipeline = NULL`; the pipeline registry / `.eri_schema_country_map` / registered-country gates are transitional, removed at the Phase-3 cutover.

Reconciles with **ADR-0010** (ODK relational set lives under one `odk/{measure}/` namespace; joins stay downstream). Marks **ADR-0011 superseded**; updates the ADR index + roadmap (incl. the Phase-3 legacy-adapter retirement).

### Reviewed
The `review-agent` checked it (no blockers); I folded in its points — reconciling with ADR-0010, naming the catalog/log migration surfaces explicitly, specifying `format` as registry-validated, and a wording fix (7 sheets ≈ 4 measures).

### Next (after your approval)
The phased, breaking code migration per the plan: (1) 5-axis `eri_data_path` + extensible registry; (2) schemas → 4-part identity + `load_dq_schema` + shims; (3) general `eri_ingest` core + `mirror_pipeline` + CMR/ODK adapters; (4) onboarding + guides/tests/docs. **Closes #175** when that lands.