### PR TITLE
Add a role-scoped "start here" path to the guide index (#175 phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,26 @@ reference, and the project roadmap. This README is the quick orientation.
 ## Guides
 
 These copy-paste, start-to-finish walkthroughs are the fastest way to learn the system. Read them
-on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/):
+on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/).
+
+**New here? Do these in order** (then dip into the rest as your work needs them). First, run
+`eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure) every guide
+assumes.
+
+- **New Data Analyst:**
+  [Connections](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) →
+  [Onboard a space](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) →
+  [Ingest a dataset](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) →
+  [Triage the log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html).
+  Then [CMR](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) and
+  [ODK](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) when you file those.
+- **New Epidemiologist:**
+  [Connections](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) →
+  [Research workflow](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) →
+  [Reconcile localities](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) →
+  [Catch anomalies](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html).
+
+The full set:
 
 | Guide | For |
 |---|---|

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -14,6 +14,22 @@ vignettes (ADR-0001).
 
 This page is the **menu and the backlog**: what exists today, and what is still missing.
 
+## New here? Do these in order
+
+First run `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure)
+the guides assume. Then follow your role's path; dip into the rest as your work needs them.
+
+- **Data Analyst:** [`connections-guide`](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html)
+  → [`da-onboard-guide`](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html)
+  → [`da-ingest-guide`](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html)
+  → [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html).
+  Add [`da-cmr-guide`](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) /
+  [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) for those feeds.
+- **Epidemiologist:** [`connections-guide`](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html)
+  → [`epi-research-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html)
+  → [`epi-reconcile-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html)
+  → [`epi-dq-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html).
+
 ## Guides
 
 | Role | Task | Guide | Status |


### PR DESCRIPTION
## What

Adds a "New here? Do these in order" block to both the README guides section and `docs/guides.md`, above the flat guide table.

## Why

Both fresh-user red-team personas found the flat guide menu (14 entries, no ordering) overwhelming, with no "you're a DA, do these in order" path to follow on day one.

## Changes

- **Data Analyst path:** connections → onboard → ingest → logs (CMR / ODK as those feeds arrive).
- **Epidemiologist path:** connections → research → reconcile → dq.
- Both point a newcomer at `eri_data_model()` **first** to learn the channel-vs-measure vocabulary the guides assume — consolidated in the start-here block rather than duplicated into every guide's header (the personas also flagged repeated boilerplate, so I deliberately didn't add the line to all ~8 guides).

## Scope

The maintainer-approved "start-here path only" option from the red-team triage. The boilerplate-factoring (one shared "working safely with sandboxes" page) is intentionally deferred. Pure docs (README + docs/guides.md); all linked article filenames match existing shipped guides. Part of #175 phase 4.