### PR TITLE
Red-team Run-2 doc fixes (#175 polish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ eri_catalog_verify()
 | Function | What it does |
 |---|---|
 | `eri_ingest_cmr(path, sheet, country)` | Parse a CMR Excel sheet |
+| `eri_split_cmr(path, country)` | Route each CMR sheet to its disease/measure staged path |
 | `load_cmr_schema(country)` | Load a bundled CMR country schema |
 | `eri_stage_cmr(country, period)` | Stage CMR files from the projects blob |
 
@@ -251,6 +252,7 @@ eri_catalog_verify()
 |---|---|
 | `eri_catalog_register(path, country, disease, data_source, layer, data_type)` | Register a file in the catalog |
 | `eri_catalog_query(country, disease, data_source, data_type, layer, period)` | Query catalog entries |
+| `eri_catalog_remove(path)` | Remove a file's catalog entry (e.g. after deleting it) |
 | `eri_catalog_verify()` | Check catalog entries exist in Azure; update verification timestamps |
 
 ### Onboarding a new country or disease

--- a/docs/feedback/red-team-learnings.md
+++ b/docs/feedback/red-team-learnings.md
@@ -79,3 +79,193 @@ The fault line is **mental-model formation**, not broken functions. A newcomer w
 forms the wrong `channel` vs `measure` model, or hits a signature that lags the data model and never
 comes back to `eri_*`. **Sourcing/onboarding is the weak link; the pipeline, reconcile, and QC are
 strengths.** Future runs should probe the *first* thing each role does (find/onboard data) hardest.
+
+---
+
+## Run 2 — 2026-06-28 (Eli, epi-fresh-user, second pass)
+
+Second epi pass, verifying the post-Run-1 fixes and re-probing the sourcing seam. Ran everything live:
+offline reconcile + DQ detectors, a live keyless OSM geocode, a catalog read against the real (empty)
+catalog, and a full **synthetic** discover→pull round-trip in a self-built `lemuria/malaria` namespace
+(written, registered, queried, pulled, torn down — left no trace). Headline: **the sourcing path now
+reads coherently; the friction has moved from "wrong vocabulary" to "small lifecycle gaps."**
+
+### Run-1 items re-checked (status)
+
+- **FIXED & confirmed — `eri_research_pull` is 5-axis (Run-1 #1).** `eri_catalog_query` and
+  `eri_research_pull` now share the *same four discovery tokens* (`country, disease, data_source,
+  data_type`). I queried a synthetic entry and pulled it back with the identical tokens the query
+  reported — `✔ Pulled 1 file from 'lemuria/malaria/research/case/processed'`. The union signature
+  (5-axis **or** legacy `path=`/`dest=`) means the epi-research-guide's `path=` examples *also* still
+  work. This is the single biggest improvement since Run 1; the discover→pull loop now reads like one
+  coherent story.
+- **FIXED & confirmed — README is uniformly 5-axis** with the role-scoped "New here? Do these in order"
+  paths and the `eri_data_model()`-first instruction. The Epi path (connections → research → reconcile
+  → dq) is coherent and not overwhelming.
+- **FIXED & confirmed — `load_dq_schema(country, disease, data_source, data_type)`** 4-arg form is what
+  both epi guides teach; ran live, schema loaded offline with `azcontainer = NULL`.
+- **STILL OPEN — CMR guide leads with Storage Explorer.** `da-cmr-guide.Rmd:72` still reads "Often this
+  upload happens through Azure Storage Explorer or SharePoint, but you can also do it from R." Run-1
+  asked for this to **lead with `eri_upload()`**; it still names the GUI first. (Epi-adjacent: an epi
+  sourcing programmatic/treatment data would read this guide.)
+- **STILL OPEN — `ERI_ANALYST_ID` not promoted to Day-1.** It appears only inside the
+  "One `.Renviron` for everything" block (connections-guide:222), never as a required first step.
+  Confirmed the live cost: with it unset, `eri_catalog_register` / `eri_research_pull` emit
+  `! ERI_ANALYST_ID is not set; governed actions will be logged as "NishantKishore"` and silently log
+  governed actions under the OS username. An epi doing a governed pull hits this on day one.
+
+### New Run-2 findings (not in Run 1)
+
+1. **[Major] `eri_dir_delete()` does not deregister catalog entries — cleanup leaves a dangling row.**
+   In my round-trip, after `eri_dir_delete("lemuria")` removed the blob files, `eri_catalog_query
+   (country="lemuria")` still returned the row, and `eri_catalog_verify()` then warned
+   `1 catalog entry not found in Azure`. The fix was `eri_catalog_remove(path)` — which **works
+   cleanly** but (a) is **absent from the README reference table** (only register/query/verify are
+   listed) and (b) is **never mentioned in the epi-research-guide §12 "Clean up"**, which teaches only
+   `eri_dir_delete()`. A fresh user who follows the cleanup guide leaves a phantom catalog entry behind.
+   Fix: add `eri_catalog_remove` to the README catalog table; either have `eri_dir_delete` offer to
+   deregister overlapping catalog paths (or warn), and mention `eri_catalog_remove` in §12.
+
+2. **[Minor] Catalog discovery is fine but invisible to a fresh epi until data exists.** The live
+   catalog is empty, so a brand-new epi running the README's example queries gets
+   `The data catalog has no entries yet` / `No catalog entries match` and has nothing to pull. The
+   discover→pull story is only *shown* end-to-end if you seed data yourself. A worked, copy-paste
+   "discover what exists, then pull it" example in the epi-research-guide (the one place an epi learns
+   sourcing) would make the round-trip legible without needing populated infrastructure. Right now §4
+   pulls by *artifact path*, never by catalog coordinates — so the 5-axis pull (the headline fix) is
+   not actually demonstrated in the epi guide.
+
+### Delighters re-confirmed (protect these)
+
+- `eri_data_model()` is still the best orientation tool — printed the full channel/measure/format/layer
+  vocabulary with the transitional `cmr`/`odk` tokens flagged. Call it first.
+- `eri_spatial_reconcile()` trust guard: live OSM run reproduced the guide exactly — MIT geocoded into
+  Cambridge/Middlesex while the row claimed Suffolk, fired `geocoded_review`, kept the coordinates,
+  left the county untouched, and surfaced the conflict in `geocoded_adm2_name`. As an epi I would trust
+  this over hand-geocoding. ~3.1s Nominatim query for 3 addresses.
+- The four `add_anomaly_*` detectors chained cleanly; spike (+400% then -73%), missing-week structural
+  gap, consistency pass, and spatial **skip-clean** (`No admin block in schema; skipping`) all matched
+  the guide output. Flags are framed in epi terms ("real cluster vs double-entry", "no report vs lost
+  in transfer"), not engineering terms.
+
+### Run mechanics (unchanged, still true)
+
+- `.R` script file via `Rscript`, not inline `-e`. Cached Azure token loads non-interactively. Keyless
+  OSM path works with no key. The renv "out-of-sync" notice is harmless.
+- A self-built `lemuria/malaria` synthetic namespace is a clean way to demonstrate the governed
+  discover→pull→teardown loop without touching real data — but **remember to `eri_catalog_remove()`**,
+  not just `eri_dir_delete()`, or the catalog keeps the row (see finding #1).
+
+### The durable conceptual risk (updated)
+
+Run 1 said the weak link was vocabulary; Run 2 says the vocabulary is now right and the weak link is
+**lifecycle completeness in the sourcing story** — the 5-axis pull is implemented and coherent but not
+*demonstrated* in the epi guide (which still pulls by artifact path), and the cleanup/catalog lifecycle
+has one un-closed loop (`eri_dir_delete` vs `eri_catalog_remove`). Sourcing is no longer broken; it is
+*under-shown*.
+
+## Run 2 — 2026-06-28 (Dana, da-fresh-user, second pass)
+
+Second DA pass, paired with Eli above. Ran the **entire DA arc live** on a self-built `atlantis/malaria`
+sandbox: `eri_data_model` → onboard (dry-run + real, schema validated clean out of the box) → hand-author
++ upload a `case` DQ schema → ingest two extracts (clean + flagged) → DQ → stage → `eri_approve` (×2) →
+catalog query → the full `eri_dq_log`/`eri_logs`/`eri_logs_resolve` triage loop → `eri_split_cmr` offline
+on the bundled `cmr-example.xlsx` → an ODK **registry** round-trip → teardown (`eri_catalog_remove` ×2,
+`eri_delete` schema, `eri_dir_delete("atlantis")`). Verified `atlantis` gone from catalog **and** the
+top-level listing. **Never needed Storage Explorer or raw AzureStor for a single step.** Headline: the
+ADR-0012 surface (`data_source` vs `data_type`, catalog/logs columns, the CMR split, ODK→research) is
+**code-correct and reads cleanly in the README, ingest, ODK, and CMR guides** — the remaining friction is
+two stale guide sections and a couple of small lifecycle gaps, not the model.
+
+### Run-1 items re-checked (DA side)
+
+- **PARTIALLY FIXED — `ERI_ANALYST_ID` now warns at runtime (Run-1 still-open item).** A runtime signpost
+  *has been added*: the first governed write in a session prints `! ERI_ANALYST_ID is not set; governed
+  actions will be logged as "NishantKishore"` + `ℹ Set it in your '.Renviron' so approvals and logs carry
+  your analyst identity.` That is a real improvement over Run 1 (silent fallback). **Still open:** it is
+  not promoted to a Day-1 step in the connections guide (buried in the `.Renviron` block as just
+  "identity"), and the approval log + `eri_logs` `analyst` column still recorded the **OS username**
+  (`Approver: NishantKishore`) — an un-attributable identity in a governed audit log. Confirmed live in
+  `eri_approve`, `eri_dir_create`, `eri_dq_log`, `eri_odk_register`.
+- **STILL OPEN — CMR guide leads with Storage Explorer in prose** (`da-cmr-guide.Rmd:72`), independently
+  re-confirmed (Eli noted the same line). `eri_upload()` *is* now shown immediately after, so the fix is
+  half-done; just reorder the sentence to lead with `eri_upload()` and relegate the GUI to an aside.
+
+### New Run-2 findings (DA, not in Run 1 or Eli's section)
+
+1. **[Major] `da-onboard-guide §3` contradicts the now-shipped CMR split — actively teaches the wrong
+   model.** Lines 199–203 still say *"Until that split ships, keep using `rblf`/`cmr` as shown here —
+   don't adopt them as the canonical addressing model."* But `eri_split_cmr()` **has shipped** (exported,
+   has a man page, ran offline against `cmr-example.xlsx` and routed `RB Treatment → oncho`,
+   `SCH Treatment → sch`), and `da-cmr-guide` teaches the per-disease split + per-measure approval as the
+   canonical flow. A newcomer who reads onboard before CMR is told the opposite of what's true. Fix:
+   rewrite the §3 callout to "the split *has* shipped — `rblf/cmr` is now a transitional **staging
+   archive** that `eri_split_cmr()` routes per-disease; see the CMR guide," matching `da-cmr-guide`'s own
+   framing.
+
+2. **[Major] `da-logs-guide` documents the wrong logs path and an `eri_dq_log` call that splits logs
+   across two directories.** §1 line 60 says logs live in `{country}/{disease}/{data_type}/logs/` — that
+   is **doubly wrong** under ADR-0012: it omits `data_source` and labels `surveillance` (a `data_source`)
+   as `data_type`. Live reality is *split*: `eri_approve(data_type="case")` writes its op log to
+   `atlantis/malaria/surveillance/case/logs/`, but the guide's `eri_dq_log(result, "atlantis","malaria",
+   "surveillance", period=...)` call (no `data_type`) writes to `atlantis/malaria/surveillance/logs/` —
+   one level shallower. So for one dataset, DQ logs and approval logs land in **different** `logs/` dirs.
+   `eri_logs()` *scans* and finds both (so the workflow works), but the documented path is incorrect and
+   the guide never passes `data_type` to `eri_dq_log` even though it explicitly "picks up from the ingest
+   guide" which approved at `case` level. Fix: correct line 60 to
+   `{country}/{disease}/{data_source}/[{data_type}/]logs/`, and pass `data_type = "case"` in the
+   `eri_dq_log` example so it co-locates with the approval log.
+
+3. **[Minor] `eri_split_cmr` is missing from the README function-reference table.** The README "CMR
+   monthly reports" table (README:226-233) lists only `eri_ingest_cmr` / `load_cmr_schema` /
+   `eri_stage_cmr`. The headline new function of the CMR migration isn't discoverable from the README at
+   all (it *is* in `_pkgdown.yml` reference and the CMR guide). Add a row.
+
+4. **[Minor] The ODK registry has no sandbox isolation.** A practice `eri_odk_register()` (even with a
+   throwaway `project_id=99999`, `country="uga"`, `disease="demo"`) writes into the **same production
+   `odk/registry.yaml`** that holds real registered Uganda LF TAS forms — `eri_odk_list_registered()`
+   returned the four real forms alongside my test row. The guide's documented cleanup
+   (`eri_odk_deregister`) is a **soft-delete** (`active:false`), so a practice entry persists invisibly in
+   the production registry forever. Two asks: (a) note in `da-odk-guide` that registration writes to the
+   shared registry (so practice runs are visible to teammates until deregistered), and (b) consider a
+   hard-delete / purge option for synthetic test rows, or a `_sandbox` registry namespace.
+
+5. **[Nit] `eri_split_cmr` rolls skipped-sheet warnings into "There were 12 warnings (use warnings() to
+   see them)".** The CMR guide §4 shows them inline (`Warning: Sheet "LF MMDP" not found ... skipping`),
+   but live they're deferred — a fresh DA might not realize the 12 are benign without calling
+   `warnings()`. Consider a single `cli_inform` summary ("10 schema sheets not present in this workbook;
+   skipped") instead of raw deferred warnings. The dry-run routing tibble is excellent and offsets this.
+
+6. **[Nit] Catalog `row_count` is `NA`** for parquet files approved through `eri_approve` (seen on both
+   atlantis entries). Not load-bearing, but a populated row count would make `eri_catalog_query` more
+   useful at a glance.
+
+### Storage-Explorer-temptation log (DA, Run 2)
+
+Worked the entire arc and **never once needed to drop to Storage Explorer or AzureStor.** Every instinct
+had a working `eri_*` path: upload schema (`eri_upload`), make folders (`eri_dir_create`), write/read
+(`eri_write`/`eri_read`), promote (`eri_approve`), discover (`eri_catalog_query`/`eri_list`), de-list
+(`eri_catalog_remove`), delete recursively (`eri_dir_delete`), delete a single blob (`eri_delete`). The
+only place a *guide* still nudges toward the GUI is `da-cmr-guide.Rmd:72` (prose leads with Storage
+Explorer for the CMR upload) — already flagged. `eri_dir_delete` remains *the* reason a DA stays in the
+package for cleanup.
+
+### Delighters re-confirmed (DA side)
+
+- The onboard **dry-run/real parity** is exact, and the scaffolded `aggregate` schema **validates clean
+  out of the box** (`eri_schema_validate` → empty tibble) — a confidence-builder for a non-developer.
+- The two-extract ingest story (clean → 0 flags; messy → 2 flags with row-level `$flags`, then fix +
+  re-check → 0) is the single clearest teaching moment in the whole doc set; ran live, matched verbatim.
+- `eri_logs`/`eri_logs_resolve` shared-backlog loop ran live, the tibble carries `data_source` +
+  `data_type` columns (ADR-0012 correct), and resolve cleanly dropped the error from the open backlog.
+- `eri_split_cmr(dry_run=TRUE)` returns a tidy routing tibble (sheet → disease → data_type → dest →
+  n_rows) — exactly the "show me before you touch anything" affordance a cautious DA wants.
+
+### The durable conceptual risk (DA view, agreeing with Eli)
+
+The model is right; the **docs have two stale islands** that teach a newcomer the wrong thing before the
+correct guide can correct them: onboard §3 ("until the split ships") and logs §1 (wrong path axis). Both
+are *upstream* of the guides that get it right, so a sequential reader forms the wrong model first. The
+weak link is no longer vocabulary or the pipeline — it is **cross-guide consistency at the seams the
+migration touched** (CMR split, logs path). Audit every guide that mentions `cmr`/`rblf` or a `logs/`
+path against the shipped behavior.

--- a/vignettes/connections-guide.Rmd
+++ b/vignettes/connections-guide.Rmd
@@ -26,6 +26,13 @@ service(s) you need; skip the rest.
 > **A note on secrets.** Where a service needs a credential, it lives in your **`.Renviron`** file —
 > never typed into a script and never committed to git. We point that out at each step.
 
+> **Do this first: set your analyst identity.** Before your **first governed action** (approving data,
+> registering a catalog entry, syncing a form), set `ERI_ANALYST_ID` in your `.Renviron` —
+> `usethis::edit_r_environ()`, add `ERI_ANALYST_ID=firstname.lastname`, save, and **restart R**. Every
+> approval log, catalog entry, and operation log is stamped with it. If it is unset, `erifunctions`
+> warns once and falls back to your **operating-system username** — so the shared audit trail records
+> `jsmith` instead of `jane.smith`. Set it once and the attribution is correct everywhere.
+
 ```{=html}
 <div class="mermaid">
 flowchart TD

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -69,8 +69,9 @@ projects: health-rb-country-expansion-dev/raw/filled_templates/{country}/{period
 e.g.      …/raw/filled_templates/uga/202406/uga_cmr_2024_06.xlsx
 ```
 
-Often this upload happens through Azure Storage Explorer or SharePoint, but you can also do it from R.
-Connect to the `projects` blob and upload the file to that path:
+Do this from R with `eri_upload()` — it keeps the whole monthly run in one place and one tool. (If a
+file already arrived via Azure Storage Explorer or SharePoint, that's fine too; you can skip ahead to
+staging.) Connect to the `projects` blob and upload the file to that path:
 
 ```{r upload}
 # Connect to the projects blob explicitly (the same blob eri_stage_cmr reads from).

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -57,7 +57,8 @@ library(erifunctions)
 
 ## 1. Where logs come from {#sources}
 
-Two kinds of log end up in `{country}/{disease}/{data_type}/logs/`:
+Two kinds of log end up in `{country}/{disease}/{data_source}/[{data_type}/]logs/` (the measure level
+is present when the data was approved with one — `eri_logs()` reads both layouts):
 
 - **Operation logs** — written automatically by `eri_ingest()`, `eri_approve()`, `eri_stage()`,
   `eri_odk_sync()`, and friends. Each records the operation, who ran it, its parameters, and — if it
@@ -76,8 +77,10 @@ couple of flags. Persist it:
 
 ```{r dq-log}
 # result <- run_dq_checks(raw, schema)   # from the ingest guide
-eri_dq_log(result, "atlantis", "malaria", "surveillance", period = "2024-01")
-#> ℹ Operation log: atlantis/malaria/surveillance/logs/20260626_093000_dq_flags_2024-01.yaml
+# Pass the same measure you approve with (here "case") so the DQ log co-locates
+# with the approval log under the measure level.
+eri_dq_log(result, "atlantis", "malaria", "surveillance", data_type = "case", period = "2024-01")
+#> ℹ Operation log: atlantis/malaria/surveillance/case/logs/20260626_093000_dq_flags_2024-01.yaml
 #> ✔ Logged 2 DQ flags (needs_review).
 ```
 
@@ -87,9 +90,9 @@ Now a common slip: you try to approve a period before the file is staged. It err
 error log** behind:
 
 ```{r approve-fail}
-eri_approve("atlantis", "malaria", "surveillance", "2024-02")
-#> ℹ Operation log: atlantis/malaria/surveillance/logs/20260626_100000_eri_approve_2024-02.yaml
-#> Error: No staged files found matching "2024-02" in atlantis/malaria/surveillance/staged.
+eri_approve("atlantis", "malaria", "surveillance", "2024-02", data_type = "case")
+#> ℹ Operation log: atlantis/malaria/surveillance/case/logs/20260626_100000_eri_approve_2024-02.yaml
+#> Error: No staged files found matching "2024-02" in atlantis/malaria/surveillance/case/staged.
 ```
 
 ## 2. See the backlog {#backlog}

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -236,7 +236,13 @@ clean up: `country = "uga"`, `disease = "demo"`. (ODK registration requires a re
 ### Register the form
 
 Registering records the form in the shared **ODK registry** (`odk/registry.yaml`) — the team's single
-source of truth for which forms are tracked, and which country/disease each one feeds:
+source of truth for which forms are tracked, and which country/disease each one feeds.
+
+> **The registry is shared and team-visible.** Your registration lands in the **same** `odk/registry.yaml`
+> as everyone's real forms, and [Clean up](#clean-up)'s `eri_odk_deregister()` is a **soft-delete**
+> (`active: false`) that preserves the audit trail — so a practice entry lingers (inactive) rather than
+> vanishing. Use an obviously-fake `project_id`/`country` for sandbox work, and don't be surprised to see
+> a deregistered practice form still listed as inactive.
 
 ```{r register}
 data_con <- get_azure_storage_connection(storage_name = "data")

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -201,7 +201,8 @@ combined **`rblf`** disease code (RB + LF — the programmes these reports cover
 > CMR is a *format* of the `programmatic` channel. [`eri_split_cmr()`](da-cmr-guide.html) reads the
 > staged Excel and routes **each sheet to its own disease and measure** —
 > e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`, then you approve **each disease/measure**.
-> So `rblf/cmr/` is the transitional landing/archive; the canonical, approved data is per-disease. See the
+> So `rblf/cmr/` is the transitional landing/archive; the canonical, approved data is per-disease
+> (shared sheets like Training route together under the combined `rblf` disease). See the
 > [CMR guide](da-cmr-guide.html) for the full upload → stage → split → approve flow.
 
 ```{r cmr-dry}

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -192,15 +192,17 @@ Fix the schema and re-run until you get the clean ✔. That is the green light t
 ## 3. Onboard a CMR country {#cmr}
 
 **Case Management Reports (CMR)** are the monthly Excel returns from country programs. Onboarding one
-writes a CMR schema template and (when you pass `create_dirs = TRUE`) the CMR folders. CMR lives under
-the combined **`rblf`** disease code (RB + LF — the programmes these reports cover), matching where
-[`eri_stage_cmr()`](da-cmr-guide.html) and `eri_approve()` put it. Dry-run it first:
+writes a CMR schema template and (when you pass `create_dirs = TRUE`) the staging folders under the
+combined **`rblf`** disease code (RB + LF — the programmes these reports cover), where
+[`eri_stage_cmr()`](da-cmr-guide.html) lands the raw Excel. Dry-run it first:
 
-> **Transitional vocabulary.** `rblf` and `cmr` are interim coordinates. Under the
+> **`rblf`/`cmr` is the staging archive, not the canonical home.** Under the
 > [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
-> CMR is a *format* of the `programmatic` channel, and each report sheet splits to its own disease and
-> measure (e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`). Until that split ships, keep
-> using `rblf`/`cmr` as shown here — don't adopt them as the canonical addressing model.
+> CMR is a *format* of the `programmatic` channel. [`eri_split_cmr()`](da-cmr-guide.html) reads the
+> staged Excel and routes **each sheet to its own disease and measure** —
+> e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`, then you approve **each disease/measure**.
+> So `rblf/cmr/` is the transitional landing/archive; the canonical, approved data is per-disease. See the
+> [CMR guide](da-cmr-guide.html) for the full upload → stage → split → approve flow.
 
 ```{r cmr-dry}
 eri_onboard_cmr("atlantis", "Atlantis", create_dirs = TRUE, dry_run = TRUE)

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -228,6 +228,20 @@ eri_research_pull(path = "artifacts/study_data/mtcars_study_data/cars.csv", dest
 > pull in `research.yaml`, archives any superseded version, and counts updates — exactly the
 > lifecycle this guide demonstrates in §11.
 
+> **Sourcing canonical, team-approved data.** When your study draws on data the analysts already
+> approved (not a study artifact you uploaded), **discover it in the catalog and pull it with the same
+> coordinates** — `eri_research_pull()` takes the four tokens `eri_catalog_query()` reports
+> (`country`, `disease`, `data_source`, `data_type`):
+>
+> ```r
+> eri_catalog_query(country = "dr", disease = "malaria", layer = "processed")
+> #> # ... data_source = surveillance, data_type = case ...
+> eri_research_pull("dr", "malaria", "surveillance", "case", dest = "data")
+> ```
+>
+> Discover what exists, then pull it with the coordinates the catalog handed you — one vocabulary,
+> end to end.
+
 > **Never commit `data/` to git.** The scaffold's `.gitignore` already excludes it. Data lives in
 > Azure; your repository holds only *code* and the `research.yaml` record of what was pulled. For
 > `mtcars` it would not matter, but this is the habit that keeps real, protected country data safe

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -236,7 +236,8 @@ eri_research_pull(path = "artifacts/study_data/mtcars_study_data/cars.csv", dest
 > ```r
 > eri_catalog_query(country = "dr", disease = "malaria", layer = "processed")
 > #> # ... data_source = surveillance, data_type = case ...
-> eri_research_pull("dr", "malaria", "surveillance", "case", dest = "data")
+> eri_research_pull(country = "dr", disease = "malaria",
+>                   data_source = "surveillance", data_type = "case", dest = "data")
 > ```
 >
 > Discover what exists, then pull it with the coordinates the catalog handed you — one vocabulary,


### PR DESCRIPTION
## What

Fixes the documentation gaps both fresh-user red-team personas (Dana/DA + Eli/Epi) flagged on their **second** pass, after the full #175 migration landed. Both completed the whole job using only `eri_*` (no Storage Explorer), and confirmed the Run-1 findings fixed — these are the remaining doc issues.

## Changes

**Two Majors (actively misleading, now that the migration shipped):**
- **`da-onboard §3`** still said *"until that split ships, keep using `rblf`/`cmr`"* — but `eri_split_cmr()` has shipped. Rewrote the callout: `rblf/cmr/` is the transitional **staging archive**; `eri_split_cmr()` routes each sheet to its disease/measure, approved per-disease.
- **`da-logs-guide`** documented the wrong logs path (`{country}/{disease}/{data_type}/logs/` — omitted `data_source`, mislabelled the channel). Corrected to `{country}/{disease}/{data_source}/[{data_type}/]logs/`, and the `eri_dq_log` / `eri_approve` examples now pass `data_type = "case"` (matching the ingest guide) so the DQ and approval logs co-locate.

**Recurring + minor:**
- `ERI_ANALYST_ID` promoted to a prominent **"do this first"** step in the connections guide (unset → governed logs silently record the OS username — both personas, both runs).
- README reference table gains **`eri_split_cmr`** and **`eri_catalog_remove`** rows (both were undiscoverable from the README).
- `epi-research-guide §4` now demonstrates the canonical **`eri_catalog_query()` → `eri_research_pull()`** round-trip (the Run-1 headline fix was implemented but never shown).
- `da-cmr-guide` upload step now **leads with `eri_upload()`** (GUI as fallback).
- `da-odk-guide` notes the registry is **shared/team-visible** and `eri_odk_deregister()` is a soft-delete.
- Seeds the Run-2 sections of `docs/feedback/red-team-learnings.md`.

## Verification

Pure docs. All six edited guides knit clean. (A companion **code** PR handles the two non-doc findings: `eri_dir_delete()` leaving dangling catalog rows, and `eri_split_cmr` deferring skipped-sheet warnings.)

Part of #175 polish.