### PR TITLE
Stage eri_ingest() to the five-axis measure path (#175 phase 4)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # erifunctions (development version)
 
+## Feature: `eri_ingest()` stages to the five-axis measure path (ADR-0012, #175 phase 4)
+
+- `eri_ingest()` now writes the cleaned parquet to
+  `data/{country}/{disease}/{data_source}/{data_type}/staged/` (the **measure** is in the path, not just
+  used to pick the schema), and its operation/DQ logs land alongside. So `eri_ingest()` →
+  `eri_approve(country, disease, data_source, period, data_type = …)` is now a consistent five-axis
+  round-trip. **Behaviour change:** with the default `data_type = "aggregate"`, a plain
+  `eri_ingest(path, country, disease)` now stages to `.../{data_source}/aggregate/staged/` (was
+  `.../{data_source}/staged/`); pass the matching `data_type` to `eri_approve()`. This finishes the
+  measure-into-path work for the ingest entry point and is the foundation the CMR per-disease split
+  builds on.
+
 ## Feature: `eri_approve()` signposts the no-measure (four-axis) form (ADR-0012, #175 phase 4)
 
 - When `eri_approve()` runs without a `data_type`, the dataset is filed and catalogued at the channel

--- a/R/dal.R
+++ b/R/dal.R
@@ -1331,9 +1331,9 @@ eri_stage <- function(pipeline, country, disease,
 #'
 #' The general analyst ingest entry point. Reads a raw local file, runs all DQ
 #' checks via [run_dq_checks()], prints the flags, and writes the cleaned parquet
-#' to `data/{country}/{disease}/{data_source}/staged/` — feeding [eri_approve()].
-#' It runs on **any** data, including a throwaway sandbox: there is no
-#' pipeline-registry or country gate by default.
+#' to `data/{country}/{disease}/{data_source}/{data_type}/staged/` — feeding
+#' [eri_approve()] with the matching measure. It runs on **any** data, including a
+#' throwaway sandbox: there is no pipeline-registry or country gate by default.
 #'
 #' The legacy `projects`-blob dual-write (the hsp-mal cutover comparison) is an
 #' **opt-in** mirror: pass `mirror_pipeline = "hsp-mal"` to additionally mirror the
@@ -1345,8 +1345,9 @@ eri_stage <- function(pipeline, country, disease,
 #' @param disease `str` Disease name (e.g. `"malaria"`).
 #' @param data_source `str` The channel (`"surveillance"`, `"programmatic"`,
 #'   `"research"`). Default `"surveillance"`.
-#' @param data_type `str` The measure used to select the DQ schema (e.g.
-#'   `"aggregate"`, `"case"`). Default `"aggregate"`.
+#' @param data_type `str` The measure (e.g. `"aggregate"`, `"case"`, `"treatment"`).
+#'   Selects the DQ schema **and** is the measure level in the staged path
+#'   `.../{data_source}/{data_type}/staged/`. Default `"aggregate"`.
 #' @param schema Named list from [load_dq_schema()]. If `NULL` (default), loaded
 #'   for `(country, disease, data_source, data_type)`.
 #' @param data_con Azure container for the `data` blob. If `NULL` (default),
@@ -1360,9 +1361,12 @@ eri_stage <- function(pipeline, country, disease,
 #' @returns Invisibly, the `dq_result` object (`$data`, `$log`, `$flags`).
 #' @examples
 #' \dontrun{
+#' # Default measure is "aggregate", so it stages to
+#' # dr/malaria/surveillance/aggregate/staged/ ...
 #' result <- eri_ingest("data/raw/dr_malaria_2024W01.xlsx", "dr", "malaria")
 #' result$flags  # review before approving
-#' eri_approve("dr", "malaria", "surveillance", "2024W01")
+#' # ... and the same measure promotes it:
+#' eri_approve("dr", "malaria", "surveillance", "2024W01", data_type = "aggregate")
 #' }
 #' @export
 eri_ingest <- function(path, country, disease,
@@ -1420,8 +1424,11 @@ eri_ingest <- function(path, country, disease,
   dq_report(result)
 
   fname_parquet <- paste0(tools::file_path_sans_ext(basename(path)), ".parquet")
-  staged_dir    <- eri_data_path(country, disease, data_source, "staged")
-  log_dir       <- paste(c(country, disease, data_source, "logs"), collapse = "/")
+  # Five-axis staging (ADR-0012): the measure lands in the path, so a later
+  # eri_approve(country, disease, data_source, period, data_type) promotes it.
+  # c() drops a NULL data_type, so a measure-less ingest stays four-axis.
+  staged_dir    <- eri_data_path(country, disease, data_source, data_type, "staged")
+  log_dir       <- paste(c(country, disease, data_source, data_type, "logs"), collapse = "/")
 
   op_log <- list(
     operation  = "eri_ingest",
@@ -1479,7 +1486,7 @@ eri_ingest <- function(path, country, disease,
     # Persist the DQ flags to the log backlog so they are durable and triageable
     # via eri_logs() / eri_logs_resolve(). Never let a logging hiccup break ingest.
     tryCatch(
-      eri_dq_log(result, country, disease, data_source, data_con = data_con),
+      eri_dq_log(result, country, disease, data_source, data_type, data_con = data_con),
       error = function(e) cli::cli_alert_warning("Could not log DQ flags: {conditionMessage(e)}")
     )
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -1345,9 +1345,13 @@ eri_stage <- function(pipeline, country, disease,
 #' @param disease `str` Disease name (e.g. `"malaria"`).
 #' @param data_source `str` The channel (`"surveillance"`, `"programmatic"`,
 #'   `"research"`). Default `"surveillance"`.
-#' @param data_type `str` The measure (e.g. `"aggregate"`, `"case"`, `"treatment"`).
-#'   Selects the DQ schema **and** is the measure level in the staged path
-#'   `.../{data_source}/{data_type}/staged/`. Default `"aggregate"`.
+#' @param data_type `str` or `NULL` The measure (e.g. `"aggregate"`, `"case"`,
+#'   `"treatment"`). Selects the DQ schema **and** is the measure level in the staged
+#'   path `.../{data_source}/{data_type}/staged/`. Default `"aggregate"`. Whatever you
+#'   pass here, **promote with the same measure** —
+#'   `eri_approve(country, disease, data_source, period, data_type = <same>)` — or the
+#'   approve will look one level up and find nothing. `NULL` stages channel-level
+#'   (four-axis), for the rare measure-less case.
 #' @param schema Named list from [load_dq_schema()]. If `NULL` (default), loaded
 #'   for `(country, disease, data_source, data_type)`.
 #' @param data_con Azure container for the `data` blob. If `NULL` (default),

--- a/man/eri_approve.Rd
+++ b/man/eri_approve.Rd
@@ -27,7 +27,9 @@ is promoted.}
 
 \item{data_type}{\code{str} or \code{NULL} The measure the data captures (e.g. \code{"case"},
 \code{"aggregate"}, \code{"treatment"}, \code{"tas"}). \code{NULL} (default) approves the legacy
-four-axis path \code{{country}/{disease}/{data_source}/...} without a measure level.}
+four-axis path \code{{country}/{disease}/{data_source}/...} without a measure level,
+and the catalog entry's measure is recorded as \code{NA} — a one-time per-session
+note points this out so it is a deliberate choice, not a silent omission.}
 
 \item{azcontainer}{Azure container object for the \verb{data/} blob, returned by
 \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}. If \code{NULL} (default), connects automatically

--- a/man/eri_ingest.Rd
+++ b/man/eri_ingest.Rd
@@ -26,8 +26,9 @@ eri_ingest(
 \item{data_source}{\code{str} The channel (\code{"surveillance"}, \code{"programmatic"},
 \code{"research"}). Default \code{"surveillance"}.}
 
-\item{data_type}{\code{str} The measure used to select the DQ schema (e.g.
-\code{"aggregate"}, \code{"case"}). Default \code{"aggregate"}.}
+\item{data_type}{\code{str} The measure (e.g. \code{"aggregate"}, \code{"case"}, \code{"treatment"}).
+Selects the DQ schema \strong{and} is the measure level in the staged path
+\verb{.../\{data_source\}/\{data_type\}/staged/}. Default \code{"aggregate"}.}
 
 \item{schema}{Named list from \code{\link[=load_dq_schema]{load_dq_schema()}}. If \code{NULL} (default), loaded
 for \verb{(country, disease, data_source, data_type)}.}
@@ -50,9 +51,9 @@ Invisibly, the \code{dq_result} object (\verb{$data}, \verb{$log}, \verb{$flags}
 
 The general analyst ingest entry point. Reads a raw local file, runs all DQ
 checks via \code{\link[=run_dq_checks]{run_dq_checks()}}, prints the flags, and writes the cleaned parquet
-to \verb{data/\{country\}/\{disease\}/\{data_source\}/staged/} — feeding \code{\link[=eri_approve]{eri_approve()}}.
-It runs on \strong{any} data, including a throwaway sandbox: there is no
-pipeline-registry or country gate by default.
+to \verb{data/\{country\}/\{disease\}/\{data_source\}/\{data_type\}/staged/} — feeding
+\code{\link[=eri_approve]{eri_approve()}} with the matching measure. It runs on \strong{any} data, including a
+throwaway sandbox: there is no pipeline-registry or country gate by default.
 
 The legacy \code{projects}-blob dual-write (the hsp-mal cutover comparison) is an
 \strong{opt-in} mirror: pass \code{mirror_pipeline = "hsp-mal"} to additionally mirror the
@@ -61,8 +62,11 @@ This is transitional and removed at the Phase-3 cutover (ADR-0012).
 }
 \examples{
 \dontrun{
+# Default measure is "aggregate", so it stages to
+# dr/malaria/surveillance/aggregate/staged/ ...
 result <- eri_ingest("data/raw/dr_malaria_2024W01.xlsx", "dr", "malaria")
 result$flags  # review before approving
-eri_approve("dr", "malaria", "surveillance", "2024W01")
+# ... and the same measure promotes it:
+eri_approve("dr", "malaria", "surveillance", "2024W01", data_type = "aggregate")
 }
 }

--- a/man/eri_ingest.Rd
+++ b/man/eri_ingest.Rd
@@ -26,9 +26,13 @@ eri_ingest(
 \item{data_source}{\code{str} The channel (\code{"surveillance"}, \code{"programmatic"},
 \code{"research"}). Default \code{"surveillance"}.}
 
-\item{data_type}{\code{str} The measure (e.g. \code{"aggregate"}, \code{"case"}, \code{"treatment"}).
-Selects the DQ schema \strong{and} is the measure level in the staged path
-\verb{.../\{data_source\}/\{data_type\}/staged/}. Default \code{"aggregate"}.}
+\item{data_type}{\code{str} or \code{NULL} The measure (e.g. \code{"aggregate"}, \code{"case"},
+\code{"treatment"}). Selects the DQ schema \strong{and} is the measure level in the staged
+path \verb{.../\{data_source\}/\{data_type\}/staged/}. Default \code{"aggregate"}. Whatever you
+pass here, \strong{promote with the same measure} —
+\verb{eri_approve(country, disease, data_source, period, data_type = <same>)} — or the
+approve will look one level up and find nothing. \code{NULL} stages channel-level
+(four-axis), for the rare measure-less case.}
 
 \item{schema}{Named list from \code{\link[=load_dq_schema]{load_dq_schema()}}. If \code{NULL} (default), loaded
 for \verb{(country, disease, data_source, data_type)}.}

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -340,6 +340,42 @@ test_that("eri_ingest stages to the five-axis {data_source}/{data_type} path", {
   expect_equal(logged_dir, "uga/oncho/programmatic/treatment/logs")
 })
 
+test_that("eri_ingest with data_type = NULL stays four-axis (no measure level)", {
+  raw_csv <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(Year = 2024L, EpiWeek = 1L), raw_csv, row.names = FALSE)
+
+  schema <- list(
+    country = "uga", disease = "oncho", data_source = "surveillance",
+    temporal = list(year_col = "Year", period_col = "EpiWeek"),
+    columns  = list(
+      Year    = list(required = TRUE, type = "numeric"),
+      EpiWeek = list(required = TRUE, type = "numeric")
+    )
+  )
+
+  staged_dest <- NULL
+  logged_dir  <- NULL
+
+  local_mocked_bindings(
+    .eri_blob_write = function(con, src, dest, ...) { staged_dest <<- dest; invisible(NULL) },
+    .eri_write_log  = function(op_log, con, dir, ...) { logged_dir <<- dir; invisible(NULL) },
+    eri_dq_log      = function(...) invisible(NULL),
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    storage_dir_exists = function(...) TRUE,
+    .package = "AzureStor"
+  )
+
+  eri_ingest(raw_csv, "uga", "oncho",
+             data_source = "surveillance", data_type = NULL,
+             schema = schema, data_con = structure(list(), class = "mock"))
+
+  expect_match(staged_dest, "^uga/oncho/surveillance/staged/")
+  expect_equal(logged_dir, "uga/oncho/surveillance/logs")
+})
+
 #### Tests for eri_approve error paths (no Azure needed) ####
 
 test_that("eri_approve errors informatively when staged dir does not exist", {

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -303,6 +303,43 @@ test_that("eri_ingest no longer needs .eri_schema_country_map (retired)", {
   expect_false(exists(".eri_schema_country_map", where = asNamespace("erifunctions")))
 })
 
+test_that("eri_ingest stages to the five-axis {data_source}/{data_type} path", {
+  raw_csv <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(Year = 2024L, EpiWeek = 1L), raw_csv, row.names = FALSE)
+
+  schema <- list(
+    country = "uga", disease = "oncho",
+    data_source = "programmatic", data_type = "treatment",
+    temporal = list(year_col = "Year", period_col = "EpiWeek"),
+    columns  = list(
+      Year    = list(required = TRUE, type = "numeric"),
+      EpiWeek = list(required = TRUE, type = "numeric")
+    )
+  )
+
+  staged_dest <- NULL
+  logged_dir  <- NULL
+
+  local_mocked_bindings(
+    .eri_blob_write = function(con, src, dest, ...) { staged_dest <<- dest; invisible(NULL) },
+    .eri_write_log  = function(op_log, con, dir, ...) { logged_dir <<- dir; invisible(NULL) },
+    eri_dq_log      = function(...) invisible(NULL),
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    storage_dir_exists = function(...) TRUE,
+    .package = "AzureStor"
+  )
+
+  eri_ingest(raw_csv, "uga", "oncho",
+             data_source = "programmatic", data_type = "treatment",
+             schema = schema, data_con = structure(list(), class = "mock"))
+
+  expect_match(staged_dest, "^uga/oncho/programmatic/treatment/staged/")
+  expect_equal(logged_dir, "uga/oncho/programmatic/treatment/logs")
+})
+
 #### Tests for eri_approve error paths (no Azure needed) ####
 
 test_that("eri_approve errors informatively when staged dir does not exist", {


### PR DESCRIPTION
## What

`eri_ingest()` now threads `data_type` (the measure) into its staged path and logs, writing the cleaned parquet to `data/{country}/{disease}/{data_source}/{data_type}/staged/` (previously `.../{data_source}/staged/`, with the measure only used to pick the schema).

## Why

This is the **foundation for the CMR per-disease split (#51)**: routing each CMR disease-group to `{country}/{disease}/programmatic/{measure}/` needs the measure in the staged path. It also finishes the "measure-into-path" work (#194 did `eri_approve`/catalog/logs; this completes the ingest entry point), so `eri_ingest()` → `eri_approve(country, disease, data_source, period, data_type = …)` is now a consistent five-axis round-trip. Maintainer-approved direction from the #51 triage.

## Changes

- `staged_dir` and `log_dir` gain the measure level via `eri_data_path(country, disease, data_source, data_type, "staged")` (`c()` drops a `NULL` `data_type`, so a measure-less ingest stays four-axis). The `eri_dq_log()` call passes the measure so DQ flags land alongside.
- **Behaviour change:** with the default `data_type = "aggregate"`, a plain `eri_ingest(path, country, disease)` now stages to `.../{data_source}/aggregate/staged/`. Documented in NEWS + roxygen + the example (the example's `eri_approve` now passes `data_type = "aggregate"`).
- Test: a mocked ingest asserts the staged dest and log dir both carry the measure level.
- Incidental: regenerates `man/eri_approve.Rd`, which was left out of sync when #197 updated its roxygen but not the `.Rd`.

## Verification

Full offline suite green: **FAIL 0 | PASS 1239**. Existing `eri_ingest` error-path tests unaffected.

Part of #175 phase 4 (CMR split prerequisite).