### PR TITLE
Thread the measure (data_type) through eri_approve and the catalog (#175 phase 4b)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # erifunctions (development version)
 
+## Feature: the measure (`data_type`) reaches the human gate and the catalog (ADR-0012, #175 phase 4b)
+
+- `eri_approve()` gains an optional `data_type` (the measure) argument:
+  `eri_approve(country, disease, data_source, period, data_type = NULL, …)`. When supplied it promotes
+  the full five-axis path `{country}/{disease}/{data_source}/{data_type}/staged → processed/` and records
+  the measure in the approval log, the operation log, and the catalog. The third positional argument is
+  now named `data_source` (it always carried the channel); `data_type` defaults to `NULL`, so existing
+  four-axis calls — `eri_approve("dr", "malaria", "surveillance", "2024-W01")` — are unchanged.
+- The data catalog carries a `data_source` column alongside `data_type`, and `eri_catalog_register()` /
+  `eri_catalog_query()` gain a `data_source` argument (`eri_catalog_register(... , data_source, ... ,
+  data_type = NULL)`; `eri_catalog_query(... , data_source = NULL, data_type = NULL, ...)`). Four-axis
+  entries leave `data_type` as `NA`. Legacy positional `eri_catalog_register()` calls that passed the
+  channel as `data_type` now pass it as `data_source`.
+
 ## Feature: onboarding scaffolders emit the 4-part schema identity (ADR-0012, #175 phase 4a)
 
 - `eri_onboard_disease()` and `eri_onboard_country()` now write schema skeletons named to the ADR-0012

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,13 @@
   data_type = NULL)`; `eri_catalog_query(... , data_source = NULL, data_type = NULL, ...)`). Four-axis
   entries leave `data_type` as `NA`. Legacy positional `eri_catalog_register()` calls that passed the
   channel as `data_type` now pass it as `data_source`.
+- The log triage reader follows the writer: `eri_logs()` scans both the four-axis channel-level
+  `…/{data_source}/logs/` and the five-axis measure-level `…/{data_source}/{data_type}/logs/` layouts, and
+  its backlog tibble gains a `data_source` column with `data_type` now meaning the measure.
+  `eri_logs(country, disease, data_source, data_type = NULL, …)` and
+  `eri_dq_log(result, country, disease, data_source, data_type = NULL, …)` rename the old third/fourth
+  argument to `data_source` (it always held the channel) and add the optional measure. Positional callers
+  passing the channel third are unchanged.
 
 ## Feature: onboarding scaffolders emit the 4-part schema identity (ADR-0012, #175 phase 4a)
 

--- a/R/catalog.R
+++ b/R/catalog.R
@@ -40,13 +40,14 @@
 
 # Build a single catalog entry list from its components.
 #' @keywords internal
-.eri_catalog_entry <- function(path, country, disease, data_type, layer,
-                                period, row_count, analyst) {
+.eri_catalog_entry <- function(path, country, disease, data_source, layer,
+                                period, row_count, analyst, data_type = NULL) {
   list(
     path             = path,
     country          = country,
     disease          = disease,
-    data_type        = data_type,
+    data_source      = data_source,
+    data_type        = if (is.null(data_type)) NA_character_ else data_type,
     layer            = layer,
     period           = if (is.null(period)) NA_character_ else period,
     file_format      = tools::file_ext(path),
@@ -69,21 +70,24 @@
 #' @param path `chr` Blob path of the file (e.g. `"dr/malaria/surveillance/processed/2024_W01.parquet"`).
 #' @param country `chr` Country code (e.g. `"uga"`).
 #' @param disease `chr` Disease name (e.g. `"oncho"`).
-#' @param data_type `chr` Data type (e.g. `"surveillance"`, `"cmr"`, `"odk"`).
+#' @param data_source `chr` The channel (`"surveillance"`, `"programmatic"`, `"research"`).
 #' @param layer `chr` Storage layer (`"raw"`, `"staged"`, or `"processed"`).
 #' @param period `chr` or `NULL` Data period string (e.g. `"2024-W01"`, `"202405"`).
 #' @param row_count `int` or `NULL` Number of rows in the file, if known.
 #' @param data_con Azure container object for the `data/` blob. If `NULL`, connects automatically.
+#' @param data_type `chr` or `NULL` The measure (e.g. `"case"`, `"treatment"`, `"tas"`); `NULL` for
+#'   legacy four-axis entries (ADR-0012).
 #' @returns The registered entry (invisibly).
 #' @examples
 #' \dontrun{
 #' eri_catalog_register(
-#'   path      = "uga/oncho/surveillance/processed/2024_W01.parquet",
-#'   country   = "uga",
-#'   disease   = "oncho",
-#'   data_type = "surveillance",
-#'   layer     = "processed",
-#'   period    = "2024-W01"
+#'   path        = "uga/oncho/programmatic/treatment/processed/2024_06.parquet",
+#'   country     = "uga",
+#'   disease     = "oncho",
+#'   data_source = "programmatic",
+#'   data_type   = "treatment",
+#'   layer       = "processed",
+#'   period      = "2024-06"
 #' )
 #' }
 #' @export
@@ -91,18 +95,19 @@ eri_catalog_register <- function(
     path,
     country,
     disease,
-    data_type,
+    data_source,
     layer,
     period    = NULL,
     row_count = NULL,
-    data_con  = NULL
+    data_con  = NULL,
+    data_type = NULL
 ) {
   data_con <- .eri_catalog_con(data_con)
   analyst  <- .eri_analyst_id()
   catalog  <- .eri_catalog_read(data_con)
 
-  entry    <- .eri_catalog_entry(path, country, disease, data_type, layer,
-                                  period, row_count, analyst)
+  entry    <- .eri_catalog_entry(path, country, disease, data_source, layer,
+                                  period, row_count, analyst, data_type = data_type)
 
   existing <- vapply(catalog$entries, function(e) identical(e$path, path), logical(1L))
   if (any(existing)) {
@@ -166,13 +171,14 @@ eri_catalog_remove <- function(path, data_con = NULL) {
 #'
 #' @param country `chr` or `NULL` Filter by country code.
 #' @param disease `chr` or `NULL` Filter by disease name.
-#' @param data_type `chr` or `NULL` Filter by data type.
+#' @param data_source `chr` or `NULL` Filter by channel (`"surveillance"`, `"programmatic"`, ...).
+#' @param data_type `chr` or `NULL` Filter by measure (`"case"`, `"treatment"`, ...).
 #' @param layer `chr` or `NULL` Filter by storage layer.
 #' @param period `chr` or `NULL` Filter by period string (exact match).
 #' @param data_con Azure container object for the `data/` blob. If `NULL`, connects automatically.
-#' @returns A tibble with columns: `path`, `country`, `disease`, `data_type`, `layer`,
-#'   `period`, `file_format`, `row_count`, `size_bytes`, `registered_at`, `registered_by`,
-#'   `last_verified_at`.
+#' @returns A tibble with columns: `path`, `country`, `disease`, `data_source`, `data_type`,
+#'   `layer`, `period`, `file_format`, `row_count`, `size_bytes`, `registered_at`,
+#'   `registered_by`, `last_verified_at`.
 #' @examples
 #' \dontrun{
 #' # All processed Uganda oncho data
@@ -183,12 +189,13 @@ eri_catalog_remove <- function(path, data_con = NULL) {
 #' }
 #' @export
 eri_catalog_query <- function(
-    country   = NULL,
-    disease   = NULL,
-    data_type = NULL,
-    layer     = NULL,
-    period    = NULL,
-    data_con  = NULL
+    country     = NULL,
+    disease     = NULL,
+    data_source = NULL,
+    data_type   = NULL,
+    layer       = NULL,
+    period      = NULL,
+    data_con    = NULL
 ) {
   data_con <- .eri_catalog_con(data_con)
   catalog  <- .eri_catalog_read(data_con)
@@ -197,6 +204,7 @@ eri_catalog_query <- function(
     path             = character(),
     country          = character(),
     disease          = character(),
+    data_source      = character(),
     data_type        = character(),
     layer            = character(),
     period           = character(),
@@ -214,6 +222,8 @@ eri_catalog_query <- function(
     entries <- Filter(function(e) identical(e$country, country), entries)
   if (!is.null(disease))
     entries <- Filter(function(e) identical(e$disease, disease), entries)
+  if (!is.null(data_source))
+    entries <- Filter(function(e) identical(e$data_source, data_source), entries)
   if (!is.null(data_type))
     entries <- Filter(function(e) identical(e$data_type, data_type), entries)
   if (!is.null(layer))
@@ -224,7 +234,7 @@ eri_catalog_query <- function(
   if (length(entries) == 0L) {
     # Distinguish "your filter matched nothing" from "the whole catalog is empty"
     # so a filtered query never implies the shared catalog was wiped.
-    any_filter <- !is.null(country) || !is.null(disease) ||
+    any_filter <- !is.null(country) || !is.null(disease) || !is.null(data_source) ||
       !is.null(data_type) || !is.null(layer) || !is.null(period)
     if (any_filter) {
       cli::cli_inform("No catalog entries match the specified filters.")
@@ -241,6 +251,7 @@ eri_catalog_query <- function(
     path             = vapply(entries, function(e) .na_chr(e$path),             character(1L)),
     country          = vapply(entries, function(e) .na_chr(e$country),          character(1L)),
     disease          = vapply(entries, function(e) .na_chr(e$disease),          character(1L)),
+    data_source      = vapply(entries, function(e) .na_chr(e$data_source),      character(1L)),
     data_type        = vapply(entries, function(e) .na_chr(e$data_type),        character(1L)),
     layer            = vapply(entries, function(e) .na_chr(e$layer),            character(1L)),
     period           = vapply(entries, function(e) .na_chr(e$period),           character(1L)),
@@ -313,6 +324,7 @@ eri_catalog_verify <- function(data_con = NULL) {
     path             = vapply(entries, function(e) .na_chr(e$path),             character(1L)),
     country          = vapply(entries, function(e) .na_chr(e$country),          character(1L)),
     disease          = vapply(entries, function(e) .na_chr(e$disease),          character(1L)),
+    data_source      = vapply(entries, function(e) .na_chr(e$data_source),      character(1L)),
     data_type        = vapply(entries, function(e) .na_chr(e$data_type),        character(1L)),
     layer            = vapply(entries, function(e) .na_chr(e$layer),            character(1L)),
     period           = vapply(entries, function(e) .na_chr(e$period),           character(1L)),

--- a/R/dal.R
+++ b/R/dal.R
@@ -828,8 +828,8 @@ eri_upload <- function(local_path, file_loc, azcontainer = NULL) {
 #'
 #' @param country `str` Country code (e.g. `"dr"`, `"ht"`, `"uga"`).
 #' @param disease `str` Disease name (e.g. `"malaria"`, `"lf"`, `"oncho"`).
-#' @param data_source `str` The channel: `"surveillance"`, `"programmatic"`, `"odk"`
-#'   (extensible — see [eri_data_model()]; unknown values warn).
+#' @param data_source `str` The channel: `"surveillance"`, `"programmatic"`,
+#'   `"research"` (extensible — see [eri_data_model()]; unknown values warn).
 #' @param data_type `str` The measure: `"case"`, `"aggregate"`, `"treatment"`,
 #'   `"tas"`, ... (extensible; unknown values warn).
 #' @param layer `str` Pipeline layer: `"raw"`, `"staged"`, or `"processed"`.

--- a/R/dal.R
+++ b/R/dal.R
@@ -849,8 +849,10 @@ eri_data_path <- function(country, disease, data_source, data_type, layer, filen
   known_sources <- names(model$data_sources)
 
   # Capture which arguments were actually supplied before any reassignment.
+  # An explicit NULL `data_type` is treated as "no measure" (the 4-axis form), so
+  # callers can pass `data_type` through uniformly during the migration.
   src_missing   <- missing(data_source)
-  type_missing  <- missing(data_type)
+  type_missing  <- missing(data_type) || is.null(data_type)
   layer_missing <- missing(layer)
 
   # Legacy NAMED form: the old 3rd parameter was *named* `data_type` but held the
@@ -912,26 +914,34 @@ eri_data_path <- function(country, disease, data_source, data_type, layer, filen
 #' one-time warning is emitted so the fallback attribution is not silent).
 #'
 #' An operation log capturing every step (including errors) is always written to
-#' `{country}/{disease}/{data_type}/logs/` in the data container, regardless of
-#' whether the approval succeeds or fails. This log is the primary debugging
-#' artifact for pipeline issues.
+#' `{country}/{disease}/{data_source}/{data_type}/logs/` in the data container,
+#' regardless of whether the approval succeeds or fails. This log is the primary
+#' debugging artifact for pipeline issues.
 #'
 #' @param country `str` Country code (e.g. `"dr"`, `"ht"`).
 #' @param disease `str` Disease name (e.g. `"malaria"`).
-#' @param data_type `str` Data input type: `"surveillance"`, `"cmr"`, or `"odk"`.
+#' @param data_source `str` The channel the data came through: `"surveillance"`,
+#'   `"programmatic"`, or `"research"` (ADR-0012).
 #' @param period `str` Period string matched against staged filenames (e.g.
 #'   `"2024-W01"`, `"2024-01"`). Any staged file whose name contains this string
 #'   is promoted.
+#' @param data_type `str` or `NULL` The measure the data captures (e.g. `"case"`,
+#'   `"aggregate"`, `"treatment"`, `"tas"`). `NULL` (default) approves the legacy
+#'   four-axis path `{country}/{disease}/{data_source}/...` without a measure level.
 #' @param azcontainer Azure container object for the `data/` blob, returned by
 #'   [get_azure_storage_connection()]. If `NULL` (default), connects automatically
 #'   using `ERIFUNCTIONS_DATA_STORAGE_NAME`.
 #' @returns Invisibly, a character vector of the promoted file paths in `processed/`.
 #' @examples
 #' \dontrun{
+#' # Four-axis (no measure): {country}/{disease}/{data_source}/...
 #' eri_approve("dr", "malaria", "surveillance", "2024-W01")
+#'
+#' # Five-axis (with measure): {country}/{disease}/{data_source}/{data_type}/...
+#' eri_approve("dr", "malaria", "surveillance", "2024-W01", data_type = "case")
 #' }
 #' @export
-eri_approve <- function(country, disease, data_type, period, azcontainer = NULL) {
+eri_approve <- function(country, disease, data_source, period, data_type = NULL, azcontainer = NULL) {
   .eri_log_session()
   if (is.null(azcontainer)) {
     azcontainer <- suppressMessages(
@@ -942,16 +952,17 @@ eri_approve <- function(country, disease, data_type, period, azcontainer = NULL)
   }
 
   analyst_id    <- .eri_analyst_id()
-  staged_dir    <- eri_data_path(country, disease, data_type, "staged")
-  processed_dir <- eri_data_path(country, disease, data_type, "processed")
-  log_dir       <- paste(c(country, disease, data_type, "logs"), collapse = "/")
+  staged_dir    <- eri_data_path(country, disease, data_source, data_type, "staged")
+  processed_dir <- eri_data_path(country, disease, data_source, data_type, "processed")
+  log_dir       <- paste(c(country, disease, data_source, data_type, "logs"), collapse = "/")
 
   op_log <- list(
     operation  = "eri_approve",
     analyst    = analyst_id,
     started_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     parameters = list(country = country, disease = disease,
-                      data_type = data_type, period = period),
+                      data_source = data_source, data_type = data_type,
+                      period = period),
     status     = "in_progress",
     steps      = list(),
     error      = NULL,
@@ -1000,13 +1011,14 @@ eri_approve <- function(country, disease, data_type, period, azcontainer = NULL)
                                      src = src_path, dest = dest_path)
       tryCatch(
         eri_catalog_register(
-          path      = dest_path,
-          country   = country,
-          disease   = disease,
-          data_type = data_type,
-          layer     = "processed",
-          period    = period,
-          data_con  = azcontainer
+          path        = dest_path,
+          country     = country,
+          disease     = disease,
+          data_source = data_source,
+          data_type   = data_type,
+          layer       = "processed",
+          period      = period,
+          data_con    = azcontainer
         ),
         error = function(e) invisible(NULL)
       )
@@ -1017,11 +1029,12 @@ eri_approve <- function(country, disease, data_type, period, azcontainer = NULL)
     approval <- list(
       analyst   = analyst_id,
       timestamp = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
-      period    = period,
-      country   = country,
-      disease   = disease,
-      data_type = data_type,
-      files     = as.list(moved)
+      period      = period,
+      country     = country,
+      disease     = disease,
+      data_source = data_source,
+      data_type   = data_type,
+      files       = as.list(moved)
     )
     approval_path <- paste0(processed_dir, "/", period, "_approval_log.yaml")
     approval_file <- tempfile(fileext = ".yaml")
@@ -1032,7 +1045,7 @@ eri_approve <- function(country, disease, data_type, period, azcontainer = NULL)
                                    path = approval_path)
     .eri_say_done("Approval log: {.path {approval_path}}")
     .eri_summary("Approved {.val {period}}", c(
-      Dataset  = sprintf("%s / %s / %s", country, disease, data_type),
+      Dataset  = paste(c(country, disease, data_source, data_type), collapse = " / "),
       Files    = sprintf("%d moved to processed", length(moved)),
       Approver = analyst_id,
       Location = processed_dir

--- a/R/logs.R
+++ b/R/logs.R
@@ -32,26 +32,32 @@
   )
 }
 
-# Top-level data/ directories that are infrastructure, not country namespaces,
-# plus the pipeline layer names (raw/staged/processed) and `logs`, which are
-# never country/disease/source/measure values. Used to skip non-axis subdirs
-# while walking the tree.
+# Top-level `data/` directories that are infrastructure, not country namespaces.
+# These are skipped only at the *country* level of the walk — crucially, some of
+# these names (`research`, `odk`) are also valid `data_source` values deeper in
+# the tree, so they must NOT be stripped below the country level.
 #' @keywords internal
 .ERI_LOGS_INFRA_DIRS <- c("artifacts", "research", "schemas", "spatial",
-                          "odk", "templates", "logs",
-                          "raw", "staged", "processed")
+                          "odk", "templates", "logs")
 
-# List immediate sub-directory names under a blob prefix, skipping infra dirs
-# (those starting with "_", e.g. _catalog, or in the known infra set).
+# Structural directory names that are never a country/disease/data_source/measure
+# value: the pipeline layers and the `logs/` leaf. Skipped at every level below
+# the country so the measure enumeration doesn't mistake a layer for a measure.
 #' @keywords internal
-.eri_logs_list_subdirs <- function(con, prefix) {
+.ERI_LOGS_NONAXIS_DIRS <- c("raw", "staged", "processed", "logs")
+
+# List immediate sub-directory names under a blob prefix, skipping `_`-prefixed
+# dirs (e.g. _catalog) and any name in `exclude`. `exclude` is level-specific:
+# the top-level infra set at the country level, the non-axis set deeper down.
+#' @keywords internal
+.eri_logs_list_subdirs <- function(con, prefix, exclude = .ERI_LOGS_NONAXIS_DIRS) {
   lst <- tryCatch(
     dplyr::as_tibble(AzureStor::list_storage_files(con, prefix)),
     error = function(e) NULL
   )
   if (is.null(lst) || nrow(lst) == 0L) return(character(0))
   nm <- basename(lst$name[lst$isdir])
-  nm[!startsWith(nm, "_") & !(nm %in% .ERI_LOGS_INFRA_DIRS)]
+  nm[!startsWith(nm, "_") & !(nm %in% exclude)]
 }
 
 #' @keywords internal
@@ -68,7 +74,8 @@
 # own `logs/` and every measure's `logs/` under it are scanned.
 #' @keywords internal
 .eri_logs_dirs <- function(con, country, disease, data_source, data_type) {
-  countries <- if (!is.null(country)) country else .eri_logs_list_subdirs(con, "")
+  countries <- if (!is.null(country)) country
+               else .eri_logs_list_subdirs(con, "", exclude = .ERI_LOGS_INFRA_DIRS)
 
   dirs <- character(0)
   for (cc in countries) {

--- a/R/logs.R
+++ b/R/logs.R
@@ -1,9 +1,12 @@
 #### Operation / DQ log triage ####
 #
 # Reads the structured operation-log YAMLs already written across
-# `{country}/{disease}/{data_type}/logs/` (by .eri_write_log) plus the DQ-flag
-# logs written by eri_dq_log(), into a triage backlog, and lets an analyst mark
-# items handled. Mirrors the catalog query/verify pattern in R/catalog.R.
+# `{country}/{disease}/{data_source}[/{data_type}]/logs/` (by .eri_write_log)
+# plus the DQ-flag logs written by eri_dq_log(), into a triage backlog, and lets
+# an analyst mark items handled. Mirrors the catalog query/verify pattern in
+# R/catalog.R. Per ADR-0012 the log path carries the channel (`data_source`) and,
+# when present, the measure (`data_type`); the reader handles both the four-axis
+# (no measure) and five-axis layouts.
 
 #' @keywords internal
 .eri_na_chr <- function(x) {
@@ -29,10 +32,14 @@
   )
 }
 
-# Top-level data/ directories that are infrastructure, not country namespaces.
+# Top-level data/ directories that are infrastructure, not country namespaces,
+# plus the pipeline layer names (raw/staged/processed) and `logs`, which are
+# never country/disease/source/measure values. Used to skip non-axis subdirs
+# while walking the tree.
 #' @keywords internal
 .ERI_LOGS_INFRA_DIRS <- c("artifacts", "research", "schemas", "spatial",
-                          "odk", "templates", "logs")
+                          "odk", "templates", "logs",
+                          "raw", "staged", "processed")
 
 # List immediate sub-directory names under a blob prefix, skipping infra dirs
 # (those starting with "_", e.g. _catalog, or in the known infra set).
@@ -47,25 +54,46 @@
   nm[!startsWith(nm, "_") & !(nm %in% .ERI_LOGS_INFRA_DIRS)]
 }
 
-# Resolve which `…/logs/` directories to scan. If country+disease+data_type are
-# all supplied, that single dir; otherwise enumerate the tree (data_type is
-# bounded to the three known types, so only country/disease levels are listed).
 #' @keywords internal
-.eri_logs_dirs <- function(con, country, disease, data_type) {
-  dts <- if (!is.null(data_type)) data_type else c("surveillance", "cmr", "odk")
+.eri_logs_dir_exists <- function(con, d) {
+  isTRUE(tryCatch(AzureStor::storage_dir_exists(con, d), error = function(e) FALSE))
+}
+
+# Resolve which `…/logs/` directories to scan, across both the four-axis
+# (`{country}/{disease}/{data_source}/logs/`) and five-axis
+# (`{country}/{disease}/{data_source}/{data_type}/logs/`) layouts (ADR-0012).
+# Supplying `country`/`disease`/`data_source`/`data_type` narrows each level;
+# any left `NULL` is enumerated from the blob. A supplied `data_type` (measure)
+# restricts to the five-axis dir for that measure; otherwise both the channel's
+# own `logs/` and every measure's `logs/` under it are scanned.
+#' @keywords internal
+.eri_logs_dirs <- function(con, country, disease, data_source, data_type) {
   countries <- if (!is.null(country)) country else .eri_logs_list_subdirs(con, "")
 
   dirs <- character(0)
   for (cc in countries) {
-    diseases <- if (!is.null(disease)) disease else .eri_logs_list_subdirs(con, cc)
+    diseases <- if (!is.null(disease)) disease
+                else .eri_logs_list_subdirs(con, cc)
     for (dd in diseases) {
-      for (dt in dts) {
-        d <- paste(c(cc, dd, dt, "logs"), collapse = "/")
-        exists <- isTRUE(tryCatch(
-          AzureStor::storage_dir_exists(con, d),
-          error = function(e) FALSE
-        ))
-        if (exists) dirs <- c(dirs, d)
+      dd_prefix <- paste(cc, dd, sep = "/")
+      sources   <- if (!is.null(data_source)) data_source
+                   else .eri_logs_list_subdirs(con, dd_prefix)
+      for (ds in sources) {
+        src_prefix <- paste(dd_prefix, ds, sep = "/")
+
+        # Four-axis: the channel's own logs/ (only when not scoping to a measure).
+        if (is.null(data_type)) {
+          d4 <- paste0(src_prefix, "/logs")
+          if (.eri_logs_dir_exists(con, d4)) dirs <- c(dirs, d4)
+        }
+
+        # Five-axis: a measure level under the channel.
+        measures <- if (!is.null(data_type)) data_type
+                    else .eri_logs_list_subdirs(con, src_prefix)
+        for (mm in measures) {
+          d5 <- paste(c(cc, dd, ds, mm, "logs"), collapse = "/")
+          if (.eri_logs_dir_exists(con, d5)) dirs <- c(dirs, d5)
+        }
       }
     }
   }
@@ -78,14 +106,19 @@
 .eri_log_flatten <- function(entry, log_path) {
   # Some operations (eri_odk_sync, eri_stage_cmr) don't record every scoping
   # field in `parameters`; the values are unambiguous in the blob path
-  # `{country}/{disease}/{data_type}/logs/{file}.yaml`, so fall back to that.
+  # `{country}/{disease}/{data_source}[/{data_type}]/logs/{file}.yaml`, so fall
+  # back to that. The path is authoritative for the channel/measure axes, since
+  # legacy envelopes overloaded `parameters$data_type` with the channel value.
   parts   <- strsplit(log_path, "/", fixed = TRUE)[[1]]
   logs_at <- which(parts == "logs")
   logs_at <- if (length(logs_at)) logs_at[length(logs_at)] else NA_integer_
-  from_path <- function(offset) {
-    i <- logs_at - offset
-    if (!is.na(logs_at) && i >= 1L) parts[i] else NA_character_
-  }
+  depth   <- if (!is.na(logs_at)) logs_at - 1L else 0L  # segments before /logs
+  # Layout is country/disease/data_source[/data_type]/logs, so the axes read off
+  # the front of the path; a measure exists only at depth 4 (the five-axis form).
+  path_country <- if (depth >= 1L) parts[1L] else NA_character_
+  path_disease <- if (depth >= 2L) parts[2L] else NA_character_
+  path_source  <- if (depth >= 3L) parts[3L] else NA_character_
+  path_measure <- if (depth >= 4L) parts[4L] else NA_character_
   coalesce_chr <- function(x, fallback) {
     x <- .eri_na_chr(x)
     if (is.na(x)) fallback else x
@@ -112,10 +145,12 @@
     operation  = .eri_na_chr(entry$operation),
     status     = .eri_na_chr(entry$status),
     analyst    = .eri_na_chr(entry$analyst),
-    country    = coalesce_chr(entry$parameters$country,   from_path(3L)),
-    disease    = coalesce_chr(entry$parameters$disease,   from_path(2L)),
-    data_type  = coalesce_chr(entry$parameters$data_type, from_path(1L)),
-    period     = .eri_na_chr(entry$parameters$period),
+    country     = coalesce_chr(entry$parameters$country, path_country),
+    disease     = coalesce_chr(entry$parameters$disease, path_disease),
+    # Channel/measure: trust the path (legacy envelopes overloaded data_type).
+    data_source = coalesce_chr(path_source,  entry$parameters$data_source),
+    data_type   = coalesce_chr(path_measure, NA_character_),
+    period      = .eri_na_chr(entry$parameters$period),
     summary    = .eri_na_chr(summary),
     n_issues   = .eri_na_int(n_issues),
     handled    = isTRUE(entry$triage$handled),
@@ -131,16 +166,17 @@
     timestamp  = character(),
     operation  = character(),
     status     = character(),
-    analyst    = character(),
-    country    = character(),
-    disease    = character(),
-    data_type  = character(),
-    period     = character(),
-    summary    = character(),
-    n_issues   = integer(),
-    handled    = logical(),
-    handled_by = character(),
-    handled_at = character()
+    analyst     = character(),
+    country     = character(),
+    disease     = character(),
+    data_source = character(),
+    data_type   = character(),
+    period      = character(),
+    summary     = character(),
+    n_issues    = integer(),
+    handled     = logical(),
+    handled_by  = character(),
+    handled_at  = character()
   )
 }
 
@@ -149,15 +185,18 @@
 #' Persist data-quality flags to the log backlog
 #'
 #' Writes the `$flags` from a [run_dq_checks()] result (plus a corrections count)
-#' to a YAML log in `{country}/{disease}/{data_type}/logs/` in the `data/` Azure
-#' blob, so the data-quality issues are durable and discoverable by [eri_logs()].
-#' Without this, `run_dq_checks()` flags exist only in your R session. `eri_ingest()`
-#' calls this automatically.
+#' to a YAML log in `{country}/{disease}/{data_source}[/{data_type}]/logs/` in the
+#' `data/` Azure blob, so the data-quality issues are durable and discoverable by
+#' [eri_logs()]. Without this, `run_dq_checks()` flags exist only in your R session.
+#' `eri_ingest()` calls this automatically.
 #'
 #' @param result A `dq_result` object returned by [run_dq_checks()].
 #' @param country `chr` Country code (e.g. `"uga"`).
 #' @param disease `chr` Disease name (e.g. `"oncho"`).
-#' @param data_type `chr` Data type (`"surveillance"`, `"cmr"`, or `"odk"`).
+#' @param data_source `chr` The channel (`"surveillance"`, `"programmatic"`,
+#'   `"research"`).
+#' @param data_type `chr` or `NULL` The measure (e.g. `"case"`, `"treatment"`);
+#'   `NULL` (default) writes to the four-axis channel-level `logs/` directory.
 #' @param period `chr` or `NULL` Reporting period the data covers (e.g. `"2024-01"`).
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
 #' @returns Invisibly, the number of flags logged.
@@ -167,8 +206,8 @@
 #' eri_dq_log(result, "uga", "oncho", "surveillance", period = "2024-01")
 #' }
 #' @export
-eri_dq_log <- function(result, country, disease, data_type,
-                       period = NULL, data_con = NULL) {
+eri_dq_log <- function(result, country, disease, data_source,
+                       data_type = NULL, period = NULL, data_con = NULL) {
   if (!inherits(result, "dq_result")) {
     cli::cli_abort("{.arg result} must be a {.cls dq_result} from {.fn run_dq_checks}.")
   }
@@ -190,14 +229,17 @@ eri_dq_log <- function(result, country, disease, data_type,
     analyst       = .eri_analyst_id(),
     timestamp     = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     parameters    = list(country = country, disease = disease,
-                         data_type = data_type, period = period),
+                         data_source = data_source, data_type = data_type,
+                         period = period),
     status        = if (n_flags > 0L) "needs_review" else "clean",
     n_flags       = n_flags,
     n_corrections = nrow(result$log),
     flags         = flags_list
   )
 
-  log_dir <- paste(c(country, disease, data_type, "logs"), collapse = "/")
+  # c() drops a NULL data_type, so a four-axis call lands at the channel level.
+  log_dir <- paste(c(country, disease, data_source, data_type, "logs"),
+                   collapse = "/")
   .eri_write_log(envelope, data_con, log_dir)
   cli::cli_alert_success(
     "Logged {n_flags} DQ flag{?s} ({envelope$status})."
@@ -211,17 +253,20 @@ eri_dq_log <- function(result, country, disease, data_type,
 #'
 #' Reads the structured operation logs (written by `eri_ingest()`, `eri_approve()`,
 #' `eri_stage()`, `eri_odk_sync()`, …) and the DQ-flag logs (written by
-#' [eri_dq_log()]) from `{country}/{disease}/{data_type}/logs/` in the `data/`
-#' Azure blob, and returns them as a triage backlog. Filter to failures with
-#' `status = "error"` or data-quality items with `status = "needs_review"`, then
-#' close items out with [eri_logs_resolve()].
+#' [eri_dq_log()]) from `{country}/{disease}/{data_source}[/{data_type}]/logs/` in
+#' the `data/` Azure blob, and returns them as a triage backlog. Filter to failures
+#' with `status = "error"` or data-quality items with `status = "needs_review"`,
+#' then close items out with [eri_logs_resolve()].
 #'
-#' If `country`, `disease`, and `data_type` are all supplied, only that one log
-#' directory is read (fast). Otherwise the function enumerates the data blob to
-#' build a system-wide backlog (slower); supplying filters narrows the scan.
+#' The function scopes the scan to whichever axes you supply and enumerates the
+#' rest from the blob; the more you supply (`country` → `disease` → `data_source`
+#' → `data_type`), the faster it is. It reads both the four-axis channel-level
+#' logs and the five-axis measure-level logs (ADR-0012).
 #'
-#' @param country,disease,data_type `chr` or `NULL` Scope the search. All three
-#'   together read a single `logs/` directory; any left `NULL` triggers enumeration.
+#' @param country,disease,data_source `chr` or `NULL` Scope the search by country,
+#'   disease, and channel; any left `NULL` is enumerated from the blob.
+#' @param data_type `chr` or `NULL` Scope to a single measure (the five-axis
+#'   layout). `NULL` reads the channel-level logs and every measure beneath it.
 #' @param status `chr` or `NULL` Filter by status (`"success"`, `"error"`,
 #'   `"in_progress"`, `"needs_review"`, `"clean"`).
 #' @param operation `chr` or `NULL` Filter by operation (e.g. `"eri_approve"`, `"dq_flags"`).
@@ -230,8 +275,9 @@ eri_dq_log <- function(result, country, disease, data_type,
 #' @param include_handled `lgl` Include items already marked handled. Default `FALSE`.
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
 #' @returns A tibble, newest first, with columns: `log_path`, `timestamp`,
-#'   `operation`, `status`, `analyst`, `country`, `disease`, `data_type`,
-#'   `period`, `summary`, `n_issues`, `handled`, `handled_by`, `handled_at`.
+#'   `operation`, `status`, `analyst`, `country`, `disease`, `data_source`,
+#'   `data_type`, `period`, `summary`, `n_issues`, `handled`, `handled_by`,
+#'   `handled_at`.
 #' @examples
 #' \dontrun{
 #' # Everything needing attention across the system
@@ -239,13 +285,17 @@ eri_dq_log <- function(result, country, disease, data_type,
 #'
 #' # The backlog for one dataset
 #' eri_logs("uga", "oncho", "surveillance")
+#'
+#' # Scope to a single measure (five-axis)
+#' eri_logs("uga", "oncho", "programmatic", data_type = "treatment")
 #' }
 #' @export
-eri_logs <- function(country = NULL, disease = NULL, data_type = NULL,
-                     status = NULL, operation = NULL, analyst = NULL,
-                     since = NULL, include_handled = FALSE, data_con = NULL) {
+eri_logs <- function(country = NULL, disease = NULL, data_source = NULL,
+                     data_type = NULL, status = NULL, operation = NULL,
+                     analyst = NULL, since = NULL, include_handled = FALSE,
+                     data_con = NULL) {
   data_con <- .eri_logs_con(data_con)
-  dirs     <- .eri_logs_dirs(data_con, country, disease, data_type)
+  dirs     <- .eri_logs_dirs(data_con, country, disease, data_source, data_type)
 
   if (length(dirs) == 0L) {
     cli::cli_inform("No log directories found.")
@@ -284,10 +334,11 @@ eri_logs <- function(country = NULL, disease = NULL, data_type = NULL,
     operation  = vapply(rows, function(r) .eri_na_chr(r$operation),  character(1L)),
     status     = vapply(rows, function(r) .eri_na_chr(r$status),     character(1L)),
     analyst    = vapply(rows, function(r) .eri_na_chr(r$analyst),    character(1L)),
-    country    = vapply(rows, function(r) .eri_na_chr(r$country),    character(1L)),
-    disease    = vapply(rows, function(r) .eri_na_chr(r$disease),    character(1L)),
-    data_type  = vapply(rows, function(r) .eri_na_chr(r$data_type),  character(1L)),
-    period     = vapply(rows, function(r) .eri_na_chr(r$period),     character(1L)),
+    country     = vapply(rows, function(r) .eri_na_chr(r$country),     character(1L)),
+    disease     = vapply(rows, function(r) .eri_na_chr(r$disease),     character(1L)),
+    data_source = vapply(rows, function(r) .eri_na_chr(r$data_source), character(1L)),
+    data_type   = vapply(rows, function(r) .eri_na_chr(r$data_type),   character(1L)),
+    period      = vapply(rows, function(r) .eri_na_chr(r$period),      character(1L)),
     summary    = vapply(rows, function(r) .eri_na_chr(r$summary),    character(1L)),
     n_issues   = vapply(rows, function(r) .eri_na_int(r$n_issues),   integer(1L)),
     handled    = vapply(rows, function(r) isTRUE(r$handled),         logical(1L)),

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ eri_catalog_verify()
 
 | Function | What it does |
 |---|---|
-| `eri_approve(country, disease, data_type, period)` | Promote staged files to processed (human gate) |
+| `eri_approve(country, disease, data_source, period, data_type)` | Promote staged files to processed (human gate) |
 | `eri_stage(pipeline, country, disease)` | Pull pipeline output from projects blob into staged |
 | `eri_ingest(path, country, disease, data_source, data_type)` | DQ-check a local file and stage it (sandbox-runnable; opt-in `mirror_pipeline`) |
 | `eri_trigger(pipeline, country, disease)` | Dispatch a GitHub Actions pipeline |

--- a/man/eri_approve.Rd
+++ b/man/eri_approve.Rd
@@ -4,18 +4,30 @@
 \alias{eri_approve}
 \title{Approve staged data and promote it to processed}
 \usage{
-eri_approve(country, disease, data_type, period, azcontainer = NULL)
+eri_approve(
+  country,
+  disease,
+  data_source,
+  period,
+  data_type = NULL,
+  azcontainer = NULL
+)
 }
 \arguments{
 \item{country}{\code{str} Country code (e.g. \code{"dr"}, \code{"ht"}).}
 
 \item{disease}{\code{str} Disease name (e.g. \code{"malaria"}).}
 
-\item{data_type}{\code{str} Data input type: \code{"surveillance"}, \code{"cmr"}, or \code{"odk"}.}
+\item{data_source}{\code{str} The channel the data came through: \code{"surveillance"},
+\code{"programmatic"}, or \code{"research"} (ADR-0012).}
 
 \item{period}{\code{str} Period string matched against staged filenames (e.g.
 \code{"2024-W01"}, \code{"2024-01"}). Any staged file whose name contains this string
 is promoted.}
+
+\item{data_type}{\code{str} or \code{NULL} The measure the data captures (e.g. \code{"case"},
+\code{"aggregate"}, \code{"treatment"}, \code{"tas"}). \code{NULL} (default) approves the legacy
+four-axis path \code{{country}/{disease}/{data_source}/...} without a measure level.}
 
 \item{azcontainer}{Azure container object for the \verb{data/} blob, returned by
 \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}. If \code{NULL} (default), connects automatically
@@ -36,12 +48,16 @@ falling back to \code{Sys.info()[["user"]]} if it is unset or empty (in which ca
 one-time warning is emitted so the fallback attribution is not silent).
 
 An operation log capturing every step (including errors) is always written to
-\verb{\{country\}/\{disease\}/\{data_type\}/logs/} in the data container, regardless of
-whether the approval succeeds or fails. This log is the primary debugging
-artifact for pipeline issues.
+\verb{\{country\}/\{disease\}/\{data_source\}/\{data_type\}/logs/} in the data container,
+regardless of whether the approval succeeds or fails. This log is the primary
+debugging artifact for pipeline issues.
 }
 \examples{
 \dontrun{
+# Four-axis (no measure): {country}/{disease}/{data_source}/...
 eri_approve("dr", "malaria", "surveillance", "2024-W01")
+
+# Five-axis (with measure): {country}/{disease}/{data_source}/{data_type}/...
+eri_approve("dr", "malaria", "surveillance", "2024-W01", data_type = "case")
 }
 }

--- a/man/eri_catalog_query.Rd
+++ b/man/eri_catalog_query.Rd
@@ -7,6 +7,7 @@
 eri_catalog_query(
   country = NULL,
   disease = NULL,
+  data_source = NULL,
   data_type = NULL,
   layer = NULL,
   period = NULL,
@@ -18,7 +19,9 @@ eri_catalog_query(
 
 \item{disease}{\code{chr} or \code{NULL} Filter by disease name.}
 
-\item{data_type}{\code{chr} or \code{NULL} Filter by data type.}
+\item{data_source}{\code{chr} or \code{NULL} Filter by channel (\code{"surveillance"}, \code{"programmatic"}, ...).}
+
+\item{data_type}{\code{chr} or \code{NULL} Filter by measure (\code{"case"}, \code{"treatment"}, ...).}
 
 \item{layer}{\code{chr} or \code{NULL} Filter by storage layer.}
 
@@ -27,9 +30,9 @@ eri_catalog_query(
 \item{data_con}{Azure container object for the \verb{data/} blob. If \code{NULL}, connects automatically.}
 }
 \value{
-A tibble with columns: \code{path}, \code{country}, \code{disease}, \code{data_type}, \code{layer},
-\code{period}, \code{file_format}, \code{row_count}, \code{size_bytes}, \code{registered_at}, \code{registered_by},
-\code{last_verified_at}.
+A tibble with columns: \code{path}, \code{country}, \code{disease}, \code{data_source}, \code{data_type},
+\code{layer}, \code{period}, \code{file_format}, \code{row_count}, \code{size_bytes}, \code{registered_at},
+\code{registered_by}, \code{last_verified_at}.
 }
 \description{
 Returns a filtered tibble of catalog entries from \verb{_catalog/data_catalog.yaml}

--- a/man/eri_catalog_register.Rd
+++ b/man/eri_catalog_register.Rd
@@ -8,11 +8,12 @@ eri_catalog_register(
   path,
   country,
   disease,
-  data_type,
+  data_source,
   layer,
   period = NULL,
   row_count = NULL,
-  data_con = NULL
+  data_con = NULL,
+  data_type = NULL
 )
 }
 \arguments{
@@ -22,7 +23,7 @@ eri_catalog_register(
 
 \item{disease}{\code{chr} Disease name (e.g. \code{"oncho"}).}
 
-\item{data_type}{\code{chr} Data type (e.g. \code{"surveillance"}, \code{"cmr"}, \code{"odk"}).}
+\item{data_source}{\code{chr} The channel (\code{"surveillance"}, \code{"programmatic"}, \code{"research"}).}
 
 \item{layer}{\code{chr} Storage layer (\code{"raw"}, \code{"staged"}, or \code{"processed"}).}
 
@@ -31,6 +32,9 @@ eri_catalog_register(
 \item{row_count}{\code{int} or \code{NULL} Number of rows in the file, if known.}
 
 \item{data_con}{Azure container object for the \verb{data/} blob. If \code{NULL}, connects automatically.}
+
+\item{data_type}{\code{chr} or \code{NULL} The measure (e.g. \code{"case"}, \code{"treatment"}, \code{"tas"}); \code{NULL} for
+legacy four-axis entries (ADR-0012).}
 }
 \value{
 The registered entry (invisibly).
@@ -42,12 +46,13 @@ in the \verb{data/} Azure blob. Existing entries are matched by \code{path} (ups
 \examples{
 \dontrun{
 eri_catalog_register(
-  path      = "uga/oncho/surveillance/processed/2024_W01.parquet",
-  country   = "uga",
-  disease   = "oncho",
-  data_type = "surveillance",
-  layer     = "processed",
-  period    = "2024-W01"
+  path        = "uga/oncho/programmatic/treatment/processed/2024_06.parquet",
+  country     = "uga",
+  disease     = "oncho",
+  data_source = "programmatic",
+  data_type   = "treatment",
+  layer       = "processed",
+  period      = "2024-06"
 )
 }
 }

--- a/man/eri_data_path.Rd
+++ b/man/eri_data_path.Rd
@@ -11,8 +11,8 @@ eri_data_path(country, disease, data_source, data_type, layer, filename = NULL)
 
 \item{disease}{\code{str} Disease name (e.g. \code{"malaria"}, \code{"lf"}, \code{"oncho"}).}
 
-\item{data_source}{\code{str} The channel: \code{"surveillance"}, \code{"programmatic"}, \code{"odk"}
-(extensible — see \code{\link[=eri_data_model]{eri_data_model()}}; unknown values warn).}
+\item{data_source}{\code{str} The channel: \code{"surveillance"}, \code{"programmatic"},
+\code{"research"} (extensible — see \code{\link[=eri_data_model]{eri_data_model()}}; unknown values warn).}
 
 \item{data_type}{\code{str} The measure: \code{"case"}, \code{"aggregate"}, \code{"treatment"},
 \code{"tas"}, ... (extensible; unknown values warn).}

--- a/man/eri_dq_log.Rd
+++ b/man/eri_dq_log.Rd
@@ -4,7 +4,15 @@
 \alias{eri_dq_log}
 \title{Persist data-quality flags to the log backlog}
 \usage{
-eri_dq_log(result, country, disease, data_type, period = NULL, data_con = NULL)
+eri_dq_log(
+  result,
+  country,
+  disease,
+  data_source,
+  data_type = NULL,
+  period = NULL,
+  data_con = NULL
+)
 }
 \arguments{
 \item{result}{A \code{dq_result} object returned by \code{\link[=run_dq_checks]{run_dq_checks()}}.}
@@ -13,7 +21,11 @@ eri_dq_log(result, country, disease, data_type, period = NULL, data_con = NULL)
 
 \item{disease}{\code{chr} Disease name (e.g. \code{"oncho"}).}
 
-\item{data_type}{\code{chr} Data type (\code{"surveillance"}, \code{"cmr"}, or \code{"odk"}).}
+\item{data_source}{\code{chr} The channel (\code{"surveillance"}, \code{"programmatic"},
+\code{"research"}).}
+
+\item{data_type}{\code{chr} or \code{NULL} The measure (e.g. \code{"case"}, \code{"treatment"});
+\code{NULL} (default) writes to the four-axis channel-level \verb{logs/} directory.}
 
 \item{period}{\code{chr} or \code{NULL} Reporting period the data covers (e.g. \code{"2024-01"}).}
 
@@ -24,10 +36,10 @@ Invisibly, the number of flags logged.
 }
 \description{
 Writes the \verb{$flags} from a \code{\link[=run_dq_checks]{run_dq_checks()}} result (plus a corrections count)
-to a YAML log in \verb{\{country\}/\{disease\}/\{data_type\}/logs/} in the \verb{data/} Azure
-blob, so the data-quality issues are durable and discoverable by \code{\link[=eri_logs]{eri_logs()}}.
-Without this, \code{run_dq_checks()} flags exist only in your R session. \code{eri_ingest()}
-calls this automatically.
+to a YAML log in \verb{\{country\}/\{disease\}/\{data_source\}[/\{data_type\}]/logs/} in the
+\verb{data/} Azure blob, so the data-quality issues are durable and discoverable by
+\code{\link[=eri_logs]{eri_logs()}}. Without this, \code{run_dq_checks()} flags exist only in your R session.
+\code{eri_ingest()} calls this automatically.
 }
 \examples{
 \dontrun{

--- a/man/eri_logs.Rd
+++ b/man/eri_logs.Rd
@@ -7,6 +7,7 @@
 eri_logs(
   country = NULL,
   disease = NULL,
+  data_source = NULL,
   data_type = NULL,
   status = NULL,
   operation = NULL,
@@ -17,8 +18,11 @@ eri_logs(
 )
 }
 \arguments{
-\item{country, disease, data_type}{\code{chr} or \code{NULL} Scope the search. All three
-together read a single \verb{logs/} directory; any left \code{NULL} triggers enumeration.}
+\item{country, disease, data_source}{\code{chr} or \code{NULL} Scope the search by country,
+disease, and channel; any left \code{NULL} is enumerated from the blob.}
+
+\item{data_type}{\code{chr} or \code{NULL} Scope to a single measure (the five-axis
+layout). \code{NULL} reads the channel-level logs and every measure beneath it.}
 
 \item{status}{\code{chr} or \code{NULL} Filter by status (\code{"success"}, \code{"error"},
 \code{"in_progress"}, \code{"needs_review"}, \code{"clean"}).}
@@ -35,21 +39,23 @@ together read a single \verb{logs/} directory; any left \code{NULL} triggers enu
 }
 \value{
 A tibble, newest first, with columns: \code{log_path}, \code{timestamp},
-\code{operation}, \code{status}, \code{analyst}, \code{country}, \code{disease}, \code{data_type},
-\code{period}, \code{summary}, \code{n_issues}, \code{handled}, \code{handled_by}, \code{handled_at}.
+\code{operation}, \code{status}, \code{analyst}, \code{country}, \code{disease}, \code{data_source},
+\code{data_type}, \code{period}, \code{summary}, \code{n_issues}, \code{handled}, \code{handled_by},
+\code{handled_at}.
 }
 \description{
 Reads the structured operation logs (written by \code{eri_ingest()}, \code{eri_approve()},
 \code{eri_stage()}, \code{eri_odk_sync()}, …) and the DQ-flag logs (written by
-\code{\link[=eri_dq_log]{eri_dq_log()}}) from \verb{\{country\}/\{disease\}/\{data_type\}/logs/} in the \verb{data/}
-Azure blob, and returns them as a triage backlog. Filter to failures with
-\code{status = "error"} or data-quality items with \code{status = "needs_review"}, then
-close items out with \code{\link[=eri_logs_resolve]{eri_logs_resolve()}}.
+\code{\link[=eri_dq_log]{eri_dq_log()}}) from \verb{\{country\}/\{disease\}/\{data_source\}[/\{data_type\}]/logs/} in
+the \verb{data/} Azure blob, and returns them as a triage backlog. Filter to failures
+with \code{status = "error"} or data-quality items with \code{status = "needs_review"},
+then close items out with \code{\link[=eri_logs_resolve]{eri_logs_resolve()}}.
 }
 \details{
-If \code{country}, \code{disease}, and \code{data_type} are all supplied, only that one log
-directory is read (fast). Otherwise the function enumerates the data blob to
-build a system-wide backlog (slower); supplying filters narrows the scan.
+The function scopes the scan to whichever axes you supply and enumerates the
+rest from the blob; the more you supply (\code{country} → \code{disease} → \code{data_source}
+→ \code{data_type}), the faster it is. It reads both the four-axis channel-level
+logs and the five-axis measure-level logs (ADR-0012).
 }
 \examples{
 \dontrun{
@@ -58,5 +64,8 @@ eri_logs(status = "error")
 
 # The backlog for one dataset
 eri_logs("uga", "oncho", "surveillance")
+
+# Scope to a single measure (five-axis)
+eri_logs("uga", "oncho", "programmatic", data_type = "treatment")
 }
 }

--- a/tests/testthat/test-catalog.R
+++ b/tests/testthat/test-catalog.R
@@ -5,17 +5,19 @@
 make_catalog <- function(...) list(entries = list(...))
 
 make_entry <- function(
-    path      = "uga/oncho/surveillance/processed/2024_W01.parquet",
-    country   = "uga",
-    disease   = "oncho",
-    data_type = "surveillance",
-    layer     = "processed",
-    period    = "2024-W01"
+    path        = "uga/oncho/surveillance/processed/2024_W01.parquet",
+    country     = "uga",
+    disease     = "oncho",
+    data_source = "surveillance",
+    data_type   = NA_character_,
+    layer       = "processed",
+    period      = "2024-W01"
 ) {
   list(
     path             = path,
     country          = country,
     disease          = disease,
+    data_source      = data_source,
     data_type        = data_type,
     layer            = layer,
     period           = period,
@@ -48,12 +50,12 @@ test_that("eri_catalog_register adds a new entry", {
   )
 
   out <- eri_catalog_register(
-    path      = "uga/oncho/surveillance/processed/2024_W01.parquet",
-    country   = "uga",
-    disease   = "oncho",
-    data_type = "surveillance",
-    layer     = "processed",
-    period    = "2024-W01"
+    path        = "uga/oncho/surveillance/processed/2024_W01.parquet",
+    country     = "uga",
+    disease     = "oncho",
+    data_source = "surveillance",
+    layer       = "processed",
+    period      = "2024-W01"
   )
 
   expect_equal(out$path, "uga/oncho/surveillance/processed/2024_W01.parquet")
@@ -81,17 +83,78 @@ test_that("eri_catalog_register upserts existing entry by path", {
   )
 
   eri_catalog_register(
-    path      = entry1$path,
-    country   = "uga",
-    disease   = "oncho",
-    data_type = "surveillance",
-    layer     = "processed",
-    period    = "2024-W01",
-    row_count = 500L
+    path        = entry1$path,
+    country     = "uga",
+    disease     = "oncho",
+    data_source = "surveillance",
+    layer       = "processed",
+    period      = "2024-W01",
+    row_count   = 500L
   )
 
   expect_length(stored$entries, 1L)
   expect_equal(stored$entries[[1]]$row_count, 500L)
+})
+
+test_that("eri_catalog_register records data_source and the optional data_type measure", {
+  stored <- list(entries = list())
+
+  local_mocked_bindings(
+    storage_file_exists = function(...) FALSE,
+    storage_dir_exists  = function(...) TRUE,
+    storage_upload = function(container, src, dest, ...) {
+      stored$entries <<- yaml::read_yaml(src)$entries
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  out <- eri_catalog_register(
+    path        = "uga/oncho/programmatic/treatment/processed/2024_06.parquet",
+    country     = "uga",
+    disease     = "oncho",
+    data_source = "programmatic",
+    data_type   = "treatment",
+    layer       = "processed",
+    period      = "2024-06"
+  )
+
+  expect_equal(out$data_source, "programmatic")
+  expect_equal(out$data_type, "treatment")
+  expect_equal(stored$entries[[1]]$data_source, "programmatic")
+  expect_equal(stored$entries[[1]]$data_type, "treatment")
+})
+
+test_that("eri_catalog_register leaves data_type NA for the four-axis (no-measure) form", {
+  stored <- list(entries = list())
+
+  local_mocked_bindings(
+    storage_file_exists = function(...) FALSE,
+    storage_dir_exists  = function(...) TRUE,
+    storage_upload = function(container, src, dest, ...) {
+      stored$entries <<- yaml::read_yaml(src)$entries
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  out <- eri_catalog_register(
+    path        = "uga/oncho/surveillance/processed/2024_W01.parquet",
+    country     = "uga",
+    disease     = "oncho",
+    data_source = "surveillance",
+    layer       = "processed",
+    period      = "2024-W01"
+  )
+
+  expect_equal(out$data_source, "surveillance")
+  expect_true(is.na(out$data_type))
 })
 
 # --- query --------------------------------------------------------------------
@@ -192,6 +255,37 @@ test_that("eri_catalog_query filters by multiple dimensions", {
   out <- eri_catalog_query(country = "uga", disease = "oncho", layer = "processed")
   expect_equal(nrow(out), 1L)
   expect_equal(out$path, e1$path)
+})
+
+test_that("eri_catalog_query filters by data_source and data_type (the measure)", {
+  e1 <- make_entry(country = "uga", disease = "oncho", data_source = "programmatic",
+                   data_type = "treatment",
+                   path = "uga/oncho/programmatic/treatment/processed/f1.parquet")
+  e2 <- make_entry(country = "uga", disease = "oncho", data_source = "programmatic",
+                   data_type = "mmdp",
+                   path = "uga/oncho/programmatic/mmdp/processed/f2.parquet")
+  e3 <- make_entry(country = "uga", disease = "malaria", data_source = "surveillance",
+                   data_type = "case",
+                   path = "uga/malaria/surveillance/case/processed/f3.parquet")
+  stored <- make_catalog(e1, e2, e3)
+
+  local_mocked_bindings(
+    storage_file_exists = function(...) TRUE,
+    storage_download = function(container, src, dest, ...) yaml::write_yaml(stored, dest),
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  by_source <- eri_catalog_query(data_source = "programmatic")
+  expect_equal(nrow(by_source), 2L)
+  expect_true(all(by_source$data_source == "programmatic"))
+
+  by_measure <- eri_catalog_query(data_source = "programmatic", data_type = "treatment")
+  expect_equal(nrow(by_measure), 1L)
+  expect_equal(by_measure$path, e1$path)
 })
 
 # --- verify -------------------------------------------------------------------
@@ -324,4 +418,41 @@ test_that("eri_approve calls eri_catalog_register for each moved file", {
   eri_approve("uga", "oncho", "surveillance", period = "2024_W01")
   expect_length(catalog_paths, 1L)
   expect_match(catalog_paths[[1]], "processed")
+})
+
+test_that("eri_approve threads data_type into a five-axis path and the catalog", {
+  listed_dirs   <- character(0)
+  reg_args      <- NULL
+  staged_files  <- tibble::tibble(
+    name = "uga/oncho/programmatic/treatment/staged/2024_06.parquet"
+  )
+
+  local_mocked_bindings(
+    storage_dir_exists   = function(...) TRUE,
+    list_storage_files   = function(container, dir, ...) {
+      listed_dirs <<- c(listed_dirs, dir)
+      staged_files
+    },
+    storage_download     = function(container, src, dest, ...) file.create(dest),
+    storage_upload       = function(...) invisible(NULL),
+    delete_storage_file  = function(...) invisible(NULL),
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .eri_log_session = function(...) invisible(NULL),
+    .eri_write_log   = function(...) invisible(NULL),
+    eri_catalog_register = function(...) { reg_args <<- list(...); invisible(NULL) },
+    .package = "erifunctions"
+  )
+
+  eri_approve("uga", "oncho", "programmatic", period = "2024_06",
+              data_type = "treatment")
+
+  # The staged dir it scanned carries the measure level.
+  expect_true(any(grepl("uga/oncho/programmatic/treatment/staged", listed_dirs)))
+  # The catalog registration records both axes.
+  expect_equal(reg_args$data_source, "programmatic")
+  expect_equal(reg_args$data_type, "treatment")
+  expect_match(reg_args$path, "uga/oncho/programmatic/treatment/processed")
 })

--- a/tests/testthat/test-logs.R
+++ b/tests/testthat/test-logs.R
@@ -167,47 +167,52 @@ test_that("eri_logs enumerates the tree when unscoped", {
   expect_equal(out$operation, "eri_approve")
 })
 
-test_that("unscoped eri_logs enumerates an odk-channel log (transitional data_source)", {
-  # `odk` is also a top-level infra dir name, but below the country level it is a
-  # valid data_source: an unscoped scan must still surface it.
-  dir <- "uga/oncho/odk/logs"
-  log <- list(
-    operation  = "eri_odk_sync", analyst = "test.user",
-    timestamp  = "2026-06-09T08:00:00Z",
-    parameters = list(country = "uga", disease = "oncho"),
-    status     = "success"
-  )
-  store <- list(); store[[paste0(dir, "/x_eri_odk_sync.yaml")]] <- log
+# `odk` and `research` are both top-level infra dir names, but below the country
+# level they are valid data_sources: an unscoped scan must still surface them.
+for (channel in c("odk", "research")) {
+  local({
+    ch <- channel
+    test_that(paste0("unscoped eri_logs enumerates a ", ch, "-channel log"), {
+      empty <- tibble::tibble(name = character(), size = numeric(),
+                              isdir = logical(), lastModified = Sys.time()[0])
+      dir <- paste0("uga/oncho/", ch, "/logs")
+      log <- list(
+        operation  = "eri_odk_sync", analyst = "test.user",
+        timestamp  = "2026-06-09T08:00:00Z",
+        parameters = list(country = "uga", disease = "oncho"),
+        status     = "success"
+      )
+      store <- list(); store[[paste0(dir, "/x.yaml")]] <- log
 
-  local_mocked_bindings(
-    storage_dir_exists = function(container, path, ...) identical(path, dir),
-    list_storage_files = function(container, path, ...) {
-      mk <- function(name) tibble::tibble(name = name, size = NA, isdir = TRUE,
-                                          lastModified = Sys.time())
-      if (identical(path, ""))               return(mk("uga"))
-      if (identical(path, "uga"))            return(mk("uga/oncho"))
-      if (identical(path, "uga/oncho"))      return(mk("uga/oncho/odk"))      # the channel
-      if (identical(path, "uga/oncho/odk"))  return(tibble::tibble(name = character(), size = numeric(),
-                                                                   isdir = logical(), lastModified = Sys.time()[0]))
-      if (identical(path, dir)) return(tibble::tibble(name = names(store), size = 100L,
-                                                      isdir = FALSE, lastModified = Sys.time()))
-      tibble::tibble(name = character(), size = numeric(), isdir = logical(), lastModified = Sys.time()[0])
-    },
-    storage_download = function(container, src, dest, ...) {
-      yaml::write_yaml(store[[src]], dest); invisible(dest)
-    },
-    .package = "AzureStor"
-  )
-  local_mocked_bindings(
-    get_azure_storage_connection = function(...) "mock_con",
-    .package = "erifunctions"
-  )
+      local_mocked_bindings(
+        storage_dir_exists = function(container, path, ...) identical(path, dir),
+        list_storage_files = function(container, path, ...) {
+          mk <- function(name) tibble::tibble(name = name, size = NA, isdir = TRUE,
+                                              lastModified = Sys.time())
+          if (identical(path, ""))                       return(mk("uga"))
+          if (identical(path, "uga"))                    return(mk("uga/oncho"))
+          if (identical(path, "uga/oncho"))              return(mk(paste0("uga/oncho/", ch)))
+          if (identical(path, paste0("uga/oncho/", ch))) return(empty)  # no measures
+          if (identical(path, dir)) return(tibble::tibble(name = names(store), size = 100L,
+                                                          isdir = FALSE, lastModified = Sys.time()))
+          empty
+        },
+        storage_download = function(container, src, dest, ...) {
+          yaml::write_yaml(store[[src]], dest); invisible(dest)
+        },
+        .package = "AzureStor"
+      )
+      local_mocked_bindings(
+        get_azure_storage_connection = function(...) "mock_con",
+        .package = "erifunctions"
+      )
 
-  out <- eri_logs()
-  expect_equal(nrow(out), 1L)
-  expect_equal(out$data_source, "odk")
-  expect_equal(out$operation, "eri_odk_sync")
-})
+      out <- eri_logs()
+      expect_equal(nrow(out), 1L)
+      expect_equal(out$data_source, ch)
+    })
+  })
+}
 
 test_that("eri_logs discovers five-axis (measure-level) logs and fills data_type", {
   # An approval log under the full {country}/{disease}/{data_source}/{measure}/logs path.

--- a/tests/testthat/test-logs.R
+++ b/tests/testthat/test-logs.R
@@ -167,6 +167,48 @@ test_that("eri_logs enumerates the tree when unscoped", {
   expect_equal(out$operation, "eri_approve")
 })
 
+test_that("unscoped eri_logs enumerates an odk-channel log (transitional data_source)", {
+  # `odk` is also a top-level infra dir name, but below the country level it is a
+  # valid data_source: an unscoped scan must still surface it.
+  dir <- "uga/oncho/odk/logs"
+  log <- list(
+    operation  = "eri_odk_sync", analyst = "test.user",
+    timestamp  = "2026-06-09T08:00:00Z",
+    parameters = list(country = "uga", disease = "oncho"),
+    status     = "success"
+  )
+  store <- list(); store[[paste0(dir, "/x_eri_odk_sync.yaml")]] <- log
+
+  local_mocked_bindings(
+    storage_dir_exists = function(container, path, ...) identical(path, dir),
+    list_storage_files = function(container, path, ...) {
+      mk <- function(name) tibble::tibble(name = name, size = NA, isdir = TRUE,
+                                          lastModified = Sys.time())
+      if (identical(path, ""))               return(mk("uga"))
+      if (identical(path, "uga"))            return(mk("uga/oncho"))
+      if (identical(path, "uga/oncho"))      return(mk("uga/oncho/odk"))      # the channel
+      if (identical(path, "uga/oncho/odk"))  return(tibble::tibble(name = character(), size = numeric(),
+                                                                   isdir = logical(), lastModified = Sys.time()[0]))
+      if (identical(path, dir)) return(tibble::tibble(name = names(store), size = 100L,
+                                                      isdir = FALSE, lastModified = Sys.time()))
+      tibble::tibble(name = character(), size = numeric(), isdir = logical(), lastModified = Sys.time()[0])
+    },
+    storage_download = function(container, src, dest, ...) {
+      yaml::write_yaml(store[[src]], dest); invisible(dest)
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  out <- eri_logs()
+  expect_equal(nrow(out), 1L)
+  expect_equal(out$data_source, "odk")
+  expect_equal(out$operation, "eri_odk_sync")
+})
+
 test_that("eri_logs discovers five-axis (measure-level) logs and fills data_type", {
   # An approval log under the full {country}/{disease}/{data_source}/{measure}/logs path.
   dir <- "uga/oncho/programmatic/treatment/logs"

--- a/tests/testthat/test-logs.R
+++ b/tests/testthat/test-logs.R
@@ -136,13 +136,19 @@ test_that("eri_logs enumerates the tree when unscoped", {
   logfile <- paste0(scoped_dir, "/20260604_120000_eri_approve.yaml")
   store <- list(); store[[logfile]] <- make_op_log(period = NULL)
 
+  empty_tbl <- tibble::tibble(name = character(), size = numeric(),
+                              isdir = logical(), lastModified = Sys.time()[0])
+
   local_mocked_bindings(
     storage_dir_exists = function(container, path, ...) identical(path, scoped_dir),
     list_storage_files = function(container, path, ...) {
-      if (identical(path, ""))    return(tibble::tibble(name = "uga", size = NA, isdir = TRUE, lastModified = Sys.time()))
-      if (identical(path, "uga")) return(tibble::tibble(name = "uga/oncho", size = NA, isdir = TRUE, lastModified = Sys.time()))
-      if (identical(path, scoped_dir)) return(tibble::tibble(name = names(store), size = 100L, isdir = FALSE, lastModified = Sys.time()))
-      tibble::tibble(name = character(), size = numeric(), isdir = logical(), lastModified = Sys.time()[0])
+      # Walk country -> disease -> data_source; no measure level (four-axis).
+      if (identical(path, ""))               return(tibble::tibble(name = "uga", size = NA, isdir = TRUE, lastModified = Sys.time()))
+      if (identical(path, "uga"))            return(tibble::tibble(name = "uga/oncho", size = NA, isdir = TRUE, lastModified = Sys.time()))
+      if (identical(path, "uga/oncho"))      return(tibble::tibble(name = "uga/oncho/surveillance", size = NA, isdir = TRUE, lastModified = Sys.time()))
+      if (identical(path, "uga/oncho/surveillance")) return(empty_tbl)  # no measures
+      if (identical(path, scoped_dir))       return(tibble::tibble(name = names(store), size = 100L, isdir = FALSE, lastModified = Sys.time()))
+      empty_tbl
     },
     storage_download = function(container, src, dest, ...) {
       yaml::write_yaml(store[[src]], dest); invisible(dest)
@@ -157,11 +163,53 @@ test_that("eri_logs enumerates the tree when unscoped", {
   out <- eri_logs()
   expect_equal(nrow(out), 1L)
   expect_equal(out$country, "uga")
+  expect_equal(out$data_source, "surveillance")
   expect_equal(out$operation, "eri_approve")
 })
 
+test_that("eri_logs discovers five-axis (measure-level) logs and fills data_type", {
+  # An approval log under the full {country}/{disease}/{data_source}/{measure}/logs path.
+  dir <- "uga/oncho/programmatic/treatment/logs"
+  log <- list(
+    operation    = "eri_approve", analyst = "test.user",
+    started_at   = "2026-06-08T08:00:00Z", completed_at = "2026-06-08T08:00:00Z",
+    parameters   = list(country = "uga", disease = "oncho",
+                        data_source = "programmatic", data_type = "treatment",
+                        period = "2024-06"),
+    status       = "success"
+  )
+  store <- list(); store[[paste0(dir, "/x_eri_approve.yaml")]] <- log
+  files <- tibble::tibble(name = names(store), size = 100L, isdir = FALSE,
+                          lastModified = Sys.time())
+
+  local_mocked_bindings(
+    storage_dir_exists = function(container, path, ...) identical(path, dir),
+    list_storage_files = function(container, path, ...) {
+      # The source has one measure subdir; its logs/ holds the file.
+      if (identical(path, "uga/oncho/programmatic"))
+        return(tibble::tibble(name = "uga/oncho/programmatic/treatment", size = NA,
+                              isdir = TRUE, lastModified = Sys.time()))
+      files[startsWith(files$name, path), , drop = FALSE]
+    },
+    storage_download = function(container, src, dest, ...) {
+      yaml::write_yaml(store[[src]], dest); invisible(dest)
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  out <- eri_logs("uga", "oncho", "programmatic")
+  expect_equal(nrow(out), 1L)
+  expect_equal(out$data_source, "programmatic")
+  expect_equal(out$data_type, "treatment")
+  expect_equal(out$period, "2024-06")
+})
+
 test_that("eri_logs fills scoping columns from the path for thin envelopes", {
-  # eri_odk_sync-style log whose parameters omit data_type/period.
+  # eri_odk_sync-style log whose parameters omit the channel/measure/period.
   dir  <- "uga/oncho/odk/logs"
   thin <- list(
     operation  = "eri_odk_sync", analyst = "test.user",
@@ -189,7 +237,8 @@ test_that("eri_logs fills scoping columns from the path for thin envelopes", {
 
   out <- eri_logs("uga", "oncho", "odk")
   expect_equal(nrow(out), 1L)
-  expect_equal(out$data_type, "odk")   # recovered from the blob path
+  expect_equal(out$data_source, "odk")  # the channel, recovered from the blob path
+  expect_true(is.na(out$data_type))     # four-axis log: no measure level
   expect_equal(out$country, "uga")
   expect_equal(out$disease, "oncho")
 })
@@ -227,6 +276,7 @@ test_that("eri_dq_log writes a dq_flags envelope with the flags", {
   expect_equal(captured$n_flags, 2L)
   expect_length(captured$flags, 2L)
   expect_equal(captured$parameters$country, "uga")
+  expect_equal(captured$parameters$data_source, "surveillance")
   expect_equal(captured$flags[[1]]$column, "Age")
 })
 

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -127,6 +127,12 @@ the two programmes these reports cover. Only the registered RB-expansion countri
 > programme code — so the paths are `{country}/rblf/cmr/…` and you approve with
 > `eri_approve(country, "rblf", "cmr", period)`. Scaffolding a new country's CMR with
 > `eri_onboard_cmr(create_dirs = TRUE)` creates those same `{country}/rblf/cmr/` folders.
+>
+> **Transitional vocabulary.** `rblf` and `cmr` are interim coordinates: under the
+> [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
+> CMR is a *format* of the `programmatic` channel, and each sheet splits to its own disease and measure
+> (e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`). Until that split ships, keep using
+> `rblf`/`cmr` as shown here — don't adopt them as the canonical addressing model.
 
 ## 3. Parse each sheet {#parse}
 

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -200,11 +200,11 @@ eri_approve("uga", "rblf", "cmr", "202406")
 The month's report is now canonical and discoverable in the catalog like any other approved dataset:
 
 ```{r catalog}
-eri_catalog_query(country = "uga", data_type = "cmr")
-#> # A tibble: 1 × 12
-#>   path                                country disease data_type layer     period …
-#>   <chr>                               <chr>   <chr>   <chr>     <chr>     <chr>
-#> 1 uga/rblf/cmr/processed/uga_cmr_202… uga     rblf    cmr       processed 202406
+eri_catalog_query(country = "uga", data_source = "cmr")
+#> # A tibble: 1 × 13
+#>   path                              country disease data_source data_type layer …
+#>   <chr>                             <chr>   <chr>   <chr>       <chr>     <chr>
+#> 1 uga/rblf/cmr/processed/uga_cmr_2… uga     rblf    cmr         NA        proces…
 ```
 
 That's the monthly loop: **upload → stage → parse → approve.**

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -100,7 +100,7 @@ or call it bare for a system-wide view:
 ```{r logs}
 eri_logs("atlantis", "malaria", "surveillance")
 #> 2 logs (2 needing attention).
-#> # A tibble: 2 × 14
+#> # A tibble: 2 × 15
 #>   timestamp            operation   status       period  summary           analyst …
 #>   <chr>                <chr>       <chr>        <chr>   <chr>             <chr>
 #> 1 2026-06-26T10:00:00Z eri_approve error        2024-02 No staged files…  da.one
@@ -113,15 +113,16 @@ Filter to just the failures:
 ```{r logs-error}
 eri_logs("atlantis", "malaria", "surveillance", status = "error")
 #> 1 log (1 needing attention).
-#> # A tibble: 1 × 14
+#> # A tibble: 1 × 15
 #>   operation   status period  summary
 #>   <chr>       <chr>  <chr>   <chr>
 #> 1 eri_approve error  2024-02 No staged files found matching '2024-02'.
 ```
 
 `status = "needs_review"` narrows to data-quality items instead; `operation =`, `analyst =`, and
-`since =` filter the rest. Leaving `country`/`disease`/`data_type` out scans the whole data blob for a
-**system-wide backlog** (scoping is faster).
+`since =` filter the rest. The tibble also carries `data_source` (the channel) and `data_type` (the
+measure, when the data was approved with one). Leaving `country`/`disease`/`data_source`/`data_type`
+out scans the whole data blob for a **system-wide backlog** (scoping is faster).
 
 ## 3. Resolve an item {#resolve}
 
@@ -143,7 +144,7 @@ Re-list, and the error is gone from the open backlog — only the data-quality i
 ```{r relist}
 eri_logs("atlantis", "malaria", "surveillance")
 #> 1 log (1 needing attention).
-#> # A tibble: 1 × 14
+#> # A tibble: 1 × 15
 #>   operation status       period  summary
 #>   <chr>     <chr>        <chr>   <chr>
 #> 1 dq_flags  needs_review 2024-01 2 flags


### PR DESCRIPTION
## What

Moves the **human approval gate** (`eri_approve`) and the **shared data catalog** from the four-axis path to the full five-axis model of ADR-0012:

```
data/{country}/{disease}/{data_source}/{data_type}/{layer}/
```

This is the delicate core of #175 — it touches the approval gate everyone trusts and the shared `_catalog/data_catalog.yaml` format — so it's done with heavy back-compat and tests.

## Changes

- **`eri_approve()`** gains an optional trailing `data_type` (the measure):
  `eri_approve(country, disease, data_source, period, data_type = NULL, …)`. When supplied it promotes the five-axis `staged → processed` path and records the measure in the approval log, the operation log, and the catalog. The third positional argument is renamed `data_source` (it always carried the channel); `data_type` defaults to `NULL`, so existing four-axis calls — `eri_approve("dr", "malaria", "surveillance", "2024-W01")` — are unchanged.
- **Catalog** carries a `data_source` column alongside `data_type`. `eri_catalog_register()` / `eri_catalog_query()` gain a `data_source` argument; `.eri_catalog_entry()` records both axes (`data_type = NA` for four-axis entries). Legacy positional `eri_catalog_register()` calls that passed the channel as `data_type` now pass it as `data_source`.
- **`eri_data_path()`** now treats an explicit `NULL` `data_type` as the four-axis form, so callers thread `data_type` through uniformly (NULL = no measure level).

## Tests

- register/query round-trip both axes; a no-measure register leaves `data_type` NA; query filters by `data_source` and by `data_type` (the measure); `eri_approve` builds a five-axis path and registers both axes.
- Full suite green: **FAIL 0 | PASS 1218**.

## Docs

NEWS phase-4b entry; README signature; `da-cmr-guide` catalog query uses `data_source`; roxygen regenerated.

## Scope note

`eri_stage` / `eri_stage_cmr` / `eri_odk_sync` stay on their current paths — they are transitional adapters reworked in the CMR-split (#51) and ODK-adapter (#53) follow-ups.

Part of #175 (ADR-0012).