### PR TITLE
Add CMR routing keys to the other 6 countries (#175 phase 4)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,13 @@
   duplicated across diseases. Data is staged **parsed as-is** (machine-readable `#field-code` columns; no
   reshape, no automated DQ — CMR review is manual); `eri_approve()` then promotes each disease/measure.
   `dry_run = TRUE` returns the routing plan without writing.
-- The CMR schema gains two per-sheet keys, `disease` and `data_type`, driving the routing. The bundled
-  `uga` schema is the worked example; the other countries' routing keys and full real-template
-  reconciliation are tracked as follow-up.
+- The CMR schema gains two per-sheet keys, `disease` and `data_type`, driving the routing. **All seven
+  registered countries** (eth/nga/sdn/ssd/uga English, tcd/mad French) now carry routing keys, so
+  `eri_split_cmr()` works for each: Treatment sheets → the disease's `treatment`, LF MMDP → `lf`/`mmdp`,
+  Training sheets → combined `rblf`/`training`, Surveys → `rblf`/`survey`, River Prospection / Fly
+  Collection → `oncho`/`entomology` (Drug Inventory and SBCC are logistics/comms, not split). The deeper
+  reconciliation of each bundled schema's sheet set to its real template (monthly `_jan…_dec` columns,
+  the larger real sheet set) remains tracked as follow-up.
 - The `da-cmr-guide` now teaches `upload → stage → split → approve`, approving each disease/measure on its
   own coordinates instead of one combined `rblf`/`cmr` bucket.
 

--- a/inst/schemas/cmr/eth.yaml
+++ b/inst/schemas/cmr/eth.yaml
@@ -3,9 +3,15 @@ country_code: eth
 language: en
 template: english_cmr
 
+# Per-sheet routing (disease from the sheet; data_type = the measure) drives
+# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
+# Drug Inventory and SBCC are logistics / communications, not per-disease
+# measures, so they declare no routing keys and are not split.
 sheets:
   RB Treatment:
     field_code_prefix: "#rbtrt_"
+    disease: oncho
+    data_type: treatment
     required_fields:
       - "#rbtrt_year"
       - "#rbtrt_month"
@@ -16,6 +22,8 @@ sheets:
 
   LF Treatment:
     field_code_prefix: "#lftrt_"
+    disease: lf
+    data_type: treatment
     required_fields:
       - "#lftrt_year"
       - "#lftrt_month"
@@ -26,6 +34,8 @@ sheets:
 
   LF MMDP:
     field_code_prefix: "#lfmmdp_"
+    disease: lf
+    data_type: mmdp
     required_fields:
       - "#lfmmdp_year"
       - "#lfmmdp_month"
@@ -38,6 +48,8 @@ sheets:
 
   CDD Training:
     field_code_prefix: "#cddtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cddtrn_year"
       - "#cddtrn_month"
@@ -48,6 +60,8 @@ sheets:
 
   CS Training:
     field_code_prefix: "#cstrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cstrn_year"
       - "#cstrn_month"
@@ -58,6 +72,8 @@ sheets:
 
   MMDP Training:
     field_code_prefix: "#mmdptrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#mmdptrn_year"
       - "#mmdptrn_month"
@@ -68,6 +84,8 @@ sheets:
 
   Surveys:
     field_code_prefix: "#svy_"
+    disease: rblf
+    data_type: survey
     required_fields:
       - "#svy_year"
       - "#svy_adm1"
@@ -100,6 +118,8 @@ sheets:
 
   River Prospection:
     field_code_prefix: "#rivpro_"
+    disease: oncho
+    data_type: entomology
     required_fields:
       - "#rivpro_year"
       - "#rivpro_month"
@@ -109,6 +129,8 @@ sheets:
 
   Fly Collection:
     field_code_prefix: "#flycol_"
+    disease: oncho
+    data_type: entomology
     required_fields:
       - "#flycol_year"
       - "#flycol_month"

--- a/inst/schemas/cmr/mad.yaml
+++ b/inst/schemas/cmr/mad.yaml
@@ -78,6 +78,8 @@ sheets:
       - "#mmdptrn_target"
       - "#mmdptrn_trained"
 
+  # Surgery training shares the MMDP-training field codes; it is a distinct sheet,
+  # so it stages as a distinct file in the same rblf/programmatic/training/ dir.
   "PCMPI Formation Chirurgie":
     field_code_prefix: "#mmdptrn_"
     disease: rblf

--- a/inst/schemas/cmr/mad.yaml
+++ b/inst/schemas/cmr/mad.yaml
@@ -12,9 +12,14 @@ sheet_aliases:
   mmdp_surgery_training: "PCMPI Formation Chirurgie"
   surveys: "Enquêtes FL"
 
+# Per-sheet routing (disease from the sheet; data_type = the measure) drives
+# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
+# Madagascar is LF-only (no RB/oncho sheets).
 sheets:
   "Traitement FL":
     field_code_prefix: "#lftrt_"
+    disease: lf
+    data_type: treatment
     required_fields:
       - "#lftrt_year"
       - "#lftrt_month"
@@ -25,6 +30,8 @@ sheets:
 
   "PCMPI FL":
     field_code_prefix: "#lfmmdp_"
+    disease: lf
+    data_type: mmdp
     required_fields:
       - "#lfmmdp_year"
       - "#lfmmdp_month"
@@ -37,6 +44,8 @@ sheets:
 
   "Formation Distributeurs":
     field_code_prefix: "#cddtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cddtrn_year"
       - "#cddtrn_month"
@@ -47,6 +56,8 @@ sheets:
 
   "Formation SC":
     field_code_prefix: "#cstrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cstrn_year"
       - "#cstrn_month"
@@ -57,6 +68,8 @@ sheets:
 
   "Formation Travailleurs de Sante":
     field_code_prefix: "#mmdptrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#mmdptrn_year"
       - "#mmdptrn_month"
@@ -67,6 +80,8 @@ sheets:
 
   "PCMPI Formation Chirurgie":
     field_code_prefix: "#mmdptrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#mmdptrn_year"
       - "#mmdptrn_month"
@@ -77,6 +92,8 @@ sheets:
 
   "Enquêtes FL":
     field_code_prefix: "#svy_"
+    disease: rblf
+    data_type: survey
     required_fields:
       - "#svy_year"
       - "#svy_adm1"

--- a/inst/schemas/cmr/nga.yaml
+++ b/inst/schemas/cmr/nga.yaml
@@ -3,9 +3,13 @@ country_code: nga
 language: en
 template: english_cmr
 
+# Per-sheet routing (disease from the sheet; data_type = the measure) drives
+# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
 sheets:
   RB Treatment:
     field_code_prefix: "#rbtrt_"
+    disease: oncho
+    data_type: treatment
     required_fields:
       - "#rbtrt_year"
       - "#rbtrt_month"
@@ -16,6 +20,8 @@ sheets:
 
   LF Treatment:
     field_code_prefix: "#lftrt_"
+    disease: lf
+    data_type: treatment
     required_fields:
       - "#lftrt_year"
       - "#lftrt_month"
@@ -26,6 +32,8 @@ sheets:
 
   SCH Treatment:
     field_code_prefix: "#schtrt_"
+    disease: sch
+    data_type: treatment
     required_fields:
       - "#schtrt_year"
       - "#schtrt_month"
@@ -36,6 +44,8 @@ sheets:
 
   STH Treatment:
     field_code_prefix: "#sthtrt_"
+    disease: sth
+    data_type: treatment
     required_fields:
       - "#sthtrt_year"
       - "#sthtrt_month"
@@ -46,6 +56,8 @@ sheets:
 
   LF MMDP:
     field_code_prefix: "#lfmmdp_"
+    disease: lf
+    data_type: mmdp
     required_fields:
       - "#lfmmdp_year"
       - "#lfmmdp_month"
@@ -58,6 +70,8 @@ sheets:
 
   CDD Training:
     field_code_prefix: "#cddtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cddtrn_year"
       - "#cddtrn_month"
@@ -68,6 +82,8 @@ sheets:
 
   CS Training:
     field_code_prefix: "#cstrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cstrn_year"
       - "#cstrn_month"
@@ -78,6 +94,8 @@ sheets:
 
   MMDP Training:
     field_code_prefix: "#mmdptrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#mmdptrn_year"
       - "#mmdptrn_month"
@@ -88,6 +106,8 @@ sheets:
 
   Surveys:
     field_code_prefix: "#svy_"
+    disease: rblf
+    data_type: survey
     required_fields:
       - "#svy_year"
       - "#svy_adm1"

--- a/inst/schemas/cmr/sdn.yaml
+++ b/inst/schemas/cmr/sdn.yaml
@@ -3,9 +3,13 @@ country_code: sdn
 language: en
 template: english_cmr
 
+# Per-sheet routing (disease from the sheet; data_type = the measure) drives
+# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
 sheets:
   RB Treatment:
     field_code_prefix: "#rbtrt_"
+    disease: oncho
+    data_type: treatment
     required_fields:
       - "#rbtrt_year"
       - "#rbtrt_month"
@@ -16,6 +20,8 @@ sheets:
 
   LF Treatment:
     field_code_prefix: "#lftrt_"
+    disease: lf
+    data_type: treatment
     required_fields:
       - "#lftrt_year"
       - "#lftrt_month"
@@ -26,6 +32,8 @@ sheets:
 
   LF MMDP:
     field_code_prefix: "#lfmmdp_"
+    disease: lf
+    data_type: mmdp
     required_fields:
       - "#lfmmdp_year"
       - "#lfmmdp_month"
@@ -38,6 +46,8 @@ sheets:
 
   CDD Training:
     field_code_prefix: "#cddtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cddtrn_year"
       - "#cddtrn_month"
@@ -48,6 +58,8 @@ sheets:
 
   CS Training:
     field_code_prefix: "#cstrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cstrn_year"
       - "#cstrn_month"
@@ -58,6 +70,8 @@ sheets:
 
   MMDP Training:
     field_code_prefix: "#mmdptrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#mmdptrn_year"
       - "#mmdptrn_month"
@@ -68,6 +82,8 @@ sheets:
 
   Surveys:
     field_code_prefix: "#svy_"
+    disease: rblf
+    data_type: survey
     required_fields:
       - "#svy_year"
       - "#svy_adm1"

--- a/inst/schemas/cmr/ssd.yaml
+++ b/inst/schemas/cmr/ssd.yaml
@@ -3,9 +3,13 @@ country_code: ssd
 language: en
 template: english_cmr
 
+# Per-sheet routing (disease from the sheet; data_type = the measure) drives
+# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
 sheets:
   RB Treatment:
     field_code_prefix: "#rbtrt_"
+    disease: oncho
+    data_type: treatment
     required_fields:
       - "#rbtrt_year"
       - "#rbtrt_month"
@@ -16,6 +20,8 @@ sheets:
 
   LF Treatment:
     field_code_prefix: "#lftrt_"
+    disease: lf
+    data_type: treatment
     required_fields:
       - "#lftrt_year"
       - "#lftrt_month"
@@ -26,6 +32,8 @@ sheets:
 
   LF MMDP:
     field_code_prefix: "#lfmmdp_"
+    disease: lf
+    data_type: mmdp
     required_fields:
       - "#lfmmdp_year"
       - "#lfmmdp_month"
@@ -38,6 +46,8 @@ sheets:
 
   CDD Training:
     field_code_prefix: "#cddtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cddtrn_year"
       - "#cddtrn_month"
@@ -48,6 +58,8 @@ sheets:
 
   CS Training:
     field_code_prefix: "#cstrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cstrn_year"
       - "#cstrn_month"
@@ -58,6 +70,8 @@ sheets:
 
   MMDP Training:
     field_code_prefix: "#mmdptrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#mmdptrn_year"
       - "#mmdptrn_month"
@@ -68,6 +82,8 @@ sheets:
 
   Surveys:
     field_code_prefix: "#svy_"
+    disease: rblf
+    data_type: survey
     required_fields:
       - "#svy_year"
       - "#svy_adm1"

--- a/inst/schemas/cmr/tcd.yaml
+++ b/inst/schemas/cmr/tcd.yaml
@@ -11,9 +11,15 @@ sheet_aliases:
   cs_training: "Formation Superviseurs Comm"
   surveys: "Enquêtes"
 
+# Per-sheet routing (disease from the sheet; data_type = the measure) drives
+# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/. The
+# #field codes are language-neutral, so routing is identical to the English
+# templates despite the French sheet names.
 sheets:
   "Oncho Traitement":
     field_code_prefix: "#rbtrt_"
+    disease: oncho
+    data_type: treatment
     required_fields:
       - "#rbtrt_year"
       - "#rbtrt_month"
@@ -24,6 +30,8 @@ sheets:
 
   "Traitement FL":
     field_code_prefix: "#lftrt_"
+    disease: lf
+    data_type: treatment
     required_fields:
       - "#lftrt_year"
       - "#lftrt_month"
@@ -34,6 +42,8 @@ sheets:
 
   "LF MMDP":
     field_code_prefix: "#lfmmdp_"
+    disease: lf
+    data_type: mmdp
     required_fields:
       - "#lfmmdp_year"
       - "#lfmmdp_month"
@@ -46,6 +56,8 @@ sheets:
 
   "Formation Distributeurs Comm":
     field_code_prefix: "#cddtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cddtrn_year"
       - "#cddtrn_month"
@@ -56,6 +68,8 @@ sheets:
 
   "Formation Superviseurs Comm":
     field_code_prefix: "#cstrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#cstrn_year"
       - "#cstrn_month"
@@ -66,6 +80,8 @@ sheets:
 
   "Enquêtes":
     field_code_prefix: "#svy_"
+    disease: rblf
+    data_type: survey
     required_fields:
       - "#svy_year"
       - "#svy_adm1"

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -338,6 +338,21 @@ test_that("eri_split_cmr keeps the per-row program code as a column (no disease 
   expect_setequal(rb[["#rbtrt_disease"]], c("RBLFSCH", "RB"))
 })
 
+test_that("every country's CMR schema routes at least one sheet to a registered measure", {
+  measures <- names(erifunctions:::.eri_data_model()$data_types)
+  for (country in c("eth", "nga", "sdn", "ssd", "tcd", "mad", "uga")) {
+    schema <- load_cmr_schema(country)
+    routed <- Filter(function(s) !is.null(s$disease) && !is.null(s$data_type), schema$sheets)
+    expect_gt(length(routed), 0L,
+              label = paste(country, "has no routable CMR sheets"))
+    for (sheet in names(routed)) {
+      dt <- routed[[sheet]]$data_type
+      expect_true(dt %in% measures,
+                  info = paste(country, "/", sheet, "data_type", dt, "is not a registered measure"))
+    }
+  }
+})
+
 test_that("eri_split_cmr aborts when the workbook has none of the routable sheets", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   writexl::write_xlsx(list(


### PR DESCRIPTION
## What

Completes the CMR per-disease split for **all seven registered RB-expansion countries**, not just `uga`. Each country's bundled CMR schema gains the per-sheet `disease` + `data_type` routing keys that `eri_split_cmr()` (#202) reads.

## How

Routing is keyed off the **language-neutral `field_code_prefix`**, so the French `tcd`/`mad` templates route identically to the English ones (`sheet_aliases` preserved):

| prefix | disease / measure |
|---|---|
| `#rbtrt_` | oncho / treatment |
| `#lftrt_` | lf / treatment |
| `#schtrt_` | sch / treatment |
| `#sthtrt_` | sth / treatment |
| `#lfmmdp_` | lf / mmdp |
| `#cddtrn_` `#cstrn_` `#mmdptrn_` | rblf / training |
| `#svy_` | rblf / survey |
| `#rivpro_` `#flycol_` | oncho / entomology |

`Drug Inventory` (`#inv_`) and `SBCC` (`#sbcc_`) are logistics / communications, not per-disease measures, so they declare **no** routing keys and are not split.

## Tests

New test: every registered country routes at least one sheet, and **every routed `data_type` is a registered measure** (guards against registry drift — also addresses a reviewer suggestion from #202).

## Scope

The deeper reconciliation of each bundled schema's **sheet set** to its real template (the real `uga` has ~14 sheets with monthly `_jan…_dec` columns vs. the stand-in's 7) remains tracked as follow-up — this PR makes the routing work for every country on the current stand-in sheet sets.

Full offline suite green: **FAIL 0 | PASS 1315**. Part of #175 phase 4.