### PR TITLE
Land ODK syncs in the research channel; retire the odk source token (#175 phase 4)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # erifunctions (development version)
 
+## Feature: `eri_odk_sync()` writes to the `research` channel (ADR-0012, #175 phase 4)
+
+- `eri_odk_sync()` now lands submissions in `data/{country}/{disease}/research/raw/` (was
+  `.../odk/raw/`), recording `data_source = "research"` + `format = "odk"` in its operation log. ODK is
+  the **research** channel's collection *format*, not a `data_source` of its own — so this retires the
+  transitional `odk` source token for new writes (the measure is assigned later, when the analyst cleans
+  the form into a final dataset, so the path carries no measure level yet). The `odk`/`cmr` tokens remain
+  registered for **reading legacy data** and are removed at the Phase-3 cutover. The `da-odk-guide` and
+  `connections-guide` are updated to the `research` paths and a channel-level `eri_approve()`.
+
 ## Feature: `eri_split_cmr()` routes a CMR per disease and measure (ADR-0012, #175 phase 4)
 
 - New `eri_split_cmr(path, country, …)` reads every routable sheet of a CMR monthly report and writes

--- a/R/odk_sync.R
+++ b/R/odk_sync.R
@@ -3,8 +3,11 @@
 #' Sync an ODK form's submissions to Azure
 #'
 #' Downloads all submissions for a registered ODK form and writes them as
-#' Parquet file(s) into `data/{country}/{disease}/odk/raw/` in the Azure `data/`
-#' container. Forms with **repeat groups** (most real forms) export multiple
+#' Parquet file(s) into `data/{country}/{disease}/research/raw/` in the Azure
+#' `data/` container — ODK is the **research** channel's collection format
+#' (`format: odk`) under ADR-0012, not a `data_source` of its own. The measure
+#' (`data_type`) is assigned later, when the analyst cleans the form into a final
+#' dataset. Forms with **repeat groups** (most real forms) export multiple
 #' tables -- the main submission table plus one child table per repeat group --
 #' and each is written as its own Parquet (`{form_id}.parquet`,
 #' `{form_id}-{repeat}.parquet`, ...); a flat form writes a single
@@ -65,7 +68,10 @@ eri_odk_sync <- function(
     return(invisible(NULL))
   }
 
-  raw_dir    <- paste0(country, "/", disease, "/odk/raw")
+  # ODK is the research channel's collection format (ADR-0012): submissions land
+  # in the `research` source (format: odk), not the retired `odk` source token.
+  # The measure is assigned later when the DA cleans the form into a final dataset.
+  raw_dir    <- paste0(country, "/", disease, "/research/raw")
   blob_paths <- character(0)
   for (nm in names(tabs)) {
     bp <- paste0(raw_dir, "/", nm, ".parquet")
@@ -80,17 +86,19 @@ eri_odk_sync <- function(
     analyst    = analyst,
     timestamp  = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     parameters = list(
-      project_id = as.integer(project_id),
-      form_id    = form_id,
-      country    = country,
-      disease    = disease,
-      n_records  = nrow(main),
-      n_tables   = length(tabs),
-      blob_paths = as.list(blob_paths)
+      project_id  = as.integer(project_id),
+      form_id     = form_id,
+      country     = country,
+      disease     = disease,
+      data_source = "research",
+      format      = "odk",
+      n_records   = nrow(main),
+      n_tables    = length(tabs),
+      blob_paths  = as.list(blob_paths)
     ),
     status = "success"
   )
-  .eri_write_log(op_log, data_con, paste0(country, "/", disease, "/odk/logs"))
+  .eri_write_log(op_log, data_con, paste0(country, "/", disease, "/research/logs"))
 
   if (length(tabs) == 1L) {
     cli::cli_alert_success(

--- a/R/odk_sync.R
+++ b/R/odk_sync.R
@@ -40,6 +40,7 @@ eri_odk_sync <- function(
     data_con = NULL,
     overwrite = TRUE
 ) {
+  .eri_log_session()
   data_con <- .odk_data_con(data_con)
   analyst  <- .eri_analyst_id()
 
@@ -71,7 +72,7 @@ eri_odk_sync <- function(
   # ODK is the research channel's collection format (ADR-0012): submissions land
   # in the `research` source (format: odk), not the retired `odk` source token.
   # The measure is assigned later when the DA cleans the form into a final dataset.
-  raw_dir    <- paste0(country, "/", disease, "/research/raw")
+  raw_dir    <- eri_data_path(country, disease, "research", "raw")
   blob_paths <- character(0)
   for (nm in names(tabs)) {
     bp <- paste0(raw_dir, "/", nm, ".parquet")

--- a/inst/registry/data_model.yaml
+++ b/inst/registry/data_model.yaml
@@ -16,9 +16,11 @@ data_sources:
   research:     "Research surveys/studies (household or community level); DA-managed, flexible measure."
   # Transitional (ADR-0012 migration): legacy source tokens still resolve so existing
   # paths don't warn. `cmr` -> `programmatic` (format: cmr); `odk` -> `research`
-  # (format: odk). Both are removed at the Phase-3 cutover.
-  cmr:          "(transitional) Legacy CMR source token; migrating to `programmatic` + format: cmr."
-  odk:          "(transitional) Legacy ODK source token; migrating to `research` + format: odk."
+  # (format: odk). New writes use the real channel — eri_odk_sync() now writes the
+  # `research` source, and eri_split_cmr() writes `programmatic` — so these tokens
+  # remain only for reading legacy data and are removed at the Phase-3 cutover.
+  cmr:          "(transitional, legacy reads only) Old CMR source token; new CMR writes use `programmatic` + format: cmr."
+  odk:          "(transitional, legacy reads only) Old ODK source token; new ODK writes use `research` + format: odk."
 
 data_types:
   case:       "Individual case records (one row per patient)."

--- a/inst/templates/eri_daily_workflow.qmd
+++ b/inst/templates/eri_daily_workflow.qmd
@@ -85,7 +85,8 @@ print(status)
 
 Run `eri_odk_sync()` for each form you manage. Add or remove chunks below as
 needed. Each call downloads new submissions and writes them to the Azure data
-blob at `{country}/{disease}/odk/raw/{form_id}.parquet`.
+blob at `{country}/{disease}/research/raw/{form_id}.parquet` (ODK is the
+`research` channel's collection format under ADR-0012).
 
 ```{r sync-form-1}
 # Replace with your actual project_id, form_id, country, and disease values.

--- a/man/eri_odk_sync.Rd
+++ b/man/eri_odk_sync.Rd
@@ -33,8 +33,11 @@ submissions are found.
 }
 \description{
 Downloads all submissions for a registered ODK form and writes them as
-Parquet file(s) into \verb{data/\{country\}/\{disease\}/odk/raw/} in the Azure \verb{data/}
-container. Forms with \strong{repeat groups} (most real forms) export multiple
+Parquet file(s) into \verb{data/\{country\}/\{disease\}/research/raw/} in the Azure
+\verb{data/} container — ODK is the \strong{research} channel's collection format
+(\code{format: odk}) under ADR-0012, not a \code{data_source} of its own. The measure
+(\code{data_type}) is assigned later, when the analyst cleans the form into a final
+dataset. Forms with \strong{repeat groups} (most real forms) export multiple
 tables -- the main submission table plus one child table per repeat group --
 and each is written as its own Parquet (\verb{\{form_id\}.parquet},
 \verb{\{form_id\}-\{repeat\}.parquet}, ...); a flat form writes a single

--- a/tests/testthat/test-odk_sync.R
+++ b/tests/testthat/test-odk_sync.R
@@ -138,7 +138,7 @@ test_that("eri_odk_sync writes to correct blob path and updates last_synced", {
     data_con = "mock"
   )
 
-  expect_equal(written_path, "uga/oncho/odk/raw/RiverProspection.parquet")
+  expect_equal(written_path, "uga/oncho/research/raw/RiverProspection.parquet")
   expect_equal(written_obj, fake_data)
   expect_false(is.null(stored_reg$forms[[1]]$last_synced))
   expect_invisible(
@@ -151,7 +151,7 @@ test_that("eri_odk_sync writes to correct blob path and updates last_synced", {
 
 # --- blob path construction ---------------------------------------------------
 
-test_that("eri_odk_sync uses correct blob path: {country}/{disease}/odk/raw/{form_id}.parquet", {
+test_that("eri_odk_sync uses correct blob path: {country}/{disease}/research/raw/{form_id}.parquet", {
   entry      <- make_sync_entry(project_id = 3L, country = "nga", disease = "lf", form_id = "LFSurvey")
   stored_reg <- make_sync_reg(entry)
 
@@ -179,7 +179,7 @@ test_that("eri_odk_sync uses correct blob path: {country}/{disease}/odk/raw/{for
 
   eri_odk_sync(project_id = 3L, form_id = "LFSurvey", data_con = "mock")
 
-  expect_equal(written_path, "nga/lf/odk/raw/LFSurvey.parquet")
+  expect_equal(written_path, "nga/lf/research/raw/LFSurvey.parquet")
 })
 
 # --- repeat groups: multiple tables -> multiple Parquets ----------------------
@@ -214,8 +214,8 @@ test_that("eri_odk_sync writes one Parquet per table for a repeat-group form", {
   res <- eri_odk_sync(project_id = 7L, form_id = "RiverRepeat", data_con = "mock")
 
   expect_equal(written_paths, c(
-    "uga/oncho/odk/raw/RiverRepeat.parquet",
-    "uga/oncho/odk/raw/RiverRepeat-larva_sample.parquet"
+    "uga/oncho/research/raw/RiverRepeat.parquet",
+    "uga/oncho/research/raw/RiverRepeat-larva_sample.parquet"
   ))
   # multi-table sync returns the named list of tables
   expect_named(res, c("RiverRepeat", "RiverRepeat-larva_sample"))

--- a/vignettes/connections-guide.Rmd
+++ b/vignettes/connections-guide.Rmd
@@ -80,8 +80,8 @@ eri_list("", azcontainer = data_con)
 ```
 
 The `name` column holds the **full path** from the container root (so a deeper listing like
-`eri_list("uga/demo/odk/raw", …)` returns `uga/demo/odk/raw/<file>` names); pass `full_names = FALSE`
-for just the leaf filenames.
+`eri_list("uga/demo/research/raw", …)` returns `uga/demo/research/raw/<file>` names); pass
+`full_names = FALSE` for just the leaf filenames.
 
 > **For automation / CI (headless).** A scheduled job has no browser. Set a **service principal** —
 > `ERIFUNCTIONS_SP_CLIENT_ID` and `ERIFUNCTIONS_SP_CLIENT_SECRET` in the environment (or pass

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -32,15 +32,15 @@ your ODK Central server, submit a few fake records, and work the loop end-to-end
 
 > **ODK Central is the front door; `erifunctions` brings the data through it into one governed
 > pipeline.** You **register** a form (the registry is the team's record of which forms are tracked),
-> **sync** its submissions into `{country}/{disease}/odk/raw/`, and from there it flows through the
+> **sync** its submissions into `{country}/{disease}/research/raw/`, and from there it flows through the
 > same `raw → staged → processed` lifecycle — with [`eri_approve()`](../reference/eri_approve.html) as
 > the human gate — as every other dataset.
 >
-> **Transitional vocabulary.** `odk` is an interim `data_source` token here. Under the
+> **Where ODK lands.** Under the
 > [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
-> ODK is a *format* of the `research` channel, and its measure (`tas`, `prevalence`, …) is optional —
-> which is why this guide's paths carry no measure level. Keep using `odk` as shown until the research
-> adapter ships; don't adopt it as the canonical channel name.
+> ODK is the **`research`** channel's collection *format* (`format: odk`), so `eri_odk_sync()` writes to
+> the `research` source. Its measure (`tas`, `prevalence`, …) is **optional** and assigned later, when
+> you clean the form into a final dataset — which is why these paths carry no measure level yet.
 
 ```{=html}
 <div class="mermaid">
@@ -49,7 +49,7 @@ flowchart TD
     B --> C["init_odk_connection()"]
     C --> D["Register the form (registry)"]
     D --> E["Monitor + manage collectors"]
-    E --> F["eri_odk_sync() -> odk/raw/"]
+    E --> F["eri_odk_sync() -> research/raw/"]
     F --> G["DQ -> staged/"]
     G --> H["eri_approve() -> processed/"]
     H --> Z["Clean up the sandbox"]
@@ -268,14 +268,14 @@ layer, then stamps the registry with the sync time:
 eri_odk_sync(project_id = project_id, form_id = form_id, con = con, data_con = data_con)
 #> ℹ Downloading submissions for "eri_test_river_prospection" (uga/demo)...
 #> ℹ Downloaded 3 records from "eri_test_river_prospection".
-#> ✔ Synced 3 records from "eri_test_river_prospection" to uga/demo/odk/raw/eri_test_river_prospection.parquet.
+#> ✔ Synced 3 records from "eri_test_river_prospection" to uga/demo/research/raw/eri_test_river_prospection.parquet.
 ```
 
 Read it back to see what landed. ODK expands the form fields plus its own system columns (note the
 `gps` geopoint is split into latitude/longitude/altitude/accuracy):
 
 ```{r read-raw}
-raw <- eri_read("uga/demo/odk/raw/eri_test_river_prospection.parquet", azcontainer = data_con)
+raw <- eri_read("uga/demo/research/raw/eri_test_river_prospection.parquet", azcontainer = data_con)
 names(raw)
 #>  [1] "SubmissionDate"   "start"            "end"              "today"
 #>  [5] "site_name"        "prospection_date" "river_stage"      "blackfly_count"
@@ -298,31 +298,33 @@ cleaned result to `staged/`, then **approve** it into the canonical `processed/`
 
 ```{r stage}
 # (After any DQ checks.) Stage the data under a reporting period.
-staged_path <- eri_data_path("uga", "demo", "odk", "staged",
+staged_path <- eri_data_path("uga", "demo", "research", "staged",
                              "eri_test_river_prospection_2026-06.parquet")
 eri_write(raw, staged_path, azcontainer = data_con)
 ```
 
 ```{r approve}
-eri_approve("uga", "demo", "odk", "2026-06", azcontainer = data_con)
+# Channel-level approve (no measure yet); pass data_type = once you assign one.
+eri_approve("uga", "demo", "research", "2026-06", azcontainer = data_con)
+#> ℹ Approving the channel-level (no-measure) form; the catalog entry's data_type will be NA.
 #> ✔ Catalog: registered eri_test_river_prospection_2026-06.parquet.
 #> ✔ Approved: eri_test_river_prospection_2026-06.parquet
-#> ✔ Approval log: uga/demo/odk/processed/2026-06_approval_log.yaml
+#> ✔ Approval log: uga/demo/research/processed/2026-06_approval_log.yaml
 #> ── ✔ Approved "2026-06" ─────────────────────────────────
-#> Dataset: uga / demo / odk
+#> Dataset: uga / demo / research
 #> Files: 1 moved to processed
 #> Approver: your.name
-#> Location: uga/demo/odk/processed
+#> Location: uga/demo/research/processed
 ```
 
 Your ODK submissions are now canonical, discoverable in the catalog like any other approved dataset:
 
 ```{r catalog}
 eri_catalog_query(country = "uga", disease = "demo", data_con = data_con)
-#> # A tibble: 1 × 12
-#>   path                                  country disease data_type layer     period  …
-#>   <chr>                                 <chr>   <chr>   <chr>     <chr>     <chr>
-#> 1 uga/demo/odk/processed/eri_test_rive… uga     demo    odk       processed 2026-06
+#> # A tibble: 1 × 13
+#>   path                              country disease data_source data_type layer …
+#>   <chr>                             <chr>   <chr>   <chr>       <chr>     <chr>
+#> 1 uga/demo/research/processed/eri…  uga     demo    research    NA        proces…
 ```
 
 ## 4. Forms with repeat groups {#repeat-groups}
@@ -414,14 +416,14 @@ eri_odk_sync(project_id = project_id, form_id = repeat_form_id, con = con, data_
 #> ℹ Downloaded 2 tables from "eri_test_river_repeat":
 #> • "eri_test_river_repeat": 3 records
 #> • "eri_test_river_repeat-larva_sample": 7 records
-#> ✔ Synced "eri_test_river_repeat": 3 submissions + 1 repeat table to 'uga/demo/odk/raw/'.
+#> ✔ Synced "eri_test_river_repeat": 3 submissions + 1 repeat table to 'uga/demo/research/raw/'.
 ```
 
 You now have two files in `raw/` — a flat form would have left exactly one:
 
 ```
-uga/demo/odk/raw/eri_test_river_repeat.parquet                # parent: 3 submissions
-uga/demo/odk/raw/eri_test_river_repeat-larva_sample.parquet   # child:  7 samples
+uga/demo/research/raw/eri_test_river_repeat.parquet                # parent: 3 submissions
+uga/demo/research/raw/eri_test_river_repeat-larva_sample.parquet   # child:  7 samples
 ```
 
 ### Rejoin them for analysis
@@ -431,8 +433,8 @@ want one flat table (one row per sample, carrying its site context), join the ch
 `PARENT_KEY` = `KEY`:
 
 ```{r repeat-join}
-parent  <- eri_read("uga/demo/odk/raw/eri_test_river_repeat.parquet", azcontainer = data_con)
-samples <- eri_read("uga/demo/odk/raw/eri_test_river_repeat-larva_sample.parquet",
+parent  <- eri_read("uga/demo/research/raw/eri_test_river_repeat.parquet", azcontainer = data_con)
+samples <- eri_read("uga/demo/research/raw/eri_test_river_repeat-larva_sample.parquet",
                     azcontainer = data_con)
 
 flat <- dplyr::left_join(

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -307,6 +307,7 @@ eri_write(raw, staged_path, azcontainer = data_con)
 # Channel-level approve (no measure yet); pass data_type = once you assign one.
 eri_approve("uga", "demo", "research", "2026-06", azcontainer = data_con)
 #> ℹ Approving the channel-level (no-measure) form; the catalog entry's data_type will be NA.
+#>   Pass data_type (e.g. "case", "aggregate", "treatment") to record a measure (ADR-0012).
 #> ✔ Catalog: registered eri_test_river_prospection_2026-06.parquet.
 #> ✔ Approved: eri_test_river_prospection_2026-06.parquet
 #> ✔ Approval log: uga/demo/research/processed/2026-06_approval_log.yaml


### PR DESCRIPTION
## What

`eri_odk_sync()` now writes ODK submissions to `data/{country}/{disease}/research/raw/` (was `.../odk/raw/`), recording `data_source = "research"` + `format = "odk"` in its operation log.

## Why

Under ADR-0012, **ODK is the `research` channel's collection *format***, not a `data_source` of its own. This retires the transitional `odk` source token for new writes — completing the source/measure migration for the ODK path (the last transitional channel token in active use besides CMR's `rblf`/`cmr`). The measure (`data_type`) is assigned later, when the analyst cleans the form into a final dataset, so the synced raw path carries no measure level yet (the `research` channel's measure is optional per ADR-0012 §2).

## Changes

- **`R/odk_sync.R`**: raw dir → `{country}/{disease}/research/raw`; op-log gains `data_source = "research"` + `format = "odk"`; logs → `.../research/logs`; roxygen updated.
- **`data_model.yaml`**: the `odk`/`cmr` source tokens stay registered for **reading legacy data** (removed at the Phase-3 cutover); the comment now notes new writes use the real channel (`research` / `programmatic`).
- **Tests**: `eri_odk_sync` blob-path assertions → `research/raw` (single-table + repeat-group).
- **`da-odk-guide`** + **`connections-guide`**: updated to `research` paths and a channel-level `eri_approve("uga","demo","research", period)` (which now emits the no-measure signpost from #197); mermaid + golden-rule callout reworded.

## Verification

Full offline suite green: **FAIL 0 | PASS 1256** (this branch is behind `main` by the non-overlapping #203). `da-odk-guide` knits clean.

Part of #175 phase 4. Legacy ODK data already under `.../odk/raw/` stays readable (the `odk` token still resolves); only new syncs use `research`.