### PR TITLE
feat: DQ schemas keyed by (country, disease, data_source, data_type) (ADR-0012, #175 phase 2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
   `"lf_tas"` — **still resolves** via an alias to the new name, so existing callers keep working.
 - DR and HT malaria each keep **both** a `case` and an `aggregate` surveillance schema (they are distinct,
   not duplicates). Part of the #175 migration (ADR-0012).
+- *Deferred to phase 4:* the `eri_onboard_*` scaffolders and the `adding-a-program` / `epi-analytics` /
+  `da-ingest` guides still emit/teach the old `{country}_{disease}_{type}` names; they keep working via
+  the alias shim and are swept to the four-part identity with the rest of the docs/onboarding pass.
 
 ## Feature: five-axis data addressing — `data_source` vs `data_type` (ADR-0012, #175 phase 1)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # erifunctions (development version)
 
+## Feature: DQ schemas keyed by `(country, disease, data_source, data_type)` (ADR-0012, #175 phase 2)
+
+- Bundled schemas are renamed to `{country}_{disease}_{data_source}_{data_type}.yaml` and carry
+  `data_source` / `format` fields. `data_source` is `surveillance` / `programmatic` / `research`; **ODK
+  is a research `format`** and **CMR a programmatic `format`** (the channel, not the lane). Country codes
+  are normalised (`ug` → `uga`) and disease names too (`rb` → `oncho`).
+- `load_dq_schema()` gains the four-argument identity form
+  `load_dq_schema(country, disease, data_source, data_type)` (the measure is optional for `research`).
+  The legacy two-argument form — where the second argument held a combined key like `"malaria_case"` or
+  `"lf_tas"` — **still resolves** via an alias to the new name, so existing callers keep working.
+- DR and HT malaria each keep **both** a `case` and an `aggregate` surveillance schema (they are distinct,
+  not duplicates). Part of the #175 migration (ADR-0012).
+
 ## Feature: five-axis data addressing — `data_source` vs `data_type` (ADR-0012, #175 phase 1)
 
 - The canonical path gains a measure axis:

--- a/R/dq.R
+++ b/R/dq.R
@@ -925,43 +925,83 @@ add_anomaly_spatial <- function(data, schema, azcontainer = NULL) {
 
 #### 4) Public API ####
 
+# Alias map from a legacy schema stem ({country}_{key}) to its new ADR-0012
+# canonical name ({country}_{disease}_{data_source}_{data_type}). Lets the legacy
+# two-argument load_dq_schema() form (and old filenames) keep resolving during the
+# migration.
+#' @keywords internal
+.eri_schema_aliases <- c(
+  dr_malaria_case            = "dr_malaria_surveillance_case",
+  dominican_republic_malaria = "dr_malaria_surveillance_aggregate",
+  ht_malaria_case            = "ht_malaria_surveillance_case",
+  haiti_malaria              = "ht_malaria_surveillance_aggregate",
+  dr_lf_mda                  = "dr_lf_programmatic_treatment",
+  dr_lf_tas                  = "dr_lf_research_tas",
+  ht_lf_mda                  = "ht_lf_programmatic_treatment",
+  ht_lf_tas                  = "ht_lf_research_tas",
+  oepa_oncho_mda             = "oepa_oncho_programmatic_treatment",
+  oepa_oncho_prevalence      = "oepa_oncho_research_prevalence",
+  ug_rb_mda                  = "uga_oncho_programmatic_treatment",
+  ug_rb_prevalence           = "uga_oncho_research_prevalence",
+  schisto_mda                = "global_schisto_programmatic_treatment",
+  schisto_prevalence         = "global_schisto_research_prevalence",
+  sth_mda                    = "global_sth_programmatic_treatment",
+  sth_prevalence             = "global_sth_research_prevalence"
+)
+
+#' @keywords internal
+.eri_schema_alias <- function(stem) {
+  if (stem %in% names(.eri_schema_aliases)) .eri_schema_aliases[[stem]] else stem
+}
+
 #' Load a DQ schema
 #'
-#' Loads a disease surveillance data quality schema from Azure blob storage, or
-#' falls back to the schema bundled with the package.
+#' Loads a data quality schema for a `(country, disease, data_source, data_type)`
+#' identity (ADR-0012) from Azure blob storage, falling back to the bundled copy.
+#' Schema files live at
+#' `schemas/{country}_{disease}_{data_source}_{data_type}.yaml`; for `research` the
+#' `data_type` (measure) is optional. When a schema is not found the error lists
+#' every available bundled schema.
 #'
-#' Schema files are YAML documents stored at `schemas/<country>_<disease>.yaml`
-#' in the `data` Azure container (or in `inst/schemas/` locally).
-#' The container name is read from `ERIFUNCTIONS_DATA_STORAGE_NAME` (default `"data"`).
+#' The legacy two-argument form `load_dq_schema(country, key)` — where `key` was a
+#' combined `{disease}_{measure}` string like `"malaria_case"` or `"lf_tas"` — still
+#' resolves during the migration via an alias to the new name.
 #'
-#' `country` and `disease` are simply the two halves of that filename stem. The
-#' bundled set currently mixes conventions (e.g. `dr_malaria_case`,
-#' `dominican_republic_malaria`, `ht_lf_tas`), so when a name is not found the
-#' error lists every available bundled schema to copy from.
-#'
-#' @param country `str` Country identifier matching the schema filename prefix
-#'   (e.g., `"dr"`, `"dominican_republic"`, `"haiti"`).
-#' @param disease `str` Disease/schema key matching the schema filename suffix
-#'   (e.g., `"malaria_case"`, `"lf_tas"`).
+#' @param country `str` Country code (e.g. `"dr"`, `"uga"`).
+#' @param disease `str` Disease (e.g. `"malaria"`, `"lf"`). In the legacy
+#'   two-argument form this slot held a combined schema key.
+#' @param data_source `str` The channel: `"surveillance"`, `"programmatic"`,
+#'   `"research"`. `NULL` (default) selects the legacy two-argument form.
+#' @param data_type `str` The measure (e.g. `"case"`, `"treatment"`, `"tas"`);
+#'   optional for `research`.
 #' @param azcontainer Azure container object from [get_azure_storage_connection()].
-#'   Defaults to the `data` container via `ERIFUNCTIONS_DATA_STORAGE_NAME`.
 #'   Pass `NULL` to use only the locally bundled schema files.
 #' @returns A named list representing the parsed YAML schema.
 #' @examples
 #' \dontrun{
-#' schema <- load_dq_schema("dominican_republic", "malaria")
-#' schema <- load_dq_schema("haiti", "malaria")
+#' schema <- load_dq_schema("dr", "malaria", "surveillance", "case")
+#' schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment")
 #' }
 #' @export
 load_dq_schema <- function(
     country,
     disease,
+    data_source = NULL,
+    data_type   = NULL,
     azcontainer = suppressMessages(
       get_azure_storage_connection(
         storage_name = Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", unset = "data")
       )
     )) {
-  schema_path <- paste0("schemas/", country, "_", disease, ".yaml")
+  if (is.null(data_source)) {
+    # Legacy form: `disease` holds a combined {disease}_{measure} key; alias the
+    # old stem to its new canonical name.
+    stem <- .eri_schema_alias(paste0(country, "_", disease))
+  } else {
+    parts <- c(country, disease, data_source, data_type)
+    stem  <- paste(parts[nzchar(parts)], collapse = "_")
+  }
+  schema_path <- paste0("schemas/", stem, ".yaml")
 
   if (!is.null(azcontainer)) {
     result <- tryCatch({
@@ -987,14 +1027,13 @@ load_dq_schema <- function(
       character()
     }
     msg <- c(
-      "No schema found for {.val {country}}/{.val {disease}}.",
-      "i" = "Looked for a bundled schema named {.file {basename(schema_path)}}."
+      "No schema found for {.file {basename(schema_path)}}.",
+      "i" = "Identity: country/disease/data_source/data_type (ADR-0012)."
     )
     if (length(available)) {
       msg <- c(msg, "i" = paste(
         "Available bundled schemas: {.val {available}}.",
-        "Pass the {.arg country}/{.arg disease} that make up one",
-        "(e.g. {.code load_dq_schema(\"dr\", \"malaria_case\")})."
+        "Call e.g. {.code load_dq_schema(\"dr\", \"malaria\", \"surveillance\", \"case\")}."
       ))
     }
     cli::cli_abort(msg)

--- a/R/onboarding.R
+++ b/R/onboarding.R
@@ -567,7 +567,7 @@ eri_onboard_cmr <- function(
 #' eri_schema_validate("uga_oncho_schema.yaml")
 #'
 #' # Validate a bundled schema
-#' eri_schema_validate(system.file("schemas/dominican_republic_malaria.yaml",
+#' eri_schema_validate(system.file("schemas/dr_malaria_surveillance_aggregate.yaml",
 #'                                  package = "erifunctions"))
 #' }
 #' @export

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ eri_catalog_verify()
 
 | Function | What it does |
 |---|---|
-| `load_dq_schema(country, disease)` | Load a bundled YAML DQ schema |
+| `load_dq_schema(country, disease, data_source, data_type)` | Load a bundled YAML DQ schema |
 | `run_dq_checks(data, schema)` | Run all schema-driven checks; returns a `dq_result` |
 | `dq_report(result)` | Print a summary of flags and corrections |
 | `add_anomaly_pct_change(data, value_col, period_col)` | Flag period-over-period spikes |

--- a/docs/adr/0012-source-measure-data-model.md
+++ b/docs/adr/0012-source-measure-data-model.md
@@ -39,7 +39,10 @@ Maintainer-clarified domain reality:
 > **Refinement (same day, during Phase-2 implementation):** the third lane was first written as `odk`.
 > Working the real schemas with the maintainer showed it is better modelled as **`research`** (the
 > nature) with **`odk` a collection `format`** (the tool) — exactly parallel to `programmatic` + `cmr` —
-> and with an optional/flexible measure. The decision below reads in those terms.
+> and with an optional/flexible measure. The decision below reads in those terms. This is a deliberate
+> *same-day, pre-implementation* in-place refinement (nothing had been built against the `odk`-lane
+> wording yet), not a post-hoc rewrite of a settled decision — the append-only ADR convention still
+> holds for any later change, which would supersede this ADR instead.
 
 The overloaded axis is also why the bundled schemas are tangled (four naming conventions), why
 `eri_ingest()` is hard-coupled to a legacy pipeline registry and a `projects`-blob dual-write (so it

--- a/docs/adr/0012-source-measure-data-model.md
+++ b/docs/adr/0012-source-measure-data-model.md
@@ -29,9 +29,17 @@ Maintainer-clarified domain reality:
   diseases** (split per disease on ingest). A country-team **CMR** is one *input format* of this source;
   Haiti's MoH LF-MDA feed lands here too **without** being a CMR. The input format is recorded, not the
   axis.
-- **`odk`** — study survey instruments (`tas`, `prevalence`, `entomology`); launched and live-monitored
-  off raw, then the DA cleans them into a **final analytic dataset that lives in the central store**
-  (processed), which the Epi sources for studies. ODK **is** in the governed pipeline.
+- **`research`** — research surveys/studies (household or community level), collected via ODK or other
+  tools — so **ODK is a `format`, not the lane**. Launched and live-monitored off raw, then the DA
+  cleans them into a **final analytic dataset in the central store** (processed) that the Epi sources for
+  studies. Research **is** in the governed pipeline; its `data_type` measure is **optional/flexible** (a
+  DA tags `tas` / `prevalence` / `household_survey` / … or omits it), since these don't emit a fixed
+  measure the way surveillance and programmatic do.
+
+> **Refinement (same day, during Phase-2 implementation):** the third lane was first written as `odk`.
+> Working the real schemas with the maintainer showed it is better modelled as **`research`** (the
+> nature) with **`odk` a collection `format`** (the tool) — exactly parallel to `programmatic` + `cmr` —
+> and with an optional/flexible measure. The decision below reads in those terms.
 
 The overloaded axis is also why the bundled schemas are tangled (four naming conventions), why
 `eri_ingest()` is hard-coupled to a legacy pipeline registry and a `projects`-blob dual-write (so it
@@ -45,14 +53,14 @@ Address governed data by **five orthogonal axes**, separating **source** from **
 data/{country}/{disease}/{data_source}/{data_type}/{layer}/
         dr    /  malaria /  surveillance /   case    / processed
         ht    /   lf     /  programmatic /  treatment/ staged
-        dr    /   lf     /     odk       /    tas    / raw
+        dr    /   lf     /    research   /    tas    / raw
 ```
 
 | Axis | Meaning | Examples |
 |---|---|---|
 | `country` | country code | dr, ht, eth, uga |
 | `disease` | the disease | malaria, oncho, lf, sch, sth |
-| `data_source` | **channel / nature** | surveillance, programmatic, odk |
+| `data_source` | **channel / nature** | surveillance, programmatic, research |
 | `data_type` | **the measure** | case, aggregate, treatment, mmdp, training, survey, tas, prevalence, entomology |
 | `layer` | pipeline stage | raw, staged, processed |
 
@@ -61,14 +69,17 @@ data/{country}/{disease}/{data_source}/{data_type}/{layer}/
    feed. `format` is **recorded metadata validated against the same registry** as the axes (not
    free-text), so it cannot become a fourth drift axis; its exact contract is settled at implementation.
 2. **`data_type` is the measure**, first-class and in the path. One `(country, disease, data_source)`
-   may hold several measures.
+   may hold several measures. For **`research`** the measure is **optional and flexible** — the path
+   may be `…/research/{layer}/` (no measure) or `…/research/{tag}/{layer}/`; the registry warns rather
+   than errors on a new tag so DAs are never blocked managing heterogeneous surveys.
 3. **Schema identity = `(country, disease, data_source, data_type)`**; the YAML carries
    `country`/`disease`/`data_source`/`data_type`/`format`.
 4. **All sources flow `raw → staged → processed`.** A CMR ingest **splits** each sheet to its
-   `disease`+`measure` (`RB Treatment` → `uga/oncho/programmatic/treatment`). An ODK form's full
+   `disease`+`measure` (`RB Treatment` → `uga/oncho/programmatic/treatment`). A `research` form's full
    relational set (parent + repeat tables, [ADR-0010](0010-odk-repeat-group-tables.md)) lives under a
-   single `…/{disease}/odk/{data_type}/` namespace, with the **measure assigned at the form (parent)
-   level**; `raw`/`staged` preserve ADR-0010's lossless table set and joins stay **downstream, never on
+   single `…/{disease}/research/{data_type?}/` namespace (`format: odk`), with the **measure assigned at
+   the form (parent) level** (or omitted); `raw`/`staged` preserve ADR-0010's lossless table set and
+   joins stay **downstream, never on
    ingest**, so the DA's cleaned `processed` analytic dataset is exactly that deliberate downstream
    join. The combined `rblf` code and `.eri_schema_country_map` are retired.
 5. **`data_source` and `data_type` are extensible by data, not code.** Validation is driven by a small

--- a/inst/registry/data_model.yaml
+++ b/inst/registry/data_model.yaml
@@ -13,11 +13,12 @@
 data_sources:
   surveillance: "Direct disease-output feed (e.g. a Ministry-of-Health surveillance system)."
   programmatic: "Programmatic activity/coverage data (country-team CMR, MoH MDA feeds); spans diseases."
-  odk:          "Study survey instruments collected via ODK Central."
-  # Transitional (ADR-0012 migration): the legacy `cmr` source token still resolves
-  # so existing paths don't warn; it is replaced by `programmatic` (format: cmr) and
-  # removed at the Phase-3 cutover.
+  research:     "Research surveys/studies (household or community level); DA-managed, flexible measure."
+  # Transitional (ADR-0012 migration): legacy source tokens still resolve so existing
+  # paths don't warn. `cmr` -> `programmatic` (format: cmr); `odk` -> `research`
+  # (format: odk). Both are removed at the Phase-3 cutover.
   cmr:          "(transitional) Legacy CMR source token; migrating to `programmatic` + format: cmr."
+  odk:          "(transitional) Legacy ODK source token; migrating to `research` + format: odk."
 
 data_types:
   case:       "Individual case records (one row per patient)."
@@ -33,6 +34,7 @@ data_types:
 formats:
   cmr:      "Country Monitoring Report Excel template (a programmatic input format)."
   moh_feed: "A direct Ministry-of-Health data feed (a programmatic input format that is not a CMR)."
+  odk:      "ODK Central survey instrument (a research collection format)."
 
 layers:
   - raw

--- a/inst/schemas/dr_lf_programmatic_treatment.yaml
+++ b/inst/schemas/dr_lf_programmatic_treatment.yaml
@@ -1,6 +1,7 @@
 country: dr
 disease: lf
-data_type: mda
+data_source: programmatic
+data_type: treatment
 version: "1.0"
 description: "Dominican Republic LF MDA coverage (one row per EU per round)"
 language: es

--- a/inst/schemas/dr_lf_research_tas.yaml
+++ b/inst/schemas/dr_lf_research_tas.yaml
@@ -1,6 +1,8 @@
 country: dr
 disease: lf
+data_source: research
 data_type: tas
+format: odk
 version: "1.0"
 description: "Dominican Republic LF TAS individual antigen test result (one row per person)"
 language: es

--- a/inst/schemas/dr_malaria_surveillance_aggregate.yaml
+++ b/inst/schemas/dr_malaria_surveillance_aggregate.yaml
@@ -1,5 +1,7 @@
-country: dominican_republic
+country: dr
 disease: malaria
+data_source: surveillance
+data_type: aggregate
 language: es
 time_grain: weekly
 aggregation: case

--- a/inst/schemas/dr_malaria_surveillance_case.yaml
+++ b/inst/schemas/dr_malaria_surveillance_case.yaml
@@ -1,5 +1,6 @@
 country: dr
-disease: malaria_case
+disease: malaria
+data_source: surveillance
 data_type: case
 version: "1.0"
 description: "Dominican Republic individual malaria case record (one row per patient)"

--- a/inst/schemas/global_schisto_programmatic_treatment.yaml
+++ b/inst/schemas/global_schisto_programmatic_treatment.yaml
@@ -1,8 +1,9 @@
 country: global
-disease: sth
-data_type: mda
+disease: schisto
+data_source: programmatic
+data_type: treatment
 version: "1.0"
-description: "Soil-transmitted helminths preventive chemotherapy MDA -- albendazole/mebendazole; SAC and pre-SAC"
+description: "Schistosomiasis preventive chemotherapy MDA -- praziquantel; school-age children"
 language: en
 time_grain: annual
 
@@ -46,30 +47,33 @@ columns:
     type: numeric
     aliases: [TreatedSAC, sac_treated, school_age_treated]
 
-  target_pop_presac:
+  target_pop_adults:
     required: false
     type: numeric
-    aliases: [TargetPopPreSAC, presac_target, preschool_target]
+    aliases: [TargetPopAdults, adult_target, high_risk_adult_target]
 
-  treated_presac:
+  treated_adults:
     required: false
     type: numeric
-    aliases: [TreatedPreSAC, presac_treated, preschool_treated]
+    aliases: [TreatedAdults, adult_treated, high_risk_adult_treated]
 
   drug:
     required: true
     type: categorical
     aliases: [Drug, drug_used, medicine]
-    allowed_values: [albendazole, mebendazole]
-    translations:
-      ALB: albendazole
-      MEB: mebendazole
+    allowed_values: [praziquantel]
 
   coverage_pct:
     required: true
     type: numeric
     aliases: [CoveragePct, coverage, sac_coverage]
     range: [0, 150]
+
+  species_target:
+    required: false
+    type: categorical
+    aliases: [SpeciesTarget, species, schisto_species]
+    allowed_values: [S.mansoni, S.haematobium, S.japonicum, mixed]
 
 consistency:
   sac_not_exceed_target:

--- a/inst/schemas/global_schisto_research_prevalence.yaml
+++ b/inst/schemas/global_schisto_research_prevalence.yaml
@@ -1,6 +1,8 @@
 country: global
 disease: schisto
+data_source: research
 data_type: prevalence
+format: odk
 version: "1.0"
 description: "Schistosomiasis prevalence survey -- Kato-Katz egg count by species"
 language: en

--- a/inst/schemas/global_sth_programmatic_treatment.yaml
+++ b/inst/schemas/global_sth_programmatic_treatment.yaml
@@ -1,8 +1,9 @@
 country: global
-disease: schisto
-data_type: mda
+disease: sth
+data_source: programmatic
+data_type: treatment
 version: "1.0"
-description: "Schistosomiasis preventive chemotherapy MDA -- praziquantel; school-age children"
+description: "Soil-transmitted helminths preventive chemotherapy MDA -- albendazole/mebendazole; SAC and pre-SAC"
 language: en
 time_grain: annual
 
@@ -46,33 +47,30 @@ columns:
     type: numeric
     aliases: [TreatedSAC, sac_treated, school_age_treated]
 
-  target_pop_adults:
+  target_pop_presac:
     required: false
     type: numeric
-    aliases: [TargetPopAdults, adult_target, high_risk_adult_target]
+    aliases: [TargetPopPreSAC, presac_target, preschool_target]
 
-  treated_adults:
+  treated_presac:
     required: false
     type: numeric
-    aliases: [TreatedAdults, adult_treated, high_risk_adult_treated]
+    aliases: [TreatedPreSAC, presac_treated, preschool_treated]
 
   drug:
     required: true
     type: categorical
     aliases: [Drug, drug_used, medicine]
-    allowed_values: [praziquantel]
+    allowed_values: [albendazole, mebendazole]
+    translations:
+      ALB: albendazole
+      MEB: mebendazole
 
   coverage_pct:
     required: true
     type: numeric
     aliases: [CoveragePct, coverage, sac_coverage]
     range: [0, 150]
-
-  species_target:
-    required: false
-    type: categorical
-    aliases: [SpeciesTarget, species, schisto_species]
-    allowed_values: [S.mansoni, S.haematobium, S.japonicum, mixed]
 
 consistency:
   sac_not_exceed_target:

--- a/inst/schemas/global_sth_research_prevalence.yaml
+++ b/inst/schemas/global_sth_research_prevalence.yaml
@@ -1,6 +1,8 @@
 country: global
 disease: sth
+data_source: research
 data_type: prevalence
+format: odk
 version: "1.0"
 description: "STH prevalence survey -- Kato-Katz; species breakdown (hookworm, Ascaris, Trichuris)"
 language: en

--- a/inst/schemas/ht_lf_programmatic_treatment.yaml
+++ b/inst/schemas/ht_lf_programmatic_treatment.yaml
@@ -1,6 +1,7 @@
 country: ht
 disease: lf
-data_type: mda
+data_source: programmatic
+data_type: treatment
 version: "1.0"
 description: "Haiti LF MDA coverage (one row per EU per round)"
 language: fr

--- a/inst/schemas/ht_lf_research_tas.yaml
+++ b/inst/schemas/ht_lf_research_tas.yaml
@@ -1,6 +1,8 @@
 country: ht
 disease: lf
+data_source: research
 data_type: tas
+format: odk
 version: "1.0"
 description: "Haiti LF TAS individual antigen test result (one row per person)"
 language: fr

--- a/inst/schemas/ht_malaria_surveillance_aggregate.yaml
+++ b/inst/schemas/ht_malaria_surveillance_aggregate.yaml
@@ -1,5 +1,7 @@
-country: haiti
+country: ht
 disease: malaria
+data_source: surveillance
+data_type: aggregate
 language: fr
 time_grain: monthly
 aggregation: count

--- a/inst/schemas/ht_malaria_surveillance_case.yaml
+++ b/inst/schemas/ht_malaria_surveillance_case.yaml
@@ -1,5 +1,6 @@
 country: ht
 disease: malaria
+data_source: surveillance
 data_type: case
 version: "1.0"
 description: "Haiti malaria case data (aggregated, one row per commune per week)"

--- a/inst/schemas/oepa_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/oepa_oncho_programmatic_treatment.yaml
@@ -1,6 +1,7 @@
 country: oepa
 disease: oncho
-data_type: mda
+data_source: programmatic
+data_type: treatment
 version: "1.0"
 description: "OEPA onchocerciasis MDA coverage (one row per focus per round)"
 language: es

--- a/inst/schemas/oepa_oncho_research_prevalence.yaml
+++ b/inst/schemas/oepa_oncho_research_prevalence.yaml
@@ -1,6 +1,8 @@
 country: oepa
 disease: oncho
+data_source: research
 data_type: prevalence
+format: odk
 version: "1.0"
 description: "OEPA onchocerciasis prevalence survey (one row per person examined)"
 language: es

--- a/inst/schemas/uga_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/uga_oncho_programmatic_treatment.yaml
@@ -1,6 +1,7 @@
-country: ug
-disease: rb
-data_type: mda
+country: uga
+disease: oncho
+data_source: programmatic
+data_type: treatment
 version: "1.0"
 description: "Uganda river blindness (onchocerciasis) MDA coverage -- APOC community-directed treatment (CDT)"
 language: en

--- a/inst/schemas/uga_oncho_research_prevalence.yaml
+++ b/inst/schemas/uga_oncho_research_prevalence.yaml
@@ -1,6 +1,8 @@
-country: ug
-disease: rb
+country: uga
+disease: oncho
+data_source: research
 data_type: prevalence
+format: odk
 version: "1.0"
 description: "Uganda river blindness (onchocerciasis) prevalence survey -- nodule palpation and skin snip"
 language: en

--- a/man/eri_schema_validate.Rd
+++ b/man/eri_schema_validate.Rd
@@ -24,7 +24,7 @@ rules referencing unknown columns. Returns a tidy tibble of issues.
 eri_schema_validate("uga_oncho_schema.yaml")
 
 # Validate a bundled schema
-eri_schema_validate(system.file("schemas/dominican_republic_malaria.yaml",
+eri_schema_validate(system.file("schemas/dr_malaria_surveillance_aggregate.yaml",
                                  package = "erifunctions"))
 }
 }

--- a/man/load_dq_schema.Rd
+++ b/man/load_dq_schema.Rd
@@ -7,41 +7,46 @@
 load_dq_schema(
   country,
   disease,
+  data_source = NULL,
+  data_type = NULL,
   azcontainer = suppressMessages(get_azure_storage_connection(storage_name =
     Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", unset = "data")))
 )
 }
 \arguments{
-\item{country}{\code{str} Country identifier matching the schema filename prefix
-(e.g., \code{"dr"}, \code{"dominican_republic"}, \code{"haiti"}).}
+\item{country}{\code{str} Country code (e.g. \code{"dr"}, \code{"uga"}).}
 
-\item{disease}{\code{str} Disease/schema key matching the schema filename suffix
-(e.g., \code{"malaria_case"}, \code{"lf_tas"}).}
+\item{disease}{\code{str} Disease (e.g. \code{"malaria"}, \code{"lf"}). In the legacy
+two-argument form this slot held a combined schema key.}
+
+\item{data_source}{\code{str} The channel: \code{"surveillance"}, \code{"programmatic"},
+\code{"research"}. \code{NULL} (default) selects the legacy two-argument form.}
+
+\item{data_type}{\code{str} The measure (e.g. \code{"case"}, \code{"treatment"}, \code{"tas"});
+optional for \code{research}.}
 
 \item{azcontainer}{Azure container object from \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}.
-Defaults to the \code{data} container via \code{ERIFUNCTIONS_DATA_STORAGE_NAME}.
 Pass \code{NULL} to use only the locally bundled schema files.}
 }
 \value{
 A named list representing the parsed YAML schema.
 }
 \description{
-Loads a disease surveillance data quality schema from Azure blob storage, or
-falls back to the schema bundled with the package.
+Loads a data quality schema for a \verb{(country, disease, data_source, data_type)}
+identity (ADR-0012) from Azure blob storage, falling back to the bundled copy.
+Schema files live at
+\verb{schemas/\{country\}_\{disease\}_\{data_source\}_\{data_type\}.yaml}; for \code{research} the
+\code{data_type} (measure) is optional. When a schema is not found the error lists
+every available bundled schema.
 }
 \details{
-Schema files are YAML documents stored at \verb{schemas/<country>_<disease>.yaml}
-in the \code{data} Azure container (or in \verb{inst/schemas/} locally).
-The container name is read from \code{ERIFUNCTIONS_DATA_STORAGE_NAME} (default \code{"data"}).
-
-\code{country} and \code{disease} are simply the two halves of that filename stem. The
-bundled set currently mixes conventions (e.g. \code{dr_malaria_case},
-\code{dominican_republic_malaria}, \code{ht_lf_tas}), so when a name is not found the
-error lists every available bundled schema to copy from.
+The legacy two-argument form \code{load_dq_schema(country, key)} — where \code{key} was a
+combined \verb{\{disease\}_\{measure\}} string like \code{"malaria_case"} or \code{"lf_tas"} — still
+resolves during the migration via an alias to the new name.
 }
 \examples{
 \dontrun{
-schema <- load_dq_schema("dominican_republic", "malaria")
-schema <- load_dq_schema("haiti", "malaria")
+schema <- load_dq_schema("dr", "malaria", "surveillance", "case")
+schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment")
 }
 }

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -410,9 +410,25 @@ test_that("load_dq_schema error enumerates available bundled schemas", {
     load_dq_schema("dr", "nonexistent_disease", azcontainer = NULL),
     "Available bundled schemas"
   )
-  # the helpful list includes the real key the user is probably after
+  # the helpful list includes the real (renamed) schema the user is probably after
   expect_error(
     load_dq_schema("dr", "nonexistent_disease", azcontainer = NULL),
-    "dr_malaria_case"
+    "dr_malaria_surveillance_case"
   )
+})
+
+test_that("load_dq_schema resolves the ADR-0012 identity and legacy aliases", {
+  # new (country, disease, data_source, data_type) identity
+  s1 <- load_dq_schema("dr", "malaria", "surveillance", "case", azcontainer = NULL)
+  expect_equal(s1$data_source, "surveillance")
+  expect_equal(s1$data_type, "case")
+  # research lane (optional/flexible measure)
+  s2 <- load_dq_schema("dr", "lf", "research", "tas", azcontainer = NULL)
+  expect_equal(s2$data_source, "research")
+  expect_equal(s2$format, "odk")
+  # legacy two-argument form aliases old keys to the new files
+  expect_equal(load_dq_schema("dr", "malaria_case", azcontainer = NULL)$data_type, "case")
+  expect_equal(load_dq_schema("schisto", "mda", azcontainer = NULL)$data_type, "treatment")
+  expect_equal(load_dq_schema("haiti", "malaria", azcontainer = NULL)$data_type, "aggregate")
+  expect_equal(load_dq_schema("ht", "malaria_case", azcontainer = NULL)$data_type, "case")
 })

--- a/tests/testthat/test-onboarding.R
+++ b/tests/testthat/test-onboarding.R
@@ -153,7 +153,7 @@ test_that("eri_schema_validate errors on missing file", {
 })
 
 test_that("eri_schema_validate returns empty tibble for valid schema", {
-  path <- system.file("schemas/dominican_republic_malaria.yaml", package = "erifunctions")
+  path <- system.file("schemas/dr_malaria_surveillance_aggregate.yaml", package = "erifunctions")
   skip_if(nchar(path) == 0, "bundled schema not found")
   result <- eri_schema_validate(path)
   expect_s3_class(result, "tbl_df")
@@ -274,27 +274,28 @@ test_that("eri_onboard_disease errors on unsupported data_type", {
 
 # --- bundled schemas for new programs -----------------------------------------
 
+# ADR-0012 identity: (country, disease, data_source, data_type)
 new_schemas <- list(
-  c("ug",      "rb_mda"),
-  c("ug",      "rb_prevalence"),
-  c("schisto", "mda"),
-  c("schisto", "prevalence"),
-  c("sth",     "mda"),
-  c("sth",     "prevalence")
+  c("uga",    "oncho",   "programmatic", "treatment"),
+  c("uga",    "oncho",   "research",     "prevalence"),
+  c("global", "schisto", "programmatic", "treatment"),
+  c("global", "schisto", "research",     "prevalence"),
+  c("global", "sth",     "programmatic", "treatment"),
+  c("global", "sth",     "research",     "prevalence")
 )
 
 for (s in new_schemas) {
   local({
-    ctry <- s[[1L]]; dis <- s[[2L]]
-    test_that(paste0("load_dq_schema('", ctry, "', '", dis, "') loads without error"), {
-      result <- load_dq_schema(ctry, dis, azcontainer = NULL)
+    co <- s[[1L]]; di <- s[[2L]]; ds <- s[[3L]]; dt <- s[[4L]]
+    stem <- paste(co, di, ds, dt, sep = "_")
+    test_that(paste0("load_dq_schema loads ", stem), {
+      result <- load_dq_schema(co, di, ds, dt, azcontainer = NULL)
       expect_type(result, "list")
       expect_true(!is.null(result$disease))
     })
-    test_that(paste0("eri_schema_validate passes for ", ctry, "_", dis), {
-      path <- system.file(paste0("schemas/", ctry, "_", dis, ".yaml"),
-                          package = "erifunctions")
-      skip_if(nchar(path) == 0L, paste("schema file not found:", ctry, dis))
+    test_that(paste0("eri_schema_validate passes for ", stem), {
+      path <- system.file(paste0("schemas/", stem, ".yaml"), package = "erifunctions")
+      skip_if(nchar(path) == 0L, paste("schema file not found:", stem))
       result <- suppressWarnings(eri_schema_validate(path))
       expect_s3_class(result, "tbl_df")
       expect_equal(nrow(result), 0L)

--- a/tests/testthat/test-smoke.R
+++ b/tests/testthat/test-smoke.R
@@ -50,7 +50,7 @@ test_that("smoke [analyst]: eri_list returns files from a known processed path",
 
 test_that("smoke [analyst]: load_dq_schema and run_dq_checks work on sample data", {
   .smoke_skip()
-  schema <- load_dq_schema("dr", "malaria")
+  schema <- load_dq_schema("dr", "malaria", "surveillance", "aggregate")
   expect_type(schema, "list")
 
   sample <- tibble::tibble(


### PR DESCRIPTION
Phase 2 of the ADR-0012 migration: the schema set + `load_dq_schema()` move to the four-part identity, with full back-compat (suite green, **1195**).

### What
- **16 bundled schemas renamed** to `{country}_{disease}_{data_source}_{data_type}.yaml` and given `data_source` / `format` header fields. `data_source` ∈ `surveillance` / `programmatic` / `research`. Country (`ug`→`uga`) and disease (`rb`→`oncho`) normalised.
- **`load_dq_schema(country, disease, data_source, data_type)`** — the new identity form; `data_type` is optional for `research`. The **legacy two-arg form** (a combined key like `"malaria_case"`/`"lf_tas"`, and old filenames) **still resolves** via `.eri_schema_aliases`, so every existing caller/test keeps working untouched (`eri_ingest`, `test-schemas-new`, the guides).
- **ADR-0012 refined** (recorded in the doc): the third lane is **`research`** (the nature), with **ODK a collection `format`** — parallel to `programmatic` + `cmr` — and an **optional/flexible measure** (DAs manage heterogeneous household/community surveys).

### A correction worth flagging
I'd planned to drop the DR/HT malaria "legacy duplicate" schemas. Investigation (a failing Haiti consistency test on `NumMicroPos`, cross-checked against the real HT data structure) showed **they are not duplicates** — DR and HT each have a genuinely distinct `case` **and** `aggregate` surveillance schema. So this PR **keeps both** for each country rather than losing real content. If you do want one retired, that's a content decision we can take separately.

### Still transitional (Phase 3)
`cmr` and `odk` remain registered as transitional `data_source`s (used by `eri_stage_cmr` / `eri_odk_sync`) so they don't warn yet; they become `programmatic`+`format:cmr` and `research`+`format:odk` when those adapters are migrated.

### Tests
New `load_dq_schema` identity + alias tests; `test-onboarding` schema-validate loop updated to the new names; `test-dq` Haiti rules preserved. `devtools::test()` → **FAIL 0 | PASS 1195**.