### PR TITLE
feat: onboarding scaffolders emit the 4-part schema identity (ADR-0012, #175 phase 4a)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # erifunctions (development version)
 
+## Feature: onboarding scaffolders emit the 4-part schema identity (ADR-0012, #175 phase 4a)
+
+- `eri_onboard_disease()` and `eri_onboard_country()` now write schema skeletons named to the ADR-0012
+  identity `{country}_{disease}_{data_source}_{data_type}.yaml` with `data_source` / `data_type` header
+  fields: `mda` → `programmatic` / `treatment`, `prevalence` → `research` / `prevalence`, and
+  surveillance → `surveillance` / `{data_type}` (new `eri_onboard_country(data_type = "aggregate")`
+  argument). So a freshly onboarded program is consistent with the migrated bundled schemas and loads
+  via the 4-arg `load_dq_schema()`. The DA onboarding guide is updated to match.
+
 ## Feature: `eri_ingest()` is a general, sandbox-runnable ingest core (ADR-0012, #175 phase 3a)
 
 - `eri_ingest()` no longer requires the `hsp-mal` pipeline registry or a registered country, and no

--- a/R/onboarding.R
+++ b/R/onboarding.R
@@ -9,7 +9,8 @@
   paste0(
     "country: ", country_code, "\n",
     "disease: ", disease, "\n",
-    "data_type: mda\n",
+    "data_source: programmatic\n",
+    "data_type: treatment\n",
     "version: \"1.0\"\n",
     "# time_grain: annual\n",
     "\n",
@@ -78,6 +79,7 @@
   paste0(
     "country: ", country_code, "\n",
     "disease: ", disease, "\n",
+    "data_source: research\n",
     "data_type: prevalence\n",
     "version: \"1.0\"\n",
     "# time_grain: annual\n",
@@ -172,10 +174,13 @@
 }
 
 # Build surveillance schema YAML content as a string with guiding comments.
-.surveillance_schema_template <- function(country_code, country_name, disease, language) {
+.surveillance_schema_template <- function(country_code, country_name, disease, language,
+                                          data_type = "aggregate") {
   paste0(
-    "country: ", country_name, "\n",
+    "country: ", country_code, "\n",
     "disease: ", disease, "\n",
+    "data_source: surveillance\n",
+    "data_type: ", data_type, "\n",
     "language: ", language, "\n",
     "# time_grain: weekly   # or: monthly\n",
     "# aggregation: case    # or: count\n",
@@ -335,7 +340,13 @@ eri_onboard_disease <- function(disease,
   country    <- tolower(trimws(country))
   data_types <- match.arg(data_types, c("mda", "prevalence"), several.ok = TRUE)
 
-  file_names <- paste0(country, "_", disease, "_", data_types, ".yaml")
+  # ADR-0012 identity: the user-facing kind maps to (data_source, data_type).
+  kind_map   <- list(mda        = c("programmatic", "treatment"),
+                     prevalence = c("research",     "prevalence"))
+  file_names <- vapply(data_types, function(k) {
+    m <- kind_map[[k]]
+    paste0(country, "_", disease, "_", m[[1L]], "_", m[[2L]], ".yaml")
+  }, character(1L))
   file_paths <- file.path(output_dir, file_names)
 
   if (dry_run) {
@@ -388,6 +399,9 @@ eri_onboard_disease <- function(disease,
 #'   Ignored when `dry_run = TRUE`.
 #' @param dry_run `lgl` If `TRUE`, print a plan but do not write files or create Azure
 #'   directories. Default `FALSE`.
+#' @param data_type `chr` The surveillance measure for the schema identity (ADR-0012),
+#'   e.g. `"aggregate"` or `"case"`. Default `"aggregate"`. Sets the schema filename
+#'   `{country}_{disease}_surveillance_{data_type}.yaml`.
 #' @returns Invisibly, the path to the written schema file (or `NULL` in dry-run mode).
 #' @examples
 #' \dontrun{
@@ -402,7 +416,8 @@ eri_onboard_country <- function(
     language  = "en",
     path      = getwd(),
     data_con  = NULL,
-    dry_run   = FALSE
+    dry_run   = FALSE,
+    data_type = "aggregate"
 ) {
   country_code <- tolower(trimws(country_code))
   disease      <- tolower(trimws(disease))
@@ -411,7 +426,7 @@ eri_onboard_country <- function(
   if (!language %in% c("en", "fr"))
     cli::cli_abort("{.arg language} must be {.val en} or {.val fr}, not {.val {language}}.")
 
-  schema_filename <- paste0(country_code, "_", disease, "_schema.yaml")
+  schema_filename <- paste0(country_code, "_", disease, "_surveillance_", data_type, ".yaml")
   schema_path     <- file.path(path, schema_filename)
 
   azure_dirs <- c(
@@ -430,7 +445,7 @@ eri_onboard_country <- function(
     return(invisible(NULL))
   }
 
-  yaml_content <- .surveillance_schema_template(country_code, country_name, disease, language)
+  yaml_content <- .surveillance_schema_template(country_code, country_name, disease, language, data_type)
   writeLines(yaml_content, schema_path)
   cli::cli_alert_success("Schema template written to {.path {schema_path}}.")
 
@@ -452,7 +467,7 @@ eri_onboard_country <- function(
     " " = "1. Open {.path {schema_path}} and fill in the TODO sections.",
     " " = "2. Run {.run eri_schema_validate('{schema_path}')} to check your edits.",
     " " = "3. Submit the schema via a pull request to add it to the package:",
-    " " = "   {.path inst/schemas/{country_code}_{disease}.yaml}",
+    " " = "   {.path inst/schemas/{country_code}_{disease}_surveillance_{data_type}.yaml}",
     " " = "4. Register any ODK forms with {.run eri_odk_register()}.",
     " " = "5. Pin the package version in your project: {.run renv::snapshot()}."
   ))

--- a/R/onboarding.R
+++ b/R/onboarding.R
@@ -579,7 +579,7 @@ eri_onboard_cmr <- function(
 #' @examples
 #' \dontrun{
 #' # Validate a schema you just generated
-#' eri_schema_validate("uga_oncho_schema.yaml")
+#' eri_schema_validate("uga_oncho_surveillance_aggregate.yaml")
 #'
 #' # Validate a bundled schema
 #' eri_schema_validate(system.file("schemas/dr_malaria_surveillance_aggregate.yaml",

--- a/man/eri_onboard_country.Rd
+++ b/man/eri_onboard_country.Rd
@@ -11,7 +11,8 @@ eri_onboard_country(
   language = "en",
   path = getwd(),
   data_con = NULL,
-  dry_run = FALSE
+  dry_run = FALSE,
+  data_type = "aggregate"
 )
 }
 \arguments{
@@ -31,6 +32,10 @@ Ignored when \code{dry_run = TRUE}.}
 
 \item{dry_run}{\code{lgl} If \code{TRUE}, print a plan but do not write files or create Azure
 directories. Default \code{FALSE}.}
+
+\item{data_type}{\code{chr} The surveillance measure for the schema identity (ADR-0012),
+e.g. \code{"aggregate"} or \code{"case"}. Default \code{"aggregate"}. Sets the schema filename
+\verb{\{country\}_\{disease\}_surveillance_\{data_type\}.yaml}.}
 }
 \value{
 Invisibly, the path to the written schema file (or \code{NULL} in dry-run mode).

--- a/man/eri_schema_validate.Rd
+++ b/man/eri_schema_validate.Rd
@@ -21,7 +21,7 @@ rules referencing unknown columns. Returns a tidy tibble of issues.
 \examples{
 \dontrun{
 # Validate a schema you just generated
-eri_schema_validate("uga_oncho_schema.yaml")
+eri_schema_validate("uga_oncho_surveillance_aggregate.yaml")
 
 # Validate a bundled schema
 eri_schema_validate(system.file("schemas/dr_malaria_surveillance_aggregate.yaml",

--- a/tests/testthat/test-onboarding.R
+++ b/tests/testthat/test-onboarding.R
@@ -7,7 +7,7 @@ test_that("eri_onboard_country dry_run returns invisible NULL without writing fi
   result <- eri_onboard_country("uga", "Uganda", "oncho",
                                  path = tmp, dry_run = TRUE)
   expect_null(result)
-  expect_false(file.exists(file.path(tmp, "uga_oncho_schema.yaml")))
+  expect_false(file.exists(file.path(tmp, "uga_oncho_surveillance_aggregate.yaml")))
 })
 
 test_that("eri_onboard_country writes a YAML file to path", {
@@ -24,12 +24,14 @@ test_that("eri_onboard_country writes a YAML file to path", {
   )
 
   out_path <- eri_onboard_country("uga", "Uganda", "oncho", path = tmp)
-  expect_equal(out_path, file.path(tmp, "uga_oncho_schema.yaml"))
+  expect_equal(out_path, file.path(tmp, "uga_oncho_surveillance_aggregate.yaml"))
   expect_true(file.exists(out_path))
 
   content <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
-  expect_match(content, "country: Uganda")
+  expect_match(content, "country: uga")
   expect_match(content, "disease: oncho")
+  expect_match(content, "data_source: surveillance")
+  expect_match(content, "data_type: aggregate")
   expect_match(content, "year_col")
   unlink(out_path)
 })
@@ -63,7 +65,7 @@ test_that("eri_onboard_country creates Azure directories", {
   expect_true("uga/oncho/surveillance/raw"       %in% created)
   expect_true("uga/oncho/surveillance/staged"    %in% created)
   expect_true("uga/oncho/surveillance/processed" %in% created)
-  unlink(file.path(tmp, "uga_oncho_schema.yaml"))
+  unlink(file.path(tmp, "uga_oncho_surveillance_aggregate.yaml"))
 })
 
 # --- eri_onboard_cmr ----------------------------------------------------------
@@ -231,8 +233,8 @@ test_that("eri_onboard_disease dry_run returns NULL without writing files", {
   tmp <- tempdir()
   result <- eri_onboard_disease("schisto", "ug", output_dir = tmp, dry_run = TRUE)
   expect_null(result)
-  expect_false(file.exists(file.path(tmp, "ug_schisto_mda.yaml")))
-  expect_false(file.exists(file.path(tmp, "ug_schisto_prevalence.yaml")))
+  expect_false(file.exists(file.path(tmp, "ug_schisto_programmatic_treatment.yaml")))
+  expect_false(file.exists(file.path(tmp, "ug_schisto_research_prevalence.yaml")))
 })
 
 test_that("eri_onboard_disease generates one file per data_type", {
@@ -240,8 +242,8 @@ test_that("eri_onboard_disease generates one file per data_type", {
   paths <- eri_onboard_disease("schisto", "ug", output_dir = tmp)
   expect_length(paths, 2L)
   expect_true(all(file.exists(paths)))
-  expect_true(any(grepl("mda", paths)))
-  expect_true(any(grepl("prevalence", paths)))
+  expect_true(any(grepl("programmatic_treatment", paths)))
+  expect_true(any(grepl("research_prevalence", paths)))
   unlink(paths)
 })
 

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -67,7 +67,7 @@ nothing. Always start here:
 ```{r dry-run}
 eri_onboard_country("atlantis", "Atlantis", "malaria", dry_run = TRUE)
 #> ℹ Dry run -- nothing will be written or created.
-#>   Would write: atlantis_malaria_schema.yaml
+#>   Would write: atlantis_malaria_surveillance_aggregate.yaml
 #>   Would create Azure directories:
 #>     atlantis/malaria/surveillance/raw
 #>     atlantis/malaria/surveillance/staged
@@ -84,13 +84,13 @@ are the **country code**, the **full country name**, and the **disease**:
 
 ```{r onboard-country}
 eri_onboard_country("atlantis", "Atlantis", "malaria")
-#> ✔ Schema template written to atlantis_malaria_schema.yaml.
+#> ✔ Schema template written to atlantis_malaria_surveillance_aggregate.yaml.
 #> ✔ Created 3 Azure directories.
 #> ℹ Next steps:
-#>   1. Open atlantis_malaria_schema.yaml and fill in the TODO sections.
-#>   2. Run eri_schema_validate('atlantis_malaria_schema.yaml') to check your edits.
+#>   1. Open atlantis_malaria_surveillance_aggregate.yaml and fill in the TODO sections.
+#>   2. Run eri_schema_validate('atlantis_malaria_surveillance_aggregate.yaml') to check your edits.
 #>   3. Submit the schema via a pull request to add it to the package:
-#>      inst/schemas/atlantis_malaria.yaml
+#>      inst/schemas/atlantis_malaria_surveillance_aggregate.yaml
 #>   4. Register any ODK forms with eri_odk_register().
 #>   5. Pin the package version in your project: renv::snapshot().
 ```
@@ -100,7 +100,7 @@ staged,processed}/` in the data blob.
 
 ### Fill in the template
 
-Open `atlantis_malaria_schema.yaml`. It is a **correct, structured starting point** — the standard
+Open `atlantis_malaria_surveillance_aggregate.yaml`. It is a **correct, structured starting point** — the standard
 sections are there, with `TODO` markers where your data is unique. Here it is **trimmed for
 readability** (your actual file also lists `aliases:` for each column and a few commented options like
 `time_grain` and `admin1_name_field`):
@@ -162,8 +162,8 @@ block, `consistency` rules — is exactly what the data-quality engine reads. Th
 temporal/consistency rules reference columns that actually exist. Run it on the file you just edited:
 
 ```{r validate-good}
-eri_schema_validate("atlantis_malaria_schema.yaml")
-#> ✔ Schema 'atlantis_malaria_schema.yaml' is valid.
+eri_schema_validate("atlantis_malaria_surveillance_aggregate.yaml")
+#> ✔ Schema 'atlantis_malaria_surveillance_aggregate.yaml' is valid.
 #> # A tibble: 0 × 3
 #> # ℹ 3 variables: issue_type <chr>, field <chr>, message <chr>
 ```
@@ -172,8 +172,8 @@ An **empty tibble means it's valid**. When something is off, you get a row per p
 finger two of the column types to `numbr`:
 
 ```{r validate-bad}
-eri_schema_validate("atlantis_malaria_schema.yaml")
-#> ⚠ 2 issues found in 'atlantis_malaria_schema.yaml':
+eri_schema_validate("atlantis_malaria_surveillance_aggregate.yaml")
+#> ⚠ 2 issues found in 'atlantis_malaria_surveillance_aggregate.yaml':
 #> ✖ Column 'Year' has invalid type 'numbr'. Valid: numeric, character, categorical, date.
 #> ✖ Column 'EpiWeek' has invalid type 'numbr'. Valid: numeric, character, categorical, date.
 
@@ -228,8 +228,8 @@ pattern needs — **MDA** (mass drug administration) and **prevalence**. Note th
 
 ```{r onboard-disease}
 eri_onboard_disease("schisto", "atlantis")
-#> ✔ Schema skeleton written to atlantis_schisto_mda.yaml.
-#> ✔ Schema skeleton written to atlantis_schisto_prevalence.yaml.
+#> ✔ Schema skeleton written to atlantis_schisto_programmatic_treatment.yaml.
+#> ✔ Schema skeleton written to atlantis_schisto_research_prevalence.yaml.
 #> ℹ Next steps:
 #>   1. Open each file and fill in the TODO sections.
 #>   2. Run eri_schema_validate('<path>') to check your edits.
@@ -268,8 +268,8 @@ con <- get_azure_storage_connection(storage_name = "data")
 eri_dir_delete("atlantis", azcontainer = con)
 
 # Remove the local schema templates.
-unlink(c("atlantis_malaria_schema.yaml", "atlantis_cmr_schema.yaml",
-         "atlantis_schisto_mda.yaml", "atlantis_schisto_prevalence.yaml"))
+unlink(c("atlantis_malaria_surveillance_aggregate.yaml", "atlantis_cmr_schema.yaml",
+         "atlantis_schisto_programmatic_treatment.yaml", "atlantis_schisto_research_prevalence.yaml"))
 ```
 
 > **Why deleting was fine here:** *Atlantis* is invented. **A real onboarded country is not torn down

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -106,8 +106,10 @@ readability** (your actual file also lists `aliases:` for each column and a few 
 `time_grain` and `admin1_name_field`):
 
 ```yaml
-country: Atlantis
+country: atlantis
 disease: malaria
+data_source: surveillance
+data_type: aggregate
 language: en
 
 admin:


### PR DESCRIPTION
Phase 4a: the onboarding scaffolders now generate schemas consistent with the migrated naming, so a freshly onboarded program drops straight into the new model (the review flagged that they still emitted the old `{country}_{disease}_{type}` names).

### What
- **`eri_onboard_disease()`** — `mda` → `{country}_{disease}_programmatic_treatment.yaml`, `prevalence` → `{country}_{disease}_research_prevalence.yaml`; the `.mda`/`.prevalence` templates now emit `data_source` + `data_type` header fields. (The user-facing `data_types = c("mda","prevalence")` kinds are unchanged.)
- **`eri_onboard_country()`** — `{country}_{disease}_surveillance_{data_type}.yaml`, with a new trailing `data_type = "aggregate"` argument (back-compat: existing positional callers unaffected). The surveillance template emits `data_source: surveillance` + `data_type:` and uses the country **code** in its `country:` field, matching the migrated bundled schemas.
- Tests + the **DA onboarding guide** `#>` outputs updated to the new filenames.

### Scope note
`eri_onboard_cmr()` is intentionally **not** changed here — it scaffolds the CMR *template parser* (`cmr/{cc}.yaml`, sheets/field-codes), a different artifact that belongs with the 3b CMR work. The `adding-a-program` / `epi-analytics` guides still teach old schema *names*, which keep resolving via the alias shim — those are the remaining Phase-4 docs sweep.

### Tests
`test-onboarding` updated (filenames + new `data_source`/`data_type` assertions); roxygen `@param data_type` added. `devtools::test()` → **FAIL 0 | PASS 1204**; guide knit-parses.