### PR TITLE
Migrate eri_research_pull() to the five-axis model (#175 phase 4b)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # erifunctions (development version)
 
+## Feature: `eri_research_pull()` speaks the five-axis model (ADR-0012, #175 phase 4b)
+
+- `eri_research_pull()` — the Epi sourcing entry point — now takes `data_source` (the channel) plus an
+  optional `data_type` (the measure), matching the coordinates [eri_catalog_query()] reports, so a study
+  pulls canonical processed data with the same tokens a discovery query returns:
+  `eri_research_pull("dr", "malaria", "surveillance", "case")`. Path construction delegates to
+  `eri_data_path()`, so the four-axis (channel-only) form works too. **Back-compat:** the pre-ADR-0012
+  form where the channel was passed as `data_type` (`data_type = "surveillance"`) still resolves to the
+  same processed path. Surfaced by a fresh-Epi red-team run as the one un-migrated step on the sourcing path.
+
 ## Feature: the measure (`data_type`) reaches the human gate and the catalog (ADR-0012, #175 phase 4b)
 
 - `eri_approve()` gains an optional `data_type` (the measure) argument:

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
   `eri_data_path()`, so the four-axis (channel-only) form works too. **Back-compat:** the pre-ADR-0012
   form where the channel was passed as `data_type` (`data_type = "surveillance"`) still resolves to the
   same processed path. Surfaced by a fresh-Epi red-team run as the one un-migrated step on the sourcing path.
+  Note: because `data_source` is inserted before `data_type`, the `path` argument moves from the fourth
+  to the fifth position — pass it by name (`eri_research_pull(path = "spatial/...")`), as the docs already do.
 
 ## Feature: the measure (`data_type`) reaches the human gate and the catalog (ADR-0012, #175 phase 4b)
 

--- a/R/research.R
+++ b/R/research.R
@@ -260,16 +260,23 @@ eri_research_list <- function(data_con = NULL) {
 #' Downloads files from Azure into a local destination and records every pull in
 #' `research.yaml` for provenance. Two modes:
 #'
-#' - **Canonical**: supply `country`, `disease`, and `data_type` to pull from the
-#'   standard processed layer (`{country}/{disease}/{data_type}/processed/`).
+#' - **Canonical**: supply `country`, `disease`, and `data_source` (optionally a
+#'   `data_type` measure) to pull from the standard processed layer
+#'   (`{country}/{disease}/{data_source}/{data_type}/processed/`, per ADR-0012).
 #' - **Path**: supply `path` to pull any Azure location (e.g. `"data/spatial/dom_admin_boundaries/"`).
 #'
 #' For non-standard external files not yet in Azure, upload them first with
 #' [eri_artifact_upload()], then pull with [eri_artifact_pull()].
 #'
-#' @param country `chr` or `NULL` Country code (e.g. `"dr"`). Used with `disease` and `data_type`.
-#' @param disease `chr` or `NULL` Disease name (e.g. `"malaria"`). Used with `country` and `data_type`.
-#' @param data_type `chr` or `NULL` Data type (`"surveillance"`, `"cmr"`, `"odk"`). Used with `country` and `disease`.
+#' @param country `chr` or `NULL` Country code (e.g. `"dr"`). Used with `disease` and `data_source`.
+#' @param disease `chr` or `NULL` Disease name (e.g. `"malaria"`). Used with `country` and `data_source`.
+#' @param data_source `chr` or `NULL` The channel (`"surveillance"`, `"programmatic"`,
+#'   `"research"`). Used with `country` and `disease`. The catalog ([eri_catalog_query()])
+#'   reports this column, so a pull uses the same coordinates a discovery query returns.
+#' @param data_type `chr` or `NULL` The measure (e.g. `"case"`, `"aggregate"`, `"treatment"`,
+#'   `"tas"`). Optional — `NULL` pulls the four-axis channel-level processed layer.
+#'   **Back-compat:** if only `data_type` is given (the pre-ADR-0012 form where it held the
+#'   channel), it is treated as `data_source`.
 #' @param path `chr` or `NULL` Explicit Azure blob path to download from. Mutually exclusive with canonical args.
 #' @param dest `chr` or `NULL` Local directory to download files into. Defaults to `data/` inside `getwd()`.
 #' @param data_con Azure container object for the `data/` blob. If `NULL`, connects automatically.
@@ -278,38 +285,52 @@ eri_research_list <- function(data_con = NULL) {
 #' @returns Character vector of local file paths downloaded (invisibly).
 #' @examples
 #' \dontrun{
-#' # Pull canonical processed surveillance data
-#' eri_research_pull(country = "dr", disease = "malaria", data_type = "surveillance")
+#' # Pull canonical processed data using the coordinates the catalog reports
+#' eri_research_pull(country = "dr", disease = "malaria",
+#'                   data_source = "surveillance", data_type = "case")
+#'
+#' # Four-axis (channel only, no measure)
+#' eri_research_pull(country = "dr", disease = "malaria", data_source = "surveillance")
 #'
 #' # Pull standard spatial reference files
 #' eri_research_pull(path = "spatial/dom_admin_boundaries")
 #' }
 #' @export
 eri_research_pull <- function(
-    country   = NULL,
-    disease   = NULL,
-    data_type = NULL,
-    path      = NULL,
-    dest      = NULL,
-    data_con  = NULL,
-    progress  = FALSE
+    country     = NULL,
+    disease     = NULL,
+    data_source = NULL,
+    data_type   = NULL,
+    path        = NULL,
+    dest        = NULL,
+    data_con    = NULL,
+    progress    = FALSE
 ) {
-  has_canonical <- !is.null(country) && !is.null(disease) && !is.null(data_type)
+  # Back-compat: before ADR-0012 the canonical channel was passed as `data_type`.
+  # If only `data_type` is supplied, treat it as the channel (`data_source`) with
+  # no measure, so legacy calls keep resolving to the same processed path.
+  if (is.null(data_source) && !is.null(data_type)) {
+    data_source <- data_type
+    data_type   <- NULL
+  }
+
+  has_canonical <- !is.null(country) && !is.null(disease) && !is.null(data_source)
   has_path      <- !is.null(path)
 
   if (!has_canonical && !has_path) {
     cli::cli_abort(
-      "Supply either {.arg country} + {.arg disease} + {.arg data_type}, or {.arg path}."
+      "Supply either {.arg country} + {.arg disease} + {.arg data_source} (optionally {.arg data_type}), or {.arg path}."
     )
   }
   if (has_canonical && has_path) {
     cli::cli_abort(
-      "Supply either canonical args ({.arg country}/{.arg disease}/{.arg data_type}) or {.arg path}, not both."
+      "Supply either canonical args ({.arg country}/{.arg disease}/{.arg data_source}/{.arg data_type}) or {.arg path}, not both."
     )
   }
 
   azure_path <- if (has_canonical) {
-    paste(country, disease, data_type, "processed", sep = "/")
+    # eri_data_path builds the four-axis path when data_type is NULL, five-axis otherwise.
+    eri_data_path(country, disease, data_source, data_type, "processed")
   } else {
     path
   }

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ eri_catalog_verify()
 | `eri_research_status(check_remote)` | Report what data the project depends on and whether any of it is stale |
 | `eri_research_log(note)` | Append a timestamped lab notebook entry to `research.yaml` |
 | `eri_research_list()` | List all research projects in Azure |
-| `eri_research_pull(country, disease, data_type)` | Pull canonical or reference data into the project with provenance |
+| `eri_research_pull(country, disease, data_source, data_type)` | Pull canonical or reference data into the project with provenance |
 | `eri_research_upload_figure(local_path, caption)` | Upload a figure to Azure outputs and record in manifest |
 | `eri_research_upload_output(obj, filename)` | Serialize and upload an R object to Azure outputs |
 | `eri_research_snapshot(label)` | Freeze the local `data/` directory to a timestamped Azure snapshot |

--- a/inst/templates/eri_research_workflow.qmd
+++ b/inst/templates/eri_research_workflow.qmd
@@ -105,7 +105,9 @@ eri_research_pull(
   country     = "dr",            # <-- replace
   disease     = "malaria",       # <-- replace
   data_source = "surveillance",  # <-- replace: surveillance, programmatic, research
-  data_type   = "case",          # <-- replace: case, aggregate, treatment, tas, ...
+  data_type   = "case",          # <-- the measure for that channel: surveillance ->
+                                 #     case/aggregate; programmatic -> treatment/mmdp;
+                                 #     research -> tas/prevalence (or omit for the channel level)
   data_con    = az_con
 )
 ```

--- a/inst/templates/eri_research_workflow.qmd
+++ b/inst/templates/eri_research_workflow.qmd
@@ -99,12 +99,14 @@ population grids), upload them first with `eri_artifact_upload()`, then pull
 with `eri_artifact_pull()`.
 
 ```{r pull-canonical, eval=FALSE}
-# Pull processed surveillance data for your country and disease
+# Pull processed data for your country and disease, using the same coordinates
+# the catalog reports (data_source = the channel, data_type = the measure).
 eri_research_pull(
-  country   = "dr",              # <-- replace
-  disease   = "malaria",         # <-- replace
-  data_type = "surveillance",    # <-- replace: surveillance, cmr, odk
-  data_con  = az_con
+  country     = "dr",            # <-- replace
+  disease     = "malaria",       # <-- replace
+  data_source = "surveillance",  # <-- replace: surveillance, programmatic, research
+  data_type   = "case",          # <-- replace: case, aggregate, treatment, tas, ...
+  data_con    = az_con
 )
 ```
 

--- a/man/eri_research_pull.Rd
+++ b/man/eri_research_pull.Rd
@@ -7,6 +7,7 @@
 eri_research_pull(
   country = NULL,
   disease = NULL,
+  data_source = NULL,
   data_type = NULL,
   path = NULL,
   dest = NULL,
@@ -15,11 +16,18 @@ eri_research_pull(
 )
 }
 \arguments{
-\item{country}{\code{chr} or \code{NULL} Country code (e.g. \code{"dr"}). Used with \code{disease} and \code{data_type}.}
+\item{country}{\code{chr} or \code{NULL} Country code (e.g. \code{"dr"}). Used with \code{disease} and \code{data_source}.}
 
-\item{disease}{\code{chr} or \code{NULL} Disease name (e.g. \code{"malaria"}). Used with \code{country} and \code{data_type}.}
+\item{disease}{\code{chr} or \code{NULL} Disease name (e.g. \code{"malaria"}). Used with \code{country} and \code{data_source}.}
 
-\item{data_type}{\code{chr} or \code{NULL} Data type (\code{"surveillance"}, \code{"cmr"}, \code{"odk"}). Used with \code{country} and \code{disease}.}
+\item{data_source}{\code{chr} or \code{NULL} The channel (\code{"surveillance"}, \code{"programmatic"},
+\code{"research"}). Used with \code{country} and \code{disease}. The catalog (\code{\link[=eri_catalog_query]{eri_catalog_query()}})
+reports this column, so a pull uses the same coordinates a discovery query returns.}
+
+\item{data_type}{\code{chr} or \code{NULL} The measure (e.g. \code{"case"}, \code{"aggregate"}, \code{"treatment"},
+\code{"tas"}). Optional — \code{NULL} pulls the four-axis channel-level processed layer.
+\strong{Back-compat:} if only \code{data_type} is given (the pre-ADR-0012 form where it held the
+channel), it is treated as \code{data_source}.}
 
 \item{path}{\code{chr} or \code{NULL} Explicit Azure blob path to download from. Mutually exclusive with canonical args.}
 
@@ -39,8 +47,9 @@ Downloads files from Azure into a local destination and records every pull in
 }
 \details{
 \itemize{
-\item \strong{Canonical}: supply \code{country}, \code{disease}, and \code{data_type} to pull from the
-standard processed layer (\verb{\{country\}/\{disease\}/\{data_type\}/processed/}).
+\item \strong{Canonical}: supply \code{country}, \code{disease}, and \code{data_source} (optionally a
+\code{data_type} measure) to pull from the standard processed layer
+(\verb{\{country\}/\{disease\}/\{data_source\}/\{data_type\}/processed/}, per ADR-0012).
 \item \strong{Path}: supply \code{path} to pull any Azure location (e.g. \code{"data/spatial/dom_admin_boundaries/"}).
 }
 
@@ -49,8 +58,12 @@ For non-standard external files not yet in Azure, upload them first with
 }
 \examples{
 \dontrun{
-# Pull canonical processed surveillance data
-eri_research_pull(country = "dr", disease = "malaria", data_type = "surveillance")
+# Pull canonical processed data using the coordinates the catalog reports
+eri_research_pull(country = "dr", disease = "malaria",
+                  data_source = "surveillance", data_type = "case")
+
+# Four-axis (channel only, no measure)
+eri_research_pull(country = "dr", disease = "malaria", data_source = "surveillance")
 
 # Pull standard spatial reference files
 eri_research_pull(path = "spatial/dom_admin_boundaries")

--- a/tests/testthat/test-research-pull.R
+++ b/tests/testthat/test-research-pull.R
@@ -79,6 +79,97 @@ test_that("eri_research_pull by canonical args resolves processed path and downl
   expect_true(any(grepl("2024_W02.parquet", downloaded)))
 })
 
+test_that("eri_research_pull builds a five-axis processed path from data_source + data_type", {
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "data"))
+  .write_manifest(tmp)
+
+  listed_path <- NULL
+
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    list_storage_files = function(con, path, ...) {
+      listed_path <<- path
+      c("uga/oncho/programmatic/treatment/processed/2024_06.parquet")
+    },
+    storage_download = function(...) invisible(NULL),
+    .package = "AzureStor"
+  )
+
+  withr::with_dir(tmp, {
+    result <- eri_research_pull(
+      country     = "uga",
+      disease     = "oncho",
+      data_source = "programmatic",
+      data_type   = "treatment",
+      dest        = file.path(tmp, "data")
+    )
+  })
+
+  expect_equal(listed_path, "uga/oncho/programmatic/treatment/processed")
+  expect_equal(length(result), 1L)
+})
+
+test_that("eri_research_pull builds a four-axis path from data_source alone (no measure)", {
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "data"))
+  .write_manifest(tmp)
+
+  listed_path <- NULL
+
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    list_storage_files = function(con, path, ...) {
+      listed_path <<- path
+      c("dr/malaria/surveillance/processed/2024_W01.parquet")
+    },
+    storage_download = function(...) invisible(NULL),
+    .package = "AzureStor"
+  )
+
+  withr::with_dir(tmp, {
+    eri_research_pull(country = "dr", disease = "malaria",
+                      data_source = "surveillance", dest = file.path(tmp, "data"))
+  })
+
+  expect_equal(listed_path, "dr/malaria/surveillance/processed")
+})
+
+test_that("eri_research_pull back-compat: legacy data_type=<channel> resolves to the channel path", {
+  tmp <- withr::local_tempdir()
+  dir.create(file.path(tmp, "data"))
+  .write_manifest(tmp)
+
+  listed_path <- NULL
+
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    list_storage_files = function(con, path, ...) {
+      listed_path <<- path
+      c("dr/malaria/surveillance/processed/2024_W01.parquet")
+    },
+    storage_download = function(...) invisible(NULL),
+    .package = "AzureStor"
+  )
+
+  withr::with_dir(tmp, {
+    # Pre-ADR-0012 form: the channel was passed as data_type.
+    eri_research_pull(country = "dr", disease = "malaria",
+                      data_type = "surveillance", dest = file.path(tmp, "data"))
+  })
+
+  expect_equal(listed_path, "dr/malaria/surveillance/processed")
+})
+
 test_that("eri_research_pull handles a single-file path directly (no directory listing)", {
   tmp <- withr::local_tempdir()
   dir.create(file.path(tmp, "data"))


### PR DESCRIPTION
## What

`eri_research_pull()` — the Epi sourcing entry point — now speaks the ADR-0012 five-axis model. It takes `data_source` (the channel) plus an optional `data_type` (the measure), matching the coordinates `eri_catalog_query()` reports, so a study pulls canonical processed data with the **same tokens a discovery query returns**:

```r
eri_research_pull("dr", "malaria", "surveillance", "case")
```

## Why

A fresh-Epi red-team run (one of the two persona agents) found this was **the only un-migrated function on the Epi sourcing path**. After the catalog (now 5-axis) hands back `(dr, malaria, surveillance, case)`, the pull could only express the old 4-axis `data_type ∈ {surveillance,cmr,odk}` vocabulary — forcing the analyst onto the raw `path=` escape hatch, exactly the habit the governed pipeline is meant to remove.

## Changes

- Canonical mode: `data_source` (channel) + optional `data_type` (measure). Path construction delegates to `eri_data_path()`, so the four-axis channel-only form works too.
- **Back-compat:** the pre-ADR-0012 form where the channel was passed as `data_type` (`data_type = "surveillance"`) still resolves to the same processed path — a `data_source`-NULL + `data_type`-set call shifts the value to `data_source`.
- Tests: 5-axis path, four-axis (`data_source` only), and the legacy `data_type=` back-compat path. Existing legacy-form tests pass unchanged.
- Docs: roxygen + examples, README reference row, research-workflow template canonical example, NEWS.

## Verification

Full offline suite green: **FAIL 0 | PASS 1233**.

Part of #175 (ADR-0012). Surfaced by the fresh-Epi persona red-team.