### PR TITLE
Reconcile bundled CMR schemas to the real country templates (#175 / #54)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # erifunctions (development version)
 
+## Data: bundled CMR schemas reconciled to the real country templates (ADR-0012, #175)
+
+- The seven bundled CMR schemas (`inst/schemas/cmr/{eth,nga,sdn,ssd,uga,tcd,mad}.yaml`) are regenerated
+  from the **real** monthly templates' structure (sheet names + machine-readable field codes only — no
+  data values), replacing the earlier simplified stand-ins. Each country now carries its actual sheet set
+  with `disease` / `data_type` routing keys, so `eri_split_cmr()` routes a real CMR completely: e.g. uga's
+  14 sheets (RB/SCH Treatment, LF MMDP, VHT/Parish/Local-Leaders/Subcounty/MMDP-surgery/MMDP-patient/
+  Field-Ento/Lab Training, LF Surveys, RB Epi Surveys, RB Ento Surveys); nga adds SCH/STH Treatment +
+  Teacher/Health-Worker/Hope-Group trainings; mad is LF-only; the French `tcd`/`mad` keep their slug
+  aliases. RB Epi Surveys → `oncho`/`prevalence`, RB Ento Surveys → `oncho`/`entomology`, LF Surveys →
+  `lf`/`tas`, all Training sheets (incl. ToT) → combined `rblf`/`training`. `required_fields` now lists the
+  real stable (non-monthly) identifier columns.
+
 ## Feature: `eri_odk_sync()` writes to the `research` channel (ADR-0012, #175 phase 4)
 
 - `eri_odk_sync()` now lands submissions in `data/{country}/{disease}/research/raw/` (was

--- a/inst/schemas/cmr/eth.yaml
+++ b/inst/schemas/cmr/eth.yaml
@@ -3,138 +3,233 @@ country_code: eth
 language: en
 template: english_cmr
 
-# Per-sheet routing (disease from the sheet; data_type = the measure) drives
-# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
-# Drug Inventory and SBCC are logistics / communications, not per-disease
-# measures, so they declare no routing keys and are not split.
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheets:
-  RB Treatment:
+  "RB Treatment":
     field_code_prefix: "#rbtrt_"
     disease: oncho
     data_type: treatment
     required_fields:
       - "#rbtrt_year"
-      - "#rbtrt_month"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
       - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
       - "#rbtrt_adm2"
-      - "#rbtrt_target"
-      - "#rbtrt_treated"
-
-  LF Treatment:
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
+  "LF Treatment":
     field_code_prefix: "#lftrt_"
     disease: lf
     data_type: treatment
     required_fields:
       - "#lftrt_year"
-      - "#lftrt_month"
+      - "#lftrt_adm0"
+      - "#lftrt_adm0_id"
       - "#lftrt_adm1"
+      - "#lftrt_adm1_id"
       - "#lftrt_adm2"
-      - "#lftrt_target"
-      - "#lftrt_treated"
-
-  LF MMDP:
-    field_code_prefix: "#lfmmdp_"
+      - "#lftrt_adm2_id"
+      - "#lftrt_adm3"
+      - "#lftrt_disease"
+  "LF MMDP":
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
-  CDD Training:
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
+  "CDD Training":
     field_code_prefix: "#cddtrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cddtrn_year"
-      - "#cddtrn_month"
+      - "#cddtrn_adm0"
+      - "#cddtrn_adm0_id"
       - "#cddtrn_adm1"
+      - "#cddtrn_adm1_id"
       - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
-  CS Training:
+      - "#cddtrn_adm2_id"
+      - "#cddtrn_adm3"
+      - "#cddtrn_disease"
+  "CS Training":
     field_code_prefix: "#cstrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cstrn_year"
-      - "#cstrn_month"
+      - "#cstrn_adm0"
+      - "#cstrn_adm0_id"
       - "#cstrn_adm1"
+      - "#cstrn_adm1_id"
       - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  MMDP Training:
-    field_code_prefix: "#mmdptrn_"
+      - "#cstrn_adm2_id"
+      - "#cstrn_adm3"
+      - "#cstrn_disease"
+  "MMDP (surgery) Training":
+    field_code_prefix: "#dmditrnsx_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  Surveys:
-    field_code_prefix: "#svy_"
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "MMDP (patient) Training":
+    field_code_prefix: "#dmditrnpt_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
-
-  Drug Inventory:
-    field_code_prefix: "#inv_"
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Field Ento Training":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
     required_fields:
-      - "#inv_year"
-      - "#inv_month"
-      - "#inv_adm1"
-      - "#inv_drug"
-      - "#inv_opening_balance"
-      - "#inv_received"
-      - "#inv_distributed"
-      - "#inv_closing_balance"
-
-  SBCC:
-    field_code_prefix: "#sbcc_"
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Hope Group Leader Training":
+    field_code_prefix: "#hgtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
-      - "#sbcc_year"
-      - "#sbcc_month"
-      - "#sbcc_adm1"
-      - "#sbcc_adm2"
-      - "#sbcc_type"
-      - "#sbcc_people_reached"
-
-  River Prospection:
-    field_code_prefix: "#rivpro_"
+      - "#hgtrn_year"
+      - "#hgtrn_adm0"
+      - "#hgtrn_adm0_id"
+      - "#hgtrn_adm1"
+      - "#hgtrn_adm1_id"
+      - "#hgtrn_adm2"
+      - "#hgtrn_adm2_id"
+      - "#hgtrn_adm3"
+      - "#hgtrn_disease"
+  "HW Training":
+    field_code_prefix: "#hwtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hwtrn_year"
+      - "#hwtrn_adm0"
+      - "#hwtrn_adm0_id"
+      - "#hwtrn_adm1"
+      - "#hwtrn_adm1_id"
+      - "#hwtrn_adm2"
+      - "#hwtrn_adm2_id"
+      - "#hwtrn_adm3"
+      - "#hwtrn_disease"
+  "Lab Training":
+    field_code_prefix: "#labtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#labtrn_year"
+      - "#labtrn_adm0"
+      - "#labtrn_adm0_id"
+      - "#labtrn_adm1"
+      - "#labtrn_adm1_id"
+      - "#labtrn_adm2"
+      - "#labtrn_adm2_id"
+      - "#labtrn_adm3"
+      - "#labtrn_disease"
+  "ToT Regional":
+    field_code_prefix: "#tot_reg_trn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#tot_reg_trn_year"
+      - "#tot_reg_trn_adm0"
+      - "#tot_reg_trn_adm0_id"
+      - "#tot_reg_trn_adm1"
+      - "#tot_reg_trn_donor"
+      - "#tot_reg_trn_goal"
+      - "#tot_reg_trn_tot_reg__male"
+      - "#tot_reg_trn_tot_reg__fem"
+  "ToT Zonal":
+    field_code_prefix: "#tot_zone_trn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#tot_zone_trn_year"
+      - "#tot_zone_trn_adm0"
+      - "#tot_zone_trn_adm1"
+      - "#tot_zone_trn_adm2"
+      - "#tot_zone_trn_donor"
+      - "#tot_zone_trn_goal"
+      - "#tot_zone_trn_tot_zone__male"
+      - "#tot_zone_trn_tot_zone__fem"
+  "LF Surveys":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "RB Epi Surveys":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "RB Ento Surveys":
+    field_code_prefix: "#rb_ento_surv_"
     disease: oncho
     data_type: entomology
     required_fields:
-      - "#rivpro_year"
-      - "#rivpro_month"
-      - "#rivpro_adm1"
-      - "#rivpro_site"
-      - "#rivpro_blackfly_positive"
-
-  Fly Collection:
-    field_code_prefix: "#flycol_"
-    disease: oncho
-    data_type: entomology
-    required_fields:
-      - "#flycol_year"
-      - "#flycol_month"
-      - "#flycol_adm1"
-      - "#flycol_site"
-      - "#flycol_flies_dissected"
-      - "#flycol_parous_rate"
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/inst/schemas/cmr/mad.yaml
+++ b/inst/schemas/cmr/mad.yaml
@@ -3,18 +3,18 @@ country_code: mad
 language: fr
 template: french_cmr
 
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheet_aliases:
   lf_treatment: "Traitement FL"
   lf_mmdp: "PCMPI FL"
-  cdd_training: "Formation Distributeurs"
-  cs_training: "Formation SC"
-  mmdp_training: "Formation Travailleurs de Sante"
-  mmdp_surgery_training: "PCMPI Formation Chirurgie"
-  surveys: "Enquêtes FL"
+  lf_surveys: "FL Enquetes"
 
-# Per-sheet routing (disease from the sheet; data_type = the measure) drives
-# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
-# Madagascar is LF-only (no RB/oncho sheets).
 sheets:
   "Traitement FL":
     field_code_prefix: "#lftrt_"
@@ -22,84 +22,135 @@ sheets:
     data_type: treatment
     required_fields:
       - "#lftrt_year"
-      - "#lftrt_month"
+      - "#lftrt_adm0"
+      - "#lftrt_adm0_id"
       - "#lftrt_adm1"
+      - "#lftrt_adm1_id"
       - "#lftrt_adm2"
-      - "#lftrt_target"
-      - "#lftrt_treated"
-
+      - "#lftrt_adm2_id"
+      - "#lftrt_adm3"
+      - "#lftrt_disease"
   "PCMPI FL":
-    field_code_prefix: "#lfmmdp_"
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_adm3_id"
+      - "#lfdmdi_disease"
   "Formation Distributeurs":
     field_code_prefix: "#cddtrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cddtrn_year"
-      - "#cddtrn_month"
+      - "#cddtrn_adm0"
+      - "#cddtrn_adm0_id"
       - "#cddtrn_adm1"
+      - "#cddtrn_adm1_id"
       - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
+      - "#cddtrn_adm2_id"
+      - "#cddtrn_adm3"
+      - "#cddtrn_disease"
   "Formation SC":
     field_code_prefix: "#cstrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cstrn_year"
-      - "#cstrn_month"
+      - "#cstrn_adm0"
+      - "#cstrn_adm0_id"
       - "#cstrn_adm1"
+      - "#cstrn_adm1_id"
       - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  "Formation Travailleurs de Sante":
-    field_code_prefix: "#mmdptrn_"
-    disease: rblf
-    data_type: training
-    required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  # Surgery training shares the MMDP-training field codes; it is a distinct sheet,
-  # so it stages as a distinct file in the same rblf/programmatic/training/ dir.
+      - "#cstrn_adm2_id"
+      - "#cstrn_adm3"
+      - "#cstrn_disease"
   "PCMPI Formation Chirurgie":
-    field_code_prefix: "#mmdptrn_"
+    field_code_prefix: "#dmditrnsx_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  "Enquêtes FL":
-    field_code_prefix: "#svy_"
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "Formation PCMPI Patient":
+    field_code_prefix: "#dmditrnpt_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
+      - "#dmditrnpt__year"
+      - "#dmditrnpt__adm0"
+      - "#dmditrnpt__adm0_id"
+      - "#dmditrnpt__adm1"
+      - "#dmditrnpt__adm1_id"
+      - "#dmditrnpt__adm2"
+      - "#dmditrnpt__adm2_id"
+      - "#dmditrnpt__adm3"
+      - "#dmditrnpt__disease"
+  "Formation Travailleurs de Sante":
+    field_code_prefix: "#hwtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hwtrn_year"
+      - "#hwtrn_adm0"
+      - "#hwtrn_adm0_id"
+      - "#hwtrn_adm1"
+      - "#hwtrn_adm1_id"
+      - "#hwtrn_adm2"
+      - "#hwtrn_adm2_id"
+      - "#hwtrn_adm3"
+      - "#hwtrn_disease"
+  "Formation Leader Groupe HOPE":
+    field_code_prefix: "#hgtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hgtrn__year"
+      - "#hgtrn__adm0"
+      - "#hgtrn__adm0_id"
+      - "#hgtrn__adm1"
+      - "#hgtrn__adm1_id"
+      - "#hgtrn__adm2"
+      - "#hgtrn__adm2_id"
+      - "#hgtrn__adm3"
+      - "#hgtrn__disease"
+  "Formation Professeurs":
+    field_code_prefix: "#tch"
+    required_fields:
+      - "#tchrtrn_year"
+      - "#tchrtrn_adm0"
+      - "#tchrtrn_adm0_id"
+      - "#tchrtrn_adm1"
+      - "#tchrtrn_adm1_id"
+      - "#tchrtrn_adm2"
+      - "#tchrtrn_adm2_id"
+      - "#tchrtrn_adm3"
+      - "#tchrtrn_disease"
+  "FL Enquetes":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"

--- a/inst/schemas/cmr/mad.yaml
+++ b/inst/schemas/cmr/mad.yaml
@@ -129,7 +129,9 @@ sheets:
       - "#hgtrn__adm3"
       - "#hgtrn__disease"
   "Formation Professeurs":
-    field_code_prefix: "#tch"
+    field_code_prefix: "#tchrtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#tchrtrn_year"
       - "#tchrtrn_adm0"

--- a/inst/schemas/cmr/nga.yaml
+++ b/inst/schemas/cmr/nga.yaml
@@ -194,7 +194,9 @@ sheets:
       - "#labtrn_adm3"
       - "#labtrn_disease"
   "Teacher Training":
-    field_code_prefix: "#tch"
+    field_code_prefix: "#tchrtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#tchrtrn_year"
       - "#tchrtrn_adm0"

--- a/inst/schemas/cmr/nga.yaml
+++ b/inst/schemas/cmr/nga.yaml
@@ -3,115 +3,247 @@ country_code: nga
 language: en
 template: english_cmr
 
-# Per-sheet routing (disease from the sheet; data_type = the measure) drives
-# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheets:
-  RB Treatment:
+  "RB Treatment":
     field_code_prefix: "#rbtrt_"
     disease: oncho
     data_type: treatment
     required_fields:
       - "#rbtrt_year"
-      - "#rbtrt_month"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
       - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
       - "#rbtrt_adm2"
-      - "#rbtrt_target"
-      - "#rbtrt_treated"
-
-  LF Treatment:
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
+  "LF Treatment":
     field_code_prefix: "#lftrt_"
     disease: lf
     data_type: treatment
     required_fields:
       - "#lftrt_year"
-      - "#lftrt_month"
+      - "#lftrt_adm0"
+      - "#lftrt_adm0_id"
       - "#lftrt_adm1"
+      - "#lftrt_adm1_id"
       - "#lftrt_adm2"
-      - "#lftrt_target"
-      - "#lftrt_treated"
-
-  SCH Treatment:
+      - "#lftrt_adm2_id"
+      - "#lftrt_adm3"
+      - "#lftrt_disease"
+  "SCH Treatment":
     field_code_prefix: "#schtrt_"
     disease: sch
     data_type: treatment
     required_fields:
       - "#schtrt_year"
-      - "#schtrt_month"
+      - "#schtrt_adm0"
+      - "#schtrt_adm0_id"
       - "#schtrt_adm1"
+      - "#schtrt_adm1_id"
       - "#schtrt_adm2"
-      - "#schtrt_target"
-      - "#schtrt_treated"
-
-  STH Treatment:
+      - "#schtrt_adm2_id"
+      - "#schtrt_adm3"
+      - "#schtrt_disease"
+  "STH Treatment":
     field_code_prefix: "#sthtrt_"
     disease: sth
     data_type: treatment
     required_fields:
       - "#sthtrt_year"
-      - "#sthtrt_month"
+      - "#sthtrt_adm0"
+      - "#sthtrt_adm0_id"
       - "#sthtrt_adm1"
+      - "#sthtrt_adm1_id"
       - "#sthtrt_adm2"
-      - "#sthtrt_target"
-      - "#sthtrt_treated"
-
-  LF MMDP:
-    field_code_prefix: "#lfmmdp_"
+      - "#sthtrt_adm2_id"
+      - "#sthtrt_adm3"
+      - "#sthtrt_disease"
+  "LF MMDP":
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
-  CDD Training:
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
+  "CDD Training":
     field_code_prefix: "#cddtrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cddtrn_year"
-      - "#cddtrn_month"
+      - "#cddtrn_adm0"
+      - "#cddtrn_adm0_id"
       - "#cddtrn_adm1"
+      - "#cddtrn_adm1_id"
       - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
-  CS Training:
+      - "#cddtrn_adm2_id"
+      - "#cddtrn_adm3"
+      - "#cddtrn_disease"
+  "CS Training":
     field_code_prefix: "#cstrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cstrn_year"
-      - "#cstrn_month"
+      - "#cstrn_adm0"
+      - "#cstrn_adm0_id"
       - "#cstrn_adm1"
+      - "#cstrn_adm1_id"
       - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  MMDP Training:
-    field_code_prefix: "#mmdptrn_"
+      - "#cstrn_adm2_id"
+      - "#cstrn_adm3"
+      - "#cstrn_disease"
+  "MMDP (surgery) Training":
+    field_code_prefix: "#dmditrnsx_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  Surveys:
-    field_code_prefix: "#svy_"
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "MMDP (patient) Training":
+    field_code_prefix: "#dmditrnpt_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Field Ento Training":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Health Workers Training":
+    field_code_prefix: "#hwtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hwtrn_year"
+      - "#hwtrn_adm0"
+      - "#hwtrn_adm0_id"
+      - "#hwtrn_adm1"
+      - "#hwtrn_adm1_id"
+      - "#hwtrn_adm2"
+      - "#hwtrn_adm2_id"
+      - "#hwtrn_adm3"
+      - "#hwtrn_disease"
+  "Hope Group Leader Training":
+    field_code_prefix: "#hgtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hgtrn_year"
+      - "#hgtrn_adm0"
+      - "#hgtrn_adm0_id"
+      - "#hgtrn_adm1"
+      - "#hgtrn_adm1_id"
+      - "#hgtrn_adm2"
+      - "#hgtrn_adm2_id"
+      - "#hgtrn_adm3"
+      - "#hgtrn_disease"
+  "Lab Training":
+    field_code_prefix: "#labtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#labtrn_year"
+      - "#labtrn_adm0"
+      - "#labtrn_adm0_id"
+      - "#labtrn_adm1"
+      - "#labtrn_adm1_id"
+      - "#labtrn_adm2"
+      - "#labtrn_adm2_id"
+      - "#labtrn_adm3"
+      - "#labtrn_disease"
+  "Teacher Training":
+    field_code_prefix: "#tch"
+    required_fields:
+      - "#tchrtrn_year"
+      - "#tchrtrn_adm0"
+      - "#tchrtrn_adm0_id"
+      - "#tchrtrn_adm1"
+      - "#tchrtrn_adm1_id"
+      - "#tchrtrn_adm2"
+      - "#tchrtrn_adm2_id"
+      - "#tchrtrn_adm3"
+      - "#tchrtrn_disease"
+  "LF Surveys":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "RB Epi Surveys":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "RB Ento Surveys":
+    field_code_prefix: "#rb_ento_surv_"
+    disease: oncho
+    data_type: entomology
+    required_fields:
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/inst/schemas/cmr/sdn.yaml
+++ b/inst/schemas/cmr/sdn.yaml
@@ -3,91 +3,179 @@ country_code: sdn
 language: en
 template: english_cmr
 
-# Per-sheet routing (disease from the sheet; data_type = the measure) drives
-# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheets:
-  RB Treatment:
+  "RB Treatment":
     field_code_prefix: "#rbtrt_"
     disease: oncho
     data_type: treatment
     required_fields:
       - "#rbtrt_year"
-      - "#rbtrt_month"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
       - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
       - "#rbtrt_adm2"
-      - "#rbtrt_target"
-      - "#rbtrt_treated"
-
-  LF Treatment:
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
+  "LF Treatment":
     field_code_prefix: "#lftrt_"
     disease: lf
     data_type: treatment
     required_fields:
       - "#lftrt_year"
-      - "#lftrt_month"
+      - "#lftrt_adm0"
+      - "#lftrt_adm0_id"
       - "#lftrt_adm1"
+      - "#lftrt_adm1_id"
       - "#lftrt_adm2"
-      - "#lftrt_target"
-      - "#lftrt_treated"
-
-  LF MMDP:
-    field_code_prefix: "#lfmmdp_"
+      - "#lftrt_adm2_id"
+      - "#lftrt_adm3"
+      - "#lftrt_disease"
+  "LF MMDP":
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
-  CDD Training:
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
+  "CDD Training":
     field_code_prefix: "#cddtrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cddtrn_year"
-      - "#cddtrn_month"
+      - "#cddtrn_adm0"
+      - "#cddtrn_adm0_id"
       - "#cddtrn_adm1"
+      - "#cddtrn_adm1_id"
       - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
-  CS Training:
+      - "#cddtrn_adm2_id"
+      - "#cddtrn_adm3"
+      - "#cddtrn_disease"
+  "CS Training":
     field_code_prefix: "#cstrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cstrn_year"
-      - "#cstrn_month"
+      - "#cstrn_adm0"
+      - "#cstrn_adm0_id"
       - "#cstrn_adm1"
+      - "#cstrn_adm1_id"
       - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  MMDP Training:
-    field_code_prefix: "#mmdptrn_"
+      - "#cstrn_adm2_id"
+      - "#cstrn_adm3"
+      - "#cstrn_disease"
+  "MMDP (surgery) Training":
+    field_code_prefix: "#dmditrnsx_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  Surveys:
-    field_code_prefix: "#svy_"
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "MMDP (patient) Training":
+    field_code_prefix: "#dmditrnpt_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Field Ento Training":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Health Workers Training":
+    field_code_prefix: "#hwtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hwtrn_year"
+      - "#hwtrn_adm0"
+      - "#hwtrn_adm0_id"
+      - "#hwtrn_adm1"
+      - "#hwtrn_adm1_id"
+      - "#hwtrn_adm2"
+      - "#hwtrn_adm2_id"
+      - "#hwtrn_adm3"
+      - "#hwtrn_disease"
+  "LF Surveys":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "RB Epi Surveys":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "RB Ento Surveys":
+    field_code_prefix: "#rb_ento_surv_"
+    disease: oncho
+    data_type: entomology
+    required_fields:
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/inst/schemas/cmr/ssd.yaml
+++ b/inst/schemas/cmr/ssd.yaml
@@ -3,91 +3,179 @@ country_code: ssd
 language: en
 template: english_cmr
 
-# Per-sheet routing (disease from the sheet; data_type = the measure) drives
-# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/.
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheets:
-  RB Treatment:
+  "RB Treatment":
     field_code_prefix: "#rbtrt_"
     disease: oncho
     data_type: treatment
     required_fields:
       - "#rbtrt_year"
-      - "#rbtrt_month"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
       - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
       - "#rbtrt_adm2"
-      - "#rbtrt_target"
-      - "#rbtrt_treated"
-
-  LF Treatment:
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
+  "LF Treatment":
     field_code_prefix: "#lftrt_"
     disease: lf
     data_type: treatment
     required_fields:
       - "#lftrt_year"
-      - "#lftrt_month"
+      - "#lftrt_adm0"
+      - "#lftrt_adm0_id"
       - "#lftrt_adm1"
+      - "#lftrt_adm1_id"
       - "#lftrt_adm2"
-      - "#lftrt_target"
-      - "#lftrt_treated"
-
-  LF MMDP:
-    field_code_prefix: "#lfmmdp_"
+      - "#lftrt_adm2_id"
+      - "#lftrt_adm3"
+      - "#lftrt_disease"
+  "LF MMDP":
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
-  CDD Training:
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
+  "CDD Training":
     field_code_prefix: "#cddtrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cddtrn_year"
-      - "#cddtrn_month"
+      - "#cddtrn_adm0"
+      - "#cddtrn_adm0_id"
       - "#cddtrn_adm1"
+      - "#cddtrn_adm1_id"
       - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
-  CS Training:
+      - "#cddtrn_adm2_id"
+      - "#cddtrn_adm3"
+      - "#cddtrn_disease"
+  "CS Training":
     field_code_prefix: "#cstrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cstrn_year"
-      - "#cstrn_month"
+      - "#cstrn_adm0"
+      - "#cstrn_adm0_id"
       - "#cstrn_adm1"
+      - "#cstrn_adm1_id"
       - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  MMDP Training:
-    field_code_prefix: "#mmdptrn_"
+      - "#cstrn_adm2_id"
+      - "#cstrn_adm3"
+      - "#cstrn_disease"
+  "MMDP (surgery) Training":
+    field_code_prefix: "#dmditrnsx_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  Surveys:
-    field_code_prefix: "#svy_"
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "MMDP (patient) Training":
+    field_code_prefix: "#dmditrnpt_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Field Ento Training":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Health Workers Training":
+    field_code_prefix: "#hwtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hwtrn_year"
+      - "#hwtrn_adm0"
+      - "#hwtrn_adm0_id"
+      - "#hwtrn_adm1"
+      - "#hwtrn_adm1_id"
+      - "#hwtrn_adm2"
+      - "#hwtrn_adm2_id"
+      - "#hwtrn_adm3"
+      - "#hwtrn_disease"
+  "LF Surveys":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "RB Epi Surveys":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "RB Ento Surveys":
+    field_code_prefix: "#rb_ento_surv_"
+    disease: oncho
+    data_type: entomology
+    required_fields:
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/inst/schemas/cmr/tcd.yaml
+++ b/inst/schemas/cmr/tcd.yaml
@@ -3,18 +3,19 @@ country_code: tcd
 language: fr
 template: french_cmr
 
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheet_aliases:
   rb_treatment: "Oncho Traitement"
   lf_treatment: "Traitement FL"
   lf_mmdp: "LF MMDP"
-  cdd_training: "Formation Distributeurs Comm"
-  cs_training: "Formation Superviseurs Comm"
-  surveys: "Enquêtes"
+  lf_surveys: "LF Enquetes"
 
-# Per-sheet routing (disease from the sheet; data_type = the measure) drives
-# eri_split_cmr() -> {country}/{disease}/programmatic/{data_type}/staged/. The
-# #field codes are language-neutral, so routing is identical to the English
-# templates despite the French sheet names.
 sheets:
   "Oncho Traitement":
     field_code_prefix: "#rbtrt_"
@@ -22,70 +23,191 @@ sheets:
     data_type: treatment
     required_fields:
       - "#rbtrt_year"
-      - "#rbtrt_month"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
       - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
       - "#rbtrt_adm2"
-      - "#rbtrt_target"
-      - "#rbtrt_treated"
-
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
   "Traitement FL":
     field_code_prefix: "#lftrt_"
     disease: lf
     data_type: treatment
     required_fields:
       - "#lftrt_year"
-      - "#lftrt_month"
+      - "#lftrt_adm0"
+      - "#lftrt_adm0_id"
       - "#lftrt_adm1"
+      - "#lftrt_adm1_id"
       - "#lftrt_adm2"
-      - "#lftrt_target"
-      - "#lftrt_treated"
-
+      - "#lftrt_adm2_id"
+      - "#lftrt_adm3"
+      - "#lftrt_disease"
   "LF MMDP":
-    field_code_prefix: "#lfmmdp_"
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
   "Formation Distributeurs Comm":
     field_code_prefix: "#cddtrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cddtrn_year"
-      - "#cddtrn_month"
+      - "#cddtrn_adm0"
+      - "#cddtrn_adm0_id"
       - "#cddtrn_adm1"
+      - "#cddtrn_adm1_id"
       - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
+      - "#cddtrn_adm2_id"
+      - "#cddtrn_adm3"
+      - "#cddtrn_disease"
   "Formation Superviseurs Comm":
     field_code_prefix: "#cstrn_"
     disease: rblf
     data_type: training
     required_fields:
       - "#cstrn_year"
-      - "#cstrn_month"
+      - "#cstrn_adm0"
+      - "#cstrn_adm0_id"
       - "#cstrn_adm1"
+      - "#cstrn_adm1_id"
       - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  "Enquêtes":
-    field_code_prefix: "#svy_"
+      - "#cstrn_adm2_id"
+      - "#cstrn_adm3"
+      - "#cstrn_disease"
+  "PCMPI (Chirurgie) Formation":
+    field_code_prefix: "#dmditrnsx_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "PCMPI Formation (Patient)":
+    field_code_prefix: "#dmditrnpt_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Formation Ento de Terrain":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Formation Trav Sante":
+    field_code_prefix: "#hwtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hwtrn_year"
+      - "#hwtrn_adm0"
+      - "#hwtrn_adm0_id"
+      - "#hwtrn_adm1"
+      - "#hwtrn_adm1_id"
+      - "#hwtrn_adm2"
+      - "#hwtrn_adm2_id"
+      - "#hwtrn_adm3"
+      - "#hwtrn_disease"
+  "Formation Leader Groupe Hope":
+    field_code_prefix: "#hgtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#hgtrn_year"
+      - "#hgtrn_adm0"
+      - "#hgtrn_adm0_id"
+      - "#hgtrn_adm1"
+      - "#hgtrn_adm1_id"
+      - "#hgtrn_adm2"
+      - "#hgtrn_adm2_id"
+      - "#hgtrn_adm3"
+      - "#hgtrn_disease"
+  "Formation Professeurs":
+    field_code_prefix: "#tch"
+    required_fields:
+      - "#tchrtrn_year"
+      - "#tchrtrn_adm0"
+      - "#tchrtrn_adm0_id"
+      - "#tchrtrn_adm1"
+      - "#tchrtrn_adm1_id"
+      - "#tchrtrn_adm2"
+      - "#tchrtrn_adm2_id"
+      - "#tchrtrn_adm3"
+      - "#tchrtrn_disease"
+  "LF Enquetes":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "Oncho Enquetes Epi":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "Oncho Enquetes Ento":
+    field_code_prefix: "#rb_ento_surv_"
+    disease: oncho
+    data_type: entomology
+    required_fields:
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/inst/schemas/cmr/tcd.yaml
+++ b/inst/schemas/cmr/tcd.yaml
@@ -158,7 +158,9 @@ sheets:
       - "#hgtrn_adm3"
       - "#hgtrn_disease"
   "Formation Professeurs":
-    field_code_prefix: "#tch"
+    field_code_prefix: "#tchrtrn_"
+    disease: rblf
+    data_type: training
     required_fields:
       - "#tchrtrn_year"
       - "#tchrtrn_adm0"

--- a/inst/schemas/cmr/uga.yaml
+++ b/inst/schemas/cmr/uga.yaml
@@ -3,105 +3,207 @@ country_code: uga
 language: en
 template: english_cmr
 
-# Per-sheet routing for the CMR per-disease split (ADR-0012, #175):
-#   disease    -- the routing disease, taken from the SHEET (not the per-row
-#                 #..._disease field, which in the real templates holds
-#                 program-coverage codes RB / RBLF / RBLFSCH and is kept as a
-#                 data column, not split on).
-#   data_type  -- the measure for that sheet's category.
-# eri_split_cmr() routes each sheet's parsed rows to
-#   {country}/{disease}/programmatic/{data_type}/staged/ (parsed as-is; no DQ).
-# Cross-programme Training sheets route together under the combined `rblf`
-# disease. Sheets without disease/data_type are skipped by the split.
-#
-# NOTE: this is a simplified stand-in. The real Uganda template has a larger
-# sheet set (VHT/Parish/Local-Leaders/Subcounty/MMDP-surgery/MMDP-patient/
-# Field-Ento/Lab Training, LF Surveys, RB Epi Surveys, RB Ento Surveys) and
-# monthly _jan..dec columns; reconciling each country's bundled schema to its
-# real template is tracked as follow-up.
+# Generated from the real CMR template structure (field codes + sheet names
+# only; no data values). Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
 sheets:
-  RB Treatment:
+  "RB Treatment":
     field_code_prefix: "#rbtrt_"
     disease: oncho
     data_type: treatment
     required_fields:
       - "#rbtrt_year"
-      - "#rbtrt_month"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
       - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
       - "#rbtrt_adm2"
-      - "#rbtrt_target"
-      - "#rbtrt_treated"
-
-  SCH Treatment:
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
+  "SCH Treatment":
     field_code_prefix: "#schtrt_"
     disease: sch
     data_type: treatment
     required_fields:
       - "#schtrt_year"
-      - "#schtrt_month"
+      - "#schtrt_adm0"
+      - "#schtrt_adm0_id"
       - "#schtrt_adm1"
+      - "#schtrt_adm1_id"
       - "#schtrt_adm2"
-      - "#schtrt_target"
-      - "#schtrt_treated"
-
-  LF MMDP:
-    field_code_prefix: "#lfmmdp_"
+      - "#schtrt_adm2_id"
+      - "#schtrt_adm3"
+      - "#schtrt_disease"
+  "LF MMDP":
+    field_code_prefix: "#lfdmdi_"
     disease: lf
     data_type: mmdp
     required_fields:
-      - "#lfmmdp_year"
-      - "#lfmmdp_month"
-      - "#lfmmdp_adm1"
-      - "#lfmmdp_adm2"
-      - "#lfmmdp_hydro_screened"
-      - "#lfmmdp_lymph_screened"
-      - "#lfmmdp_hydro_treated"
-      - "#lfmmdp_lymph_treated"
-
-  CDD Training:
-    field_code_prefix: "#cddtrn_"
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
+  "VHT Training":
+    field_code_prefix: "#vhttrn_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#cddtrn_year"
-      - "#cddtrn_month"
-      - "#cddtrn_adm1"
-      - "#cddtrn_adm2"
-      - "#cddtrn_target"
-      - "#cddtrn_trained"
-
-  CS Training:
-    field_code_prefix: "#cstrn_"
+      - "#vhttrn_year"
+      - "#vhttrn_adm0"
+      - "#vhttrn_adm0_id"
+      - "#vhttrn_adm1"
+      - "#vhttrn_adm1_id"
+      - "#vhttrn_adm2"
+      - "#vhttrn_adm2_id"
+      - "#vhttrn_adm3"
+      - "#vhttrn_disease"
+  "Parish Supervisors Training":
+    field_code_prefix: "#pstrn_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#cstrn_year"
-      - "#cstrn_month"
-      - "#cstrn_adm1"
-      - "#cstrn_adm2"
-      - "#cstrn_target"
-      - "#cstrn_trained"
-
-  MMDP Training:
-    field_code_prefix: "#mmdptrn_"
+      - "#pstrn_year"
+      - "#pstrn_adm0"
+      - "#pstrn_adm0_id"
+      - "#pstrn_adm1"
+      - "#pstrn_adm1_id"
+      - "#pstrn_adm2"
+      - "#pstrn_adm2_id"
+      - "#pstrn_adm3"
+      - "#pstrn_disease"
+  "Local Leaders Training":
+    field_code_prefix: "#lltrn_"
     disease: rblf
     data_type: training
     required_fields:
-      - "#mmdptrn_year"
-      - "#mmdptrn_month"
-      - "#mmdptrn_adm1"
-      - "#mmdptrn_adm2"
-      - "#mmdptrn_target"
-      - "#mmdptrn_trained"
-
-  Surveys:
-    field_code_prefix: "#svy_"
+      - "#lltrn_year"
+      - "#lltrn_adm0"
+      - "#lltrn_adm0_id"
+      - "#lltrn_adm1"
+      - "#lltrn_adm1_id"
+      - "#lltrn_adm2"
+      - "#lltrn_adm2_id"
+      - "#lltrn_adm3"
+      - "#lltrn_disease"
+  "Subcounty Supervisor Training":
+    field_code_prefix: "#sstrn_"
     disease: rblf
-    data_type: survey
+    data_type: training
     required_fields:
-      - "#svy_year"
-      - "#svy_adm1"
-      - "#svy_adm2"
-      - "#svy_type"
-      - "#svy_examined"
-      - "#svy_positive"
+      - "#sstrn_year"
+      - "#sstrn_adm0"
+      - "#sstrn_adm0_id"
+      - "#sstrn_adm1"
+      - "#sstrn_adm1_id"
+      - "#sstrn_adm2"
+      - "#sstrn_adm2_id"
+      - "#sstrn_adm3"
+      - "#sstrn_disease"
+  "MMDP (surgery) Training":
+    field_code_prefix: "#dmditrnsx_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "MMDP (patient) Training":
+    field_code_prefix: "#dmditrnpt_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Field Ento Training":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Lab Training":
+    field_code_prefix: "#labtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#labtrn__year"
+      - "#labtrn__adm0"
+      - "#labtrn__adm0_id"
+      - "#labtrn__adm1"
+      - "#labtrn__adm1_id"
+      - "#labtrn__adm2"
+      - "#labtrn__adm2_id"
+      - "#labtrn__adm3"
+      - "#labtrn__disease"
+  "LF Surveys":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "RB Epi Surveys":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "RB Ento Surveys":
+    field_code_prefix: "#rb_ento_surv_"
+    disease: oncho
+    data_type: entomology
+    required_fields:
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -356,6 +356,22 @@ test_that("every country's CMR schema routes at least one sheet to a registered 
   }
 })
 
+test_that("every bundled CMR sheet declares routing keys (no silently-skipped data sheet)", {
+  # Bundled CMR schemas only contain data sheets (reference tabs with no field
+  # codes are excluded at generation), so every sheet must declare disease +
+  # data_type or eri_split_cmr() would silently drop its data.
+  for (country in c("eth", "nga", "sdn", "ssd", "tcd", "mad", "uga")) {
+    schema <- load_cmr_schema(country)
+    for (sheet in names(schema$sheets)) {
+      sd <- schema$sheets[[sheet]]
+      expect_false(is.null(sd$disease),
+                   info = paste(country, "/", sheet, "missing disease routing key"))
+      expect_false(is.null(sd$data_type),
+                   info = paste(country, "/", sheet, "missing data_type routing key"))
+    }
+  }
+})
+
 test_that("eri_split_cmr aborts when the workbook has none of the routable sheets", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   writexl::write_xlsx(list(

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -144,11 +144,14 @@ test_that("load_cmr_schema Nigeria has both SCH and STH Treatment", {
   expect_true("STH Treatment" %in% sheet_names)
 })
 
-test_that("load_cmr_schema Ethiopia has Fly Collection and River Prospection", {
+test_that("load_cmr_schema Ethiopia has the RB+LF entomology/survey sheets (real template)", {
   schema <- load_cmr_schema("eth")
   sheet_names <- names(schema$sheets)
-  expect_true("Fly Collection" %in% sheet_names)
-  expect_true("River Prospection" %in% sheet_names)
+  # eth is an RB+LF country (no SCH/STH); its oncho entomology lives in the
+  # RB Ento Surveys + Field Ento Training sheets, not the old stand-in names.
+  expect_true("RB Ento Surveys" %in% sheet_names)
+  expect_true("Field Ento Training" %in% sheet_names)
+  expect_false("SCH Treatment" %in% sheet_names)
 })
 
 #### Tests for French CMR schemas (issue #29) ####

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -142,9 +142,18 @@ Now the offline heart of the job. First, see which sheets this country's templat
 ```{r schema}
 schema <- load_cmr_schema("uga")
 names(schema$sheets)
-#> [1] "RB Treatment"  "SCH Treatment" "LF MMDP"       "CDD Training"
-#> [5] "CS Training"   "MMDP Training" "Surveys"
+#>  [1] "RB Treatment"                  "SCH Treatment"
+#>  [3] "LF MMDP"                       "VHT Training"
+#>  [5] "Parish Supervisors Training"   "Local Leaders Training"
+#>  [7] "Subcounty Supervisor Training" "MMDP (surgery) Training"
+#>  [9] "MMDP (patient) Training"       "Field Ento Training"
+#> [11] "Lab Training"                  "LF Surveys"
+#> [13] "RB Epi Surveys"                "RB Ento Surveys"
 ```
+
+(A real monthly file has many sheets — treatments, MMDP, the various trainings, and surveys. The
+bundled `cmr-example.xlsx` below is a small **two-sheet** subset, `RB Treatment` + `SCH Treatment`, so
+you can run the parse and split offline.)
 
 Then read a sheet with [`eri_ingest_cmr()`](../reference/eri_ingest_cmr.html). It reads from **row 5**
 (the field codes), keeps only the `#`-coded columns, drops the template's blank spacer rows, and — when
@@ -203,7 +212,14 @@ eri_split_cmr(report, "uga", dry_run = TRUE)
 #> ℹ Dry run -- nothing written. Routing plan:
 #>   "RB Treatment"  -> uga/oncho/programmatic/treatment/staged/cmr-example_rb_treatment.parquet (3 rows)
 #>   "SCH Treatment" -> uga/sch/programmatic/treatment/staged/cmr-example_sch_treatment.parquet (2 rows)
+#> Warning: Sheet "LF MMDP" not found in cmr-example.xlsx; skipping.   # ...and the
+#> Warning: Sheet "VHT Training" not found in cmr-example.xlsx; skipping.  # other
+#> # ... (the example has only the two treatment sheets; a real file routes them all)
 ```
+
+A sheet the schema routes but the workbook doesn't contain is **skipped with a warning** — expected
+here, since the example is a two-sheet subset. (If *none* of the routable sheets are present,
+`eri_split_cmr()` errors instead of silently doing nothing.)
 
 > **Why the sheet, not the row?** Each sheet carries a per-row `#…_disease` field whose values are
 > *programme-coverage* codes (`RB` / `RBLF` / `RBLFSCH` — which programmes run at that location), **not**


### PR DESCRIPTION
## What

Regenerates all seven bundled CMR schemas (`inst/schemas/cmr/{eth,nga,sdn,ssd,uga,tcd,mad}.yaml`) from the **real** monthly templates' structure, replacing the earlier simplified stand-ins. Now `eri_split_cmr()` routes a real CMR **completely** (the stand-ins only matched a few sheets).

## How

I inspected each country's latest real template in the projects blob — **structure only** (sheet names + machine-readable `#field codes`; **no entered data values**, per the data policy) — and regenerated each schema's sheet set with `disease` / `data_type` routing keys.

| Country | Sheets | Notes |
|---|---|---|
| uga | 14 | real training/survey names (VHT/Parish/Local-Leaders/Subcounty/MMDP-surgery/MMDP-patient/Field-Ento/Lab Training, LF/RB-Epi/RB-Ento Surveys) |
| nga | 17 | adds SCH + STH Treatment, Teacher/Health-Worker/Hope-Group trainings |
| eth | 16 | RB+LF (no SCH/STH), incl. ToT Regional/Zonal |
| sdn / ssd | 12 | RB+LF |
| tcd | 14 | French sheet names + slug aliases |
| mad | 10 | LF-only |

Routing (disease from the sheet): RB Epi Surveys → `oncho`/`prevalence`, RB Ento Surveys → `oncho`/`entomology`, LF Surveys → `lf`/`tas`, all Training sheets incl. ToT → combined `rblf`/`training`, Treatments → the disease's `treatment`, LF MMDP → `lf`/`mmdp`. `required_fields` lists the real stable (non-monthly) identifier columns.

## Changes

- 7 regenerated `inst/schemas/cmr/*.yaml`.
- `test-cmr.R`: the Ethiopia assertion now checks its **real** entomology/survey sheets (the old `Fly Collection` / `River Prospection` stand-in sheets don't exist in the real template). Existing per-country `field_code_prefix`/`required_fields` and routing-to-registered-measure tests pass against the new sets.
- `da-cmr-guide`: §3 shows the real 14-sheet `uga` list; §4 notes that a sheet absent from a subset workbook is skipped with a warning (the bundled example is a 2-sheet subset).

## Verification

Full offline suite green: **FAIL 0 | PASS 1520**. Guide knits clean. The committed YAML contains only field codes (column names) and sheet names — no entered values.

Closes the real-template reconciliation half of #54. Part of #175.