### PR TITLE
feat: generalize eri_ingest into a sandbox-runnable core; opt-in mirror_pipeline (ADR-0012, #175 p3a)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # erifunctions (development version)
 
+## Feature: `eri_ingest()` is a general, sandbox-runnable ingest core (ADR-0012, #175 phase 3a)
+
+- `eri_ingest()` no longer requires the `hsp-mal` pipeline registry or a registered country, and no
+  longer *forces* a write to the legacy `projects` blob. It reads, DQ-checks, and stages to
+  `data/{country}/{disease}/{data_source}/staged/` on **any** data — so the guides can finally teach it
+  on a throwaway sandbox. Signature: `eri_ingest(path, country, disease, data_source = "surveillance",
+  data_type = "aggregate", …)`.
+- The legacy `projects`-blob dual-write is now the **opt-in `mirror_pipeline`** argument (default
+  `NULL`); legacy callers pass `mirror_pipeline = "hsp-mal"`. The `.eri_schema_country_map` hack is
+  retired (schemas are code-prefixed now). These mirror bits are transitional and removed at the
+  Phase-3 hsp-mal cutover.
+
 ## Feature: DQ schemas keyed by `(country, disease, data_source, data_type)` (ADR-0012, #175 phase 2)
 
 - Bundled schemas are renamed to `{country}_{disease}_{data_source}_{data_type}.yaml` and carry

--- a/R/dal.R
+++ b/R/dal.R
@@ -1308,35 +1308,40 @@ eri_stage <- function(pipeline, country, disease,
   invisible(staged)
 }
 
-#' Ingest a local surveillance file and write cleaned output to both blob targets
+#' Ingest a local data file: DQ-check and stage it
 #'
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' The primary analyst entry point for surveillance ingestion. Reads a raw local
-#' Excel file, runs all DQ checks via [run_dq_checks()], then dual-writes the
-#' cleaned parquet output to:
-#' 1. `projects/{project_folder}/intermediate/{country_subfolder}/` — mirrors the
-#'    GHA pipeline output for side-by-side comparison.
-#' 2. `data/{country}/{disease}/surveillance/staged/` — feeds [eri_approve()].
+#' The general analyst ingest entry point. Reads a raw local file, runs all DQ
+#' checks via [run_dq_checks()], prints the flags, and writes the cleaned parquet
+#' to `data/{country}/{disease}/{data_source}/staged/` — feeding [eri_approve()].
+#' It runs on **any** data, including a throwaway sandbox: there is no
+#' pipeline-registry or country gate by default.
 #'
-#' DQ flags are printed to the console immediately after checks complete so the
-#' analyst can review issues before calling [eri_approve()].
+#' The legacy `projects`-blob dual-write (the hsp-mal cutover comparison) is an
+#' **opt-in** mirror: pass `mirror_pipeline = "hsp-mal"` to additionally mirror the
+#' cleaned output to `projects/{project_folder}/intermediate/{country_subfolder}/`.
+#' This is transitional and removed at the Phase-3 cutover (ADR-0012).
 #'
-#' @param path `str` Local path to the raw Excel file to ingest.
+#' @param path `str` Local path to the raw file to ingest.
 #' @param country `str` Country code (e.g. `"dr"`, `"ht"`).
 #' @param disease `str` Disease name (e.g. `"malaria"`).
-#' @param pipeline `str` Registry entry that controls which `project_folder` and
-#'   `country_map` are used for the projects blob write. Default `"hsp-mal"`.
-#' @param schema Named list returned by [load_dq_schema()]. If `NULL` (default),
-#'   auto-loaded for the given country and disease.
-#' @param projects_con Azure container object for the `projects` blob. If `NULL`
-#'   (default), connects automatically using [get_azure_storage_connection()].
-#' @param data_con Azure container object for the `data` blob. If `NULL`
-#'   (default), connects using `ERIFUNCTIONS_DATA_STORAGE_NAME`.
+#' @param data_source `str` The channel (`"surveillance"`, `"programmatic"`,
+#'   `"research"`). Default `"surveillance"`.
+#' @param data_type `str` The measure used to select the DQ schema (e.g.
+#'   `"aggregate"`, `"case"`). Default `"aggregate"`.
+#' @param schema Named list from [load_dq_schema()]. If `NULL` (default), loaded
+#'   for `(country, disease, data_source, data_type)`.
+#' @param data_con Azure container for the `data` blob. If `NULL` (default),
+#'   connects using `ERIFUNCTIONS_DATA_STORAGE_NAME`.
+#' @param mirror_pipeline `str` or `NULL` If set (e.g. `"hsp-mal"`), also mirror the
+#'   cleaned output to the legacy `projects` blob via that pipeline registry entry.
+#'   Default `NULL` (no mirror; sandbox-safe).
+#' @param projects_con Azure container for the `projects` blob; used only when
+#'   `mirror_pipeline` is set. If `NULL`, connects automatically.
 #'
-#' @returns Invisibly, the `dq_result` object so the analyst can inspect
-#'   `$data`, `$log`, and `$flags`.
+#' @returns Invisibly, the `dq_result` object (`$data`, `$log`, `$flags`).
 #' @examples
 #' \dontrun{
 #' result <- eri_ingest("data/raw/dr_malaria_2024W01.xlsx", "dr", "malaria")
@@ -1345,32 +1350,36 @@ eri_stage <- function(pipeline, country, disease,
 #' }
 #' @export
 eri_ingest <- function(path, country, disease,
-                       pipeline     = "hsp-mal",
-                       schema       = NULL,
-                       projects_con = NULL,
-                       data_con     = NULL) {
+                       data_source = "surveillance",
+                       data_type   = "aggregate",
+                       schema      = NULL,
+                       data_con    = NULL,
+                       mirror_pipeline = NULL,
+                       projects_con = NULL) {
   .eri_log_session()
 
   if (!file.exists(path)) {
     cli::cli_abort("File not found: {.path {path}}")
   }
 
-  reg <- .eri_pipeline_registry[[pipeline]]
-  if (is.null(reg)) {
-    known <- paste(names(.eri_pipeline_registry), collapse = ", ")
-    cli::cli_abort(c(
-      "Unknown pipeline {.val {pipeline}}.",
-      "i" = "Registered pipelines: {known}."
-    ))
-  }
-
-  subfolder <- reg$country_map[[country]]
-  if (is.null(subfolder)) {
-    known_countries <- paste(names(reg$country_map), collapse = ", ")
-    cli::cli_abort(c(
-      "Country {.val {country}} is not registered for pipeline {.val {pipeline}}.",
-      "i" = "Registered countries: {known_countries}."
-    ))
+  # Validate the optional legacy projects-blob mirror up front (fail fast, no I/O).
+  mirror <- NULL
+  if (!is.null(mirror_pipeline)) {
+    reg <- .eri_pipeline_registry[[mirror_pipeline]]
+    if (is.null(reg)) {
+      cli::cli_abort(c(
+        "Unknown pipeline {.val {mirror_pipeline}}.",
+        "i" = "Registered pipelines: {paste(names(.eri_pipeline_registry), collapse = ', ')}."
+      ))
+    }
+    subfolder <- reg$country_map[[country]]
+    if (is.null(subfolder)) {
+      cli::cli_abort(c(
+        "Country {.val {country}} is not registered for pipeline {.val {mirror_pipeline}}.",
+        "i" = "Registered countries: {paste(names(reg$country_map), collapse = ', ')}."
+      ))
+    }
+    mirror <- list(reg = reg, subfolder = subfolder)
   }
 
   if (is.null(data_con)) {
@@ -1380,13 +1389,9 @@ eri_ingest <- function(path, country, disease,
       )
     )
   }
-  if (is.null(projects_con)) {
-    projects_con <- suppressMessages(get_azure_storage_connection())
-  }
 
   if (is.null(schema)) {
-    schema_country <- .eri_schema_country_map[[country]] %||% country
-    schema <- load_dq_schema(schema_country, disease, azcontainer = data_con)
+    schema <- load_dq_schema(country, disease, data_source, data_type, azcontainer = data_con)
   }
 
   raw_data <- eri_read(path, azure = FALSE)
@@ -1399,16 +1404,16 @@ eri_ingest <- function(path, country, disease,
   dq_report(result)
 
   fname_parquet <- paste0(tools::file_path_sans_ext(basename(path)), ".parquet")
-  staged_dir    <- eri_data_path(country, disease, "surveillance", "staged")
-  projects_dir  <- paste0(reg$project_folder, "/intermediate/", subfolder)
-  log_dir       <- paste(c(country, disease, "surveillance", "logs"), collapse = "/")
+  staged_dir    <- eri_data_path(country, disease, data_source, "staged")
+  log_dir       <- paste(c(country, disease, data_source, "logs"), collapse = "/")
 
   op_log <- list(
     operation  = "eri_ingest",
     analyst    = .eri_analyst_id(),
     started_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
-    parameters = list(path = path, country = country,
-                      disease = disease, pipeline = pipeline),
+    parameters = list(path = path, country = country, disease = disease,
+                      data_source = data_source, data_type = data_type,
+                      mirror_pipeline = mirror_pipeline),
     status     = "in_progress",
     steps      = list(),
     error      = NULL,
@@ -1434,23 +1439,31 @@ eri_ingest <- function(path, country, disease,
     op_log$steps <- .eri_log_step(op_log$steps, "write_data_blob", dest = data_dest)
     .eri_say_done("Staged to data blob: {.path {data_dest}}")
 
-    proj_dest <- paste0(projects_dir, "/", fname_parquet)
-    withr::with_tempfile("parquet_file", fileext = ".parquet", {
-      arrow::write_parquet(result$data, parquet_file)
-      .eri_blob_write(projects_con, parquet_file, proj_dest)
-    })
-    written      <- c(written, proj_dest)
-    op_log$steps <- .eri_log_step(op_log$steps, "write_projects_blob", dest = proj_dest)
-    .eri_say_done("Written to projects blob: {.path {proj_dest}}")
+    # Optional legacy projects-blob mirror (transitional; removed at the Phase-3 cutover).
+    if (!is.null(mirror)) {
+      if (is.null(projects_con)) {
+        projects_con <- suppressMessages(get_azure_storage_connection())
+      }
+      proj_dest <- paste0(mirror$reg$project_folder, "/intermediate/",
+                          mirror$subfolder, "/", fname_parquet)
+      withr::with_tempfile("parquet_file", fileext = ".parquet", {
+        arrow::write_parquet(result$data, parquet_file)
+        .eri_blob_write(projects_con, parquet_file, proj_dest)
+      })
+      written      <- c(written, proj_dest)
+      op_log$steps <- .eri_log_step(op_log$steps, "mirror_projects_blob", dest = proj_dest)
+      .eri_say_done("Mirrored to projects blob: {.path {proj_dest}}")
+    }
+
     .eri_summary("Ingested to {.path {staged_dir}}", c(
       Rows  = format(nrow(result$data), big.mark = ","),
-      Blobs = sprintf("%d written (data + projects)", length(written))
+      Blobs = sprintf("%d written", length(written))
     ))
 
     # Persist the DQ flags to the log backlog so they are durable and triageable
     # via eri_logs() / eri_logs_resolve(). Never let a logging hiccup break ingest.
     tryCatch(
-      eri_dq_log(result, country, disease, "surveillance", data_con = data_con),
+      eri_dq_log(result, country, disease, data_source, data_con = data_con),
       error = function(e) cli::cli_alert_warning("Could not log DQ flags: {conditionMessage(e)}")
     )
 
@@ -1500,12 +1513,6 @@ eri_ingest <- function(path, country, disease,
       "tcd" = "tcd"
     )
   )
-)
-
-# Maps short country codes to bundled schema country names
-.eri_schema_country_map <- list(
-  "dr" = "dominican_republic",
-  "ht" = "haiti"
 )
 
 #' Resolve the analyst identity for governed actions and audit logs

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ eri_catalog_verify()
 |---|---|
 | `eri_approve(country, disease, data_type, period)` | Promote staged files to processed (human gate) |
 | `eri_stage(pipeline, country, disease)` | Pull pipeline output from projects blob into staged |
-| `eri_ingest(path, country, disease)` | DQ-check a local file and dual-write to both blobs |
+| `eri_ingest(path, country, disease, data_source, data_type)` | DQ-check a local file and stage it (sandbox-runnable; opt-in `mirror_pipeline`) |
 | `eri_trigger(pipeline, country, disease)` | Dispatch a GitHub Actions pipeline |
 
 ### Data quality

--- a/man/eri_ingest.Rd
+++ b/man/eri_ingest.Rd
@@ -2,55 +2,62 @@
 % Please edit documentation in R/dal.R
 \name{eri_ingest}
 \alias{eri_ingest}
-\title{Ingest a local surveillance file and write cleaned output to both blob targets}
+\title{Ingest a local data file: DQ-check and stage it}
 \usage{
 eri_ingest(
   path,
   country,
   disease,
-  pipeline = "hsp-mal",
+  data_source = "surveillance",
+  data_type = "aggregate",
   schema = NULL,
-  projects_con = NULL,
-  data_con = NULL
+  data_con = NULL,
+  mirror_pipeline = NULL,
+  projects_con = NULL
 )
 }
 \arguments{
-\item{path}{\code{str} Local path to the raw Excel file to ingest.}
+\item{path}{\code{str} Local path to the raw file to ingest.}
 
 \item{country}{\code{str} Country code (e.g. \code{"dr"}, \code{"ht"}).}
 
 \item{disease}{\code{str} Disease name (e.g. \code{"malaria"}).}
 
-\item{pipeline}{\code{str} Registry entry that controls which \code{project_folder} and
-\code{country_map} are used for the projects blob write. Default \code{"hsp-mal"}.}
+\item{data_source}{\code{str} The channel (\code{"surveillance"}, \code{"programmatic"},
+\code{"research"}). Default \code{"surveillance"}.}
 
-\item{schema}{Named list returned by \code{\link[=load_dq_schema]{load_dq_schema()}}. If \code{NULL} (default),
-auto-loaded for the given country and disease.}
+\item{data_type}{\code{str} The measure used to select the DQ schema (e.g.
+\code{"aggregate"}, \code{"case"}). Default \code{"aggregate"}.}
 
-\item{projects_con}{Azure container object for the \code{projects} blob. If \code{NULL}
-(default), connects automatically using \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}.}
+\item{schema}{Named list from \code{\link[=load_dq_schema]{load_dq_schema()}}. If \code{NULL} (default), loaded
+for \verb{(country, disease, data_source, data_type)}.}
 
-\item{data_con}{Azure container object for the \code{data} blob. If \code{NULL}
-(default), connects using \code{ERIFUNCTIONS_DATA_STORAGE_NAME}.}
+\item{data_con}{Azure container for the \code{data} blob. If \code{NULL} (default),
+connects using \code{ERIFUNCTIONS_DATA_STORAGE_NAME}.}
+
+\item{mirror_pipeline}{\code{str} or \code{NULL} If set (e.g. \code{"hsp-mal"}), also mirror the
+cleaned output to the legacy \code{projects} blob via that pipeline registry entry.
+Default \code{NULL} (no mirror; sandbox-safe).}
+
+\item{projects_con}{Azure container for the \code{projects} blob; used only when
+\code{mirror_pipeline} is set. If \code{NULL}, connects automatically.}
 }
 \value{
-Invisibly, the \code{dq_result} object so the analyst can inspect
-\verb{$data}, \verb{$log}, and \verb{$flags}.
+Invisibly, the \code{dq_result} object (\verb{$data}, \verb{$log}, \verb{$flags}).
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-The primary analyst entry point for surveillance ingestion. Reads a raw local
-Excel file, runs all DQ checks via \code{\link[=run_dq_checks]{run_dq_checks()}}, then dual-writes the
-cleaned parquet output to:
-\enumerate{
-\item \verb{projects/\{project_folder\}/intermediate/\{country_subfolder\}/} — mirrors the
-GHA pipeline output for side-by-side comparison.
-\item \verb{data/\{country\}/\{disease\}/surveillance/staged/} — feeds \code{\link[=eri_approve]{eri_approve()}}.
-}
+The general analyst ingest entry point. Reads a raw local file, runs all DQ
+checks via \code{\link[=run_dq_checks]{run_dq_checks()}}, prints the flags, and writes the cleaned parquet
+to \verb{data/\{country\}/\{disease\}/\{data_source\}/staged/} — feeding \code{\link[=eri_approve]{eri_approve()}}.
+It runs on \strong{any} data, including a throwaway sandbox: there is no
+pipeline-registry or country gate by default.
 
-DQ flags are printed to the console immediately after checks complete so the
-analyst can review issues before calling \code{\link[=eri_approve]{eri_approve()}}.
+The legacy \code{projects}-blob dual-write (the hsp-mal cutover comparison) is an
+\strong{opt-in} mirror: pass \code{mirror_pipeline = "hsp-mal"} to additionally mirror the
+cleaned output to \verb{projects/\{project_folder\}/intermediate/\{country_subfolder\}/}.
+This is transitional and removed at the Phase-3 cutover (ADR-0012).
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -270,38 +270,37 @@ test_that("eri_stage_cmr selects most recent period when period = NULL", {
 test_that("eri_ingest errors when file does not exist", {
   expect_error(
     eri_ingest("nonexistent/path/file.xlsx", "dr", "malaria",
-               projects_con = structure(list(), class = "mock"),
-               data_con     = structure(list(), class = "mock")),
+               data_con = structure(list(), class = "mock")),
     "File not found"
   )
 })
 
-test_that("eri_ingest errors clearly for unknown pipeline", {
+test_that("eri_ingest errors clearly for an unknown mirror pipeline (opt-in only)", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   writexl::write_xlsx(tibble::tibble(x = 1), tmp)
+  # the pipeline registry is only consulted when mirror_pipeline is set; the error
+  # fires up front, before any Azure I/O
   expect_error(
     eri_ingest(tmp, "dr", "malaria",
-               pipeline     = "nonexistent-pipeline",
-               projects_con = structure(list(), class = "mock"),
-               data_con     = structure(list(), class = "mock")),
+               mirror_pipeline = "nonexistent-pipeline",
+               data_con        = structure(list(), class = "mock")),
     "Unknown pipeline"
   )
 })
 
-test_that("eri_ingest errors clearly for unregistered country", {
+test_that("eri_ingest errors for a country not registered to the mirror pipeline", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   writexl::write_xlsx(tibble::tibble(x = 1), tmp)
   expect_error(
     eri_ingest(tmp, "zz", "malaria",
-               projects_con = structure(list(), class = "mock"),
-               data_con     = structure(list(), class = "mock")),
+               mirror_pipeline = "hsp-mal",
+               data_con        = structure(list(), class = "mock")),
     "not registered"
   )
 })
 
-test_that(".eri_schema_country_map maps dr and ht correctly", {
-  expect_equal(.eri_schema_country_map[["dr"]], "dominican_republic")
-  expect_equal(.eri_schema_country_map[["ht"]], "haiti")
+test_that("eri_ingest no longer needs .eri_schema_country_map (retired)", {
+  expect_false(exists(".eri_schema_country_map", where = asNamespace("erifunctions")))
 })
 
 #### Tests for eri_approve error paths (no Azure needed) ####

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -482,11 +482,12 @@ unlink("atlantis_malaria.yaml")   # the local schema file
 You have now done the full DA ingest loop: store raw, quality-check against a schema, fix what only a
 human can, stage, and **approve** into the canonical layer — twice, including a messy extract.
 
-**In production, for a *registered* country** (like `dr` or `ht`), one call —
-[`eri_ingest()`](../reference/eri_ingest.html) — does the read-and-DQ-and-stage steps (§2, §4, §5)
-in a single shot and also mirrors the result to the legacy pipeline. We did each step by hand here so
-you could run it on a sandbox of your own and *see* every layer. Once you are comfortable, `eri_ingest()`
-is the fast path; `eri_approve()` — your sign-off — is always the same human gate at the end.
+One call — [`eri_ingest()`](../reference/eri_ingest.html) — does the read-and-DQ-and-stage steps
+(§2, §4, §5) in a single shot, on **any** data including the sandbox you just built (it takes the same
+`country` / `disease` / `data_source` you have been using). We did each step by hand here so you could
+*see* every layer; once you are comfortable, `eri_ingest()` is the fast path, and `eri_approve()` —
+your sign-off — is always the same human gate at the end. *(For the legacy `hsp-mal` cutover, passing
+`mirror_pipeline = "hsp-mal"` also mirrors the output to the old `projects` blob — off by default.)*
 
 This is one of a planned set of short, task-oriented guides — **one for each common job** an analyst
 or epidemiologist does. See [the guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md)


### PR DESCRIPTION
Phase 3a of the ADR-0012 migration: `eri_ingest()` becomes the **general ingest core** — the thing it always should have been — and the peculiar legacy bits become an opt-in adapter.

### What
- **General core, no gates.** `eri_ingest()` drops the hard coupling to `.eri_pipeline_registry` and the registered-country gate, and no longer *forces* a write to the legacy `projects` blob. It reads → `run_dq_checks` → `dq_report` → stages to `data/{country}/{disease}/{data_source}/staged/` → DQ-log + op-log, on **any** data including a throwaway sandbox. (This finally fixes the long-standing wart that the DA-ingest guide had to *avoid* `eri_ingest` because it couldn't run on safe data.)
- **Legacy dual-write → opt-in `mirror_pipeline = NULL`.** Default off (sandbox-safe). Set `mirror_pipeline = "hsp-mal"` to additionally mirror the cleaned output to `projects/.../intermediate/...`. Validated **up front** (fail fast, no I/O), so the registry/country errors still fire early. Removed entirely at the Phase-3 cutover.
- New signature: `eri_ingest(path, country, disease, data_source = "surveillance", data_type = "aggregate", schema = NULL, data_con = NULL, mirror_pipeline = NULL, projects_con = NULL)`. Defaults preserve the legacy hsp-mal surveillance-aggregate behavior; the schema is now resolved by the 4-part identity, so `.eri_schema_country_map` (the `dr→dominican_republic` hack) is **retired**.

### Scope note
Paths stay 4-axis (`{country}/{disease}/{data_source}/staged`) — consistent with `eri_approve`/catalog, which haven't migrated yet. Threading the **measure into the path** across the whole pipeline (`ingest`/`approve`/`stage`/`catalog`/`logs` together) is a dedicated atomic follow-up, and the **CMR/ODK source adapters** (CMR splitting per disease+measure) are phase 3b — they need a routing decision.

### Tests
The 3 `eri_ingest` error-path tests updated to the `mirror_pipeline` opt-in; the `.eri_schema_country_map` test replaced with a "retired" assertion. `devtools::test()` → **FAIL 0 | PASS 1202**.