### PR TITLE
Doc consistency: align README + guides with the ADR-0012 five-axis model (#175 phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,19 @@ Open the `.qmd` file in RStudio and knit it.
 
 ### Data layers
 
-All data lives in the `data/` Azure blob under a standard path:
+All data lives in the `data/` Azure blob under a standard path
+([ADR-0012](docs/adr/0012-source-measure-data-model.md)):
 
 ```
-data/{country}/{disease}/{data_type}/{layer}/
-                                     raw/        <- as-received from source
-                                     staged/     <- DQ-checked, awaiting approval
-                                     processed/  <- analyst-approved, canonical
+data/{country}/{disease}/{data_source}/{data_type}/{layer}/
+                                                   raw/        <- as-received from source
+                                                   staged/     <- DQ-checked, awaiting approval
+                                                   processed/  <- analyst-approved, canonical
 ```
 
-`eri_approve()` is the explicit human gate. Nothing reaches `processed/` without it.
+The `data_type` (measure) level is optional — channel-only data lands one level shallower. The two
+addressing axes are explained just below. `eri_approve()` is the explicit human gate. Nothing reaches
+`processed/` without it.
 
 ### How data is addressed (vocabulary)
 
@@ -130,7 +133,7 @@ is that **how the data arrives (`data_source`) is separate from what it measures
 |---|---|---|
 | `country` | the country | `dr`, `ht`, `uga` |
 | `disease` | the disease | `malaria`, `lf`, `oncho` |
-| `data_source` | **the channel — how it arrives** | `surveillance`, `programmatic`, `odk` |
+| `data_source` | **the channel — how it arrives** | `surveillance`, `programmatic`, `research` |
 | `data_type` | **the measure — what it captures** | `case`, `aggregate`, `treatment`, `tas` |
 | `layer` | pipeline stage | `raw`, `staged`, `processed` |
 
@@ -227,8 +230,8 @@ eri_catalog_verify()
 
 | Function | What it does |
 |---|---|
-| `eri_catalog_register(path, country, disease, data_type, layer)` | Register a file in the catalog |
-| `eri_catalog_query(country, disease, data_type, layer, period)` | Query catalog entries |
+| `eri_catalog_register(path, country, disease, data_source, layer, data_type)` | Register a file in the catalog |
+| `eri_catalog_query(country, disease, data_source, data_type, layer, period)` | Query catalog entries |
 | `eri_catalog_verify()` | Check catalog entries exist in Azure; update verification timestamps |
 
 ### Onboarding a new country or disease

--- a/docs/feedback/red-team-learnings.md
+++ b/docs/feedback/red-team-learnings.md
@@ -1,0 +1,73 @@
+# Red-team learnings
+
+Durable notes from the fresh-user red-team persona runs (`da-fresh-user` "Dana",
+`epi-fresh-user` "Eli"). Each run plays a brand-new Data Analyst or Epidemiologist trying to do
+their real job end-to-end using only `eri_*` functions, and reports where the docs or API let them
+down. **Future runs should read this first and dedupe against it** — confirm whether a prior finding
+is fixed before re-reporting it, and append new structural learnings here.
+
+This file is for *learnings* (durable facts about the system and how to test it), not the full
+reports. The detailed, severity-tagged findings live in the PRs/issues that act on them.
+
+---
+
+## Run 1 — 2026-06-27 (post-ADR-0012 migration)
+
+First paired run, right after the source ≠ measure data-model migration (#175 / ADR-0012) landed the
+5-axis path `data/{country}/{disease}/{data_source}/{data_type}/{layer}/` across the code.
+
+### The headline learning: the split was code-vs-docs, not code-vs-code
+
+Both personas independently concluded the **code is uniformly ADR-0012-correct** (`eri_data_path`,
+`eri_approve`, `eri_catalog_*`, `eri_logs`/`eri_dq_log`, the bundled schemas, `load_dq_schema`,
+`eri_data_model`), and the back-compat shims genuinely work on sandbox data. The friction was the
+**docs lagging in the old four-axis vocabulary**. So a future run right after a model change should
+**weight guide/README audits over code audits**.
+
+### What both personas could do end-to-end, live, with only `eri_*` (don't re-test exhaustively)
+
+- **DA:** onboard (dry-run + real) → ingest (clean + flagged extracts) → DQ → stage → `eri_approve`
+  → catalog → the full `eri_dq_log`/`eri_logs`/`eri_logs_resolve` triage loop → `eri_dir_delete`
+  cleanup. CMR offline parse on the bundled `cmr-example.xlsx`. **Never needed AzureStor / Storage
+  Explorer** — every GUI temptation had a working `eri_*` equivalent.
+- **Epi:** `eri_spatial_reconcile` (string-match + live keyless OSM geocode + the trust guard) and all
+  four `add_anomaly_*` detectors, live on synthetic data. The spatial detector skips cleanly offline
+  (`azcontainer = NULL`) instead of erroring.
+
+### Things to test first next time (the seams, not the happy paths)
+
+1. **Has the doc sweep landed?** Run 1 found the README "Data layers" diagram, `da-ingest`, `da-odk`,
+   and `da-onboard §3` still teaching `surveillance/cmr/odk` as `data_type` (now `data_source`), and
+   no role-scoped "start here" path. Check whether these are fixed before re-reporting.
+2. **`eri_research_pull`** was the one un-migrated function (fixed in PR #195 — verify it stays 5-axis).
+3. **Silent four-axis entries:** the legacy (no-measure) path does not warn at runtime, so a guide that
+   teaches it produces `data_type = NA` catalog rows with no signal. Watch for whether a `cli_inform`
+   signpost was added.
+
+### Delighters worth protecting (regressions here would hurt most)
+
+- `eri_data_model()` — the single best orientation tool; prints the whole 5-axis vocabulary with the
+  transitional `cmr`/`odk` tokens flagged. Future personas should **call it first** to anchor vocab.
+- The schema-not-found error lists every bundled schema + the ADR-0012 identity + an example call.
+- `eri_dir_delete()` recursive cleanup is *the* function that keeps users out of Storage Explorer.
+- The `da-odk-guide` repeat-group section (parent/child tables, `PARENT_KEY`→`KEY` join).
+- `eri_spatial_reconcile`'s trust guard (keeps coordinates, refuses to overwrite a mismatched admin
+  name) — the Epi's favorite; does the one judgment call they'd otherwise agonize over by hand.
+
+### Run mechanics (save time next run)
+
+- Invoke R via PowerShell with a **`.R` script file** (`Rscript script.R > out.txt 2>&1`), **not**
+  inline `-e` — inline quoting (`$`, `\`) causes spurious aborts under PowerShell. R is at
+  `C:\Program Files\R\R-4.5.2\bin\Rscript.exe`.
+- The cached Azure token loads non-interactively ("Loading cached token"); no browser needed in-session.
+- `devtools::load_all()` prints a harmless renv "out-of-sync" notice — ignore it.
+- The keyless OSM geocode path works for a reader with no API key (~3.5s for 3 addresses).
+- **Data policy:** synthetic/sandbox only; never read real country/research data; secrets stay in
+  `.Renviron`. Both runs verified their sandboxes left no trace (catalog empty, namespace gone).
+
+### The one durable conceptual risk
+
+The fault line is **mental-model formation**, not broken functions. A newcomer who reads a stale guide
+forms the wrong `channel` vs `measure` model, or hits a signature that lags the data model and never
+comes back to `eri_*`. **Sourcing/onboarding is the weak link; the pipeline, reconcile, and QC are
+strengths.** Future runs should probe the *first* thing each role does (find/onboard data) hardest.

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -35,6 +35,12 @@ your ODK Central server, submit a few fake records, and work the loop end-to-end
 > **sync** its submissions into `{country}/{disease}/odk/raw/`, and from there it flows through the
 > same `raw → staged → processed` lifecycle — with [`eri_approve()`](../reference/eri_approve.html) as
 > the human gate — as every other dataset.
+>
+> **Transitional vocabulary.** `odk` is an interim `data_source` token here. Under the
+> [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
+> ODK is a *format* of the `research` channel, and its measure (`tas`, `prevalence`, …) is optional —
+> which is why this guide's paths carry no measure level. Keep using `odk` as shown until the research
+> adapter ships; don't adopt it as the canonical channel name.
 
 ```{=html}
 <div class="mermaid">

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -196,6 +196,12 @@ writes a CMR schema template and (when you pass `create_dirs = TRUE`) the CMR fo
 the combined **`rblf`** disease code (RB + LF — the programmes these reports cover), matching where
 [`eri_stage_cmr()`](da-cmr-guide.html) and `eri_approve()` put it. Dry-run it first:
 
+> **Transitional vocabulary.** `rblf` and `cmr` are interim coordinates. Under the
+> [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
+> CMR is a *format* of the `programmatic` channel, and each report sheet splits to its own disease and
+> measure (e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`). Until that split ships, keep
+> using `rblf`/`cmr` as shown here — don't adopt them as the canonical addressing model.
+
 ```{r cmr-dry}
 eri_onboard_cmr("atlantis", "Atlantis", create_dirs = TRUE, dry_run = TRUE)
 #> ℹ Dry run -- nothing will be written or created.

--- a/vignettes/epi-dq-guide.Rmd
+++ b/vignettes/epi-dq-guide.Rmd
@@ -59,10 +59,11 @@ case. It has three planted problems — a species typo, a **case spike**, and a 
 kinds of thing a real extract hides:
 
 ```{r extract}
-# The `disease` argument is the *schema key* (here "malaria_case", the case-level
-# malaria schema) — more specific than the "malaria" program in the country table,
-# and separate from the layer-path data_type (surveillance/cmr/odk).
-schema <- load_dq_schema("dr", disease = "malaria_case", azcontainer = NULL)
+# Load by the four-part identity (ADR-0012): country, disease, data_source (the
+# channel — surveillance/programmatic/research), data_type (the measure — here
+# "case", the case-level line-list). The legacy compound key still works too:
+# load_dq_schema("dr", "malaria_case") resolves via an alias during the migration.
+schema <- load_dq_schema("dr", "malaria", "surveillance", "case", azcontainer = NULL)
 
 # A tiny helper to make `n` identical case rows for a province/week.
 mk <- function(province, week, n, species = "P. vivax") {


### PR DESCRIPTION
## What

The safe, mechanical slice of the documentation sweep both fresh-user red-team personas (DA "Dana" + Epi "Eli") converged on. Their shared headline: the **code is uniformly ADR-0012-correct**, but several docs still teach the old four-axis vocabulary (`surveillance/cmr/odk` as `data_type`).

## Changes

- **README "Data layers"** diagram now shows the five-axis path `data/{country}/{disease}/{data_source}/{data_type}/{layer}/` — it previously showed the four-axis path and **contradicted the addressing-vocabulary block 8 lines below it** (both personas flagged this as the worst front-door issue). The `data_source` example uses `research`, not the retired `odk` token. The `eri_catalog_register` / `eri_catalog_query` reference rows now include `data_source`.
- **`da-onboard §3`** and **`da-odk`** gain the "Transitional vocabulary" callout the CMR guide already carries, flagging `rblf`/`cmr` and `odk` as interim tokens and pointing at ADR-0012 (programmatic/research channels; cmr/odk as formats).
- **`epi-dq-guide`** loads the schema by the four-part identity `load_dq_schema("dr","malaria","surveillance","case")` (verified it resolves: `disease=malaria, data_type=case`), with the legacy compound key demoted to a comment; the parenthetical no longer mislabels `surveillance/cmr/odk` as `data_type`.
- Seeds **`docs/feedback/red-team-learnings.md`** so future persona runs dedupe against this run's findings rather than re-discovering them (both agents asked for this).

## Deliberately out of scope (left for maintainer direction)

These are judgment/behavior calls, not mechanical fixes:
- A **full `da-ingest-guide` rewrite** to the five-axis model (it's the flagship and currently teaches the old vocabulary, silently producing measure-less catalog rows).
- A **runtime `cli_inform` signpost** in `eri_approve`/`eri_data_path` when the no-measure four-axis form is used (a behavior change).
- A **role-scoped "start here" guide index** + factoring repeated golden-rule/cleanup boilerplate into one shared page.

## Verification

Pure docs (+ one `eval=FALSE` chunk swap, verified the call resolves live). pkgdown render is CI-verified. Part of #175 phase 4.