### PR TITLE
Sweep adding-a-program + epi-analytics off legacy schema names (#175 phase 4)

### DIFF
--- a/vignettes/adding-a-program.Rmd
+++ b/vignettes/adding-a-program.Rmd
@@ -32,7 +32,9 @@ eri_onboard_disease(
   data_types = c("mda", "prevalence"),
   output_dir = "schemas/"     # write locally, not to the package
 )
-# Writes schemas/ug_schisto_mda.yaml and schemas/ug_schisto_prevalence.yaml
+# Writes schemas/ug_schisto_programmatic_treatment.yaml and
+#        schemas/ug_schisto_research_prevalence.yaml (ADR-0012: mda -> programmatic/
+#        treatment, prevalence -> research/prevalence)
 ```
 
 Use `dry_run = TRUE` first to preview what will be written:
@@ -46,7 +48,7 @@ eri_onboard_disease("rb", "eth", dry_run = TRUE)
 Open each skeleton file and complete the TODO sections:
 
 ```yaml
-# ug_schisto_mda.yaml (excerpt)
+# ug_schisto_programmatic_treatment.yaml (excerpt)
 columns:
   species_target:
     required: true
@@ -93,7 +95,7 @@ Fix any flagged issues before moving on. Common problems:
 Before submitting, test the schema against real or synthetic data:
 
 ```{r test-dq}
-schema <- load_dq_schema("ug", "schisto_mda", azcontainer = NULL)
+schema <- load_dq_schema("ug", "schisto", "programmatic", "treatment", azcontainer = NULL)
 # azcontainer = NULL tells it to use the local file, not Azure
 
 # Create a small synthetic data frame that matches your schema
@@ -115,19 +117,19 @@ ready for real data.
 
 ## 5. Submit to the package
 
-Copy the validated schema file to `inst/schemas/` using the naming convention
-`{country}_{disease}_{data_type}.yaml`:
+Copy the validated schema file to `inst/schemas/` using the four-part identity
+`{country}_{disease}_{data_source}_{data_type}.yaml` (ADR-0012):
 
 ```
-inst/schemas/ug_schisto_mda.yaml
-inst/schemas/ug_schisto_prevalence.yaml
+inst/schemas/ug_schisto_programmatic_treatment.yaml
+inst/schemas/ug_schisto_research_prevalence.yaml
 ```
 
 PR checklist:
 
 - [ ] Schema file is in `inst/schemas/` with correct name
 - [ ] `eri_schema_validate()` returns 0 issues
-- [ ] `load_dq_schema("ug", "schisto_mda", azcontainer = NULL)` works
+- [ ] `load_dq_schema("ug", "schisto", "programmatic", "treatment", azcontainer = NULL)` works
 - [ ] At least one `load_dq_schema` + `eri_schema_validate` test added to
   `tests/testthat/test-onboarding.R` following the existing pattern
 - [ ] NEWS.md entry in the next version section

--- a/vignettes/epi-analytics.Rmd
+++ b/vignettes/epi-analytics.Rmd
@@ -127,11 +127,11 @@ for those rows, so batch processing is not interrupted.
 
 ## Lymphatic filariasis: MDA coverage
 
-Use the `ht_lf_mda` and `dr_lf_mda` schemas to clean coverage data, then
-compute programme indicators:
+Use the `ht_lf_programmatic_treatment` and `dr_lf_programmatic_treatment` schemas
+to clean coverage data, then compute programme indicators:
 
 ```{r lf-mda}
-schema <- load_dq_schema("ht", "lf_mda", azcontainer = NULL)
+schema <- load_dq_schema("ht", "lf", "programmatic", "treatment", azcontainer = NULL)
 result <- run_dq_checks(raw_mda, schema)
 
 coverage <- result$data |>


### PR DESCRIPTION
## What

Updates the last two guides still teaching the pre-ADR-0012 schema vocabulary to the four-part identity `{country}_{disease}_{data_source}_{data_type}.yaml`.

## Changes

- **`adding-a-program`**: `eri_onboard_disease()` now emits the four-part names (`ug_schisto_programmatic_treatment.yaml` / `ug_schisto_research_prevalence.yaml`, was `_mda` / `_prevalence`), so the guide's "what it writes" comments, the schema excerpt header, the `load_dq_schema()` example, the naming-convention section, and the PR checklist now all use `load_dq_schema(country, disease, data_source, data_type)`.
- **`epi-analytics`**: `load_dq_schema("ht", "lf_mda")` → `load_dq_schema("ht", "lf", "programmatic", "treatment")` (verified it resolves to the bundled `ht_lf_programmatic_treatment` schema).

## Verification

Both guides are `eval = FALSE` (representative); knit-checked clean. The `ht_lf` 4-arg call was run live and resolves. Pure docs — no code change.

Completes the guide-sweep portion of #175 phase 4 (the personas, da-ingest/da-odk/da-onboard/da-cmr, README, and `eri_daily_workflow` were swept earlier). Part of #175.