### PR TITLE
Red-team Run-2 code fixes: catalog-pruning delete + CMR skip summary (#175)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # erifunctions (development version)
 
+## Fix: `eri_dir_delete()` prunes the catalog; `eri_split_cmr()` summarizes skipped sheets (#175 polish)
+
+- `eri_dir_delete()` now **removes data-catalog entries under the deleted path** (new `prune_catalog`
+  argument, default `TRUE` for Azure deletes), so deleting a namespace no longer leaves dangling rows that
+  `eri_catalog_verify()` would flag. Fail-silent — a catalog hiccup never blocks the delete. Surfaced by a
+  fresh-Epi red-team run whose sandbox teardown left a phantom catalog row.
+- `eri_split_cmr()` reports sheets the schema routes but the workbook lacks as a **single informational
+  summary** ("Skipped N sheets …") instead of a deferred pile of individual warnings (a fresh-DA nit).
+
 ## Data: bundled CMR schemas reconciled to the real country templates (ADR-0012, #175)
 
 - The seven bundled CMR schemas (`inst/schemas/cmr/{eth,nga,sdn,ssd,uga,tcd,mad}.yaml`) are regenerated

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -180,11 +180,12 @@ eri_split_cmr <- function(path, country, data_con = NULL,
   fbase     <- tools::file_path_sans_ext(basename(path))
   slug      <- function(x) gsub("_+", "_", gsub("[^a-z0-9]+", "_", tolower(x)))
 
-  plan <- list()
+  plan    <- list()
+  skipped <- character(0)
   for (sheet_name in names(routable)) {
     spec <- routable[[sheet_name]]
     if (!sheet_name %in% available) {
-      cli::cli_warn("Sheet {.val {sheet_name}} not found in {.path {basename(path)}}; skipping.")
+      skipped <- c(skipped, sheet_name)
       next
     }
     df       <- eri_ingest_cmr(path, sheet = sheet_name, country = country)
@@ -194,6 +195,14 @@ eri_split_cmr <- function(path, country, data_con = NULL,
       sheet = sheet_name, disease = spec$disease, data_type = spec$data_type,
       dest = dest, dest_dir = dest_dir, n_rows = nrow(df), data = df
     )
+  }
+
+  # One tidy summary of sheets the schema routes but this workbook lacks, rather
+  # than a deferred pile of individual warnings.
+  if (length(skipped) > 0L) {
+    cli::cli_inform(c(
+      "i" = "Skipped {length(skipped)} sheet{?s} not in {.path {basename(path)}}: {.val {skipped}}."
+    ))
   }
 
   # A wrong workbook (none of the schema's routable sheets present) is an error,

--- a/R/dal.R
+++ b/R/dal.R
@@ -766,7 +766,9 @@ eri_dir_create <- function(file_loc, azure = TRUE, azcontainer = NULL) {
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' Thin wrapper around [erifunctions_io()] for deleting a file.
+#' Thin wrapper around [erifunctions_io()] for deleting a file. Note this does
+#' **not** touch the data catalog — if you are tearing down a namespace, use
+#' [eri_dir_delete()], which also prunes catalog entries under the deleted path.
 #'
 #' @inheritParams erifunctions_io
 #' @export
@@ -799,7 +801,9 @@ eri_dir_delete <- function(file_loc, azure = TRUE, azcontainer = NULL,
   result <- erifunctions_io("delete.dir", file_loc = file_loc, azure = azure,
                             azcontainer = azcontainer)
   if (isTRUE(azure) && isTRUE(prune_catalog)) {
-    .eri_prune_catalog_under(file_loc, data_con = azcontainer)
+    # The data catalog always lives in the `data/` blob, so resolve it
+    # independently of whichever container `file_loc` was deleted from.
+    .eri_prune_catalog_under(file_loc, data_con = NULL)
   }
   result
 }
@@ -819,7 +823,11 @@ eri_dir_delete <- function(file_loc, azure = TRUE, azcontainer = NULL,
       cli::cli_alert_info("Removed {length(hit)} catalog entr{?y/ies} under {.path {norm}}.")
     }
     invisible(length(hit))
-  }, error = function(e) invisible(0L))
+  }, error = function(e) {
+    # Never block the delete, but don't hide that the catalog wasn't pruned.
+    cli::cli_alert_warning("Could not prune catalog under {.path {prefix}}: {conditionMessage(e)}")
+    invisible(0L)
+  })
 }
 
 #' Upload any local file to Azure

--- a/R/dal.R
+++ b/R/dal.R
@@ -781,14 +781,45 @@ eri_delete <- function(file_loc, azure = TRUE, azcontainer = NULL) {
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' Thin wrapper around [erifunctions_io()] for deleting a directory.
+#' Thin wrapper around [erifunctions_io()] for deleting a directory. When deleting
+#' from the `data/` blob, it also **prunes the data catalog**: any
+#' [eri_catalog_query()] entry whose path falls under `file_loc` is removed, so
+#' deleting a namespace never leaves dangling rows that [eri_catalog_verify()]
+#' would later flag.
 #'
 #' @inheritParams erifunctions_io
+#' @param prune_catalog `lgl` If `TRUE` (default when `azure`), remove catalog
+#'   entries under `file_loc` after the delete. Fail-silent: a catalog hiccup
+#'   never blocks the delete.
 #' @export
-eri_dir_delete <- function(file_loc, azure = TRUE, azcontainer = NULL) {
+eri_dir_delete <- function(file_loc, azure = TRUE, azcontainer = NULL,
+                           prune_catalog = azure) {
   if (azure) .eri_log_session()
   if (azure && is.null(azcontainer)) azcontainer <- suppressMessages(get_azure_storage_connection())
-  erifunctions_io("delete.dir", file_loc = file_loc, azure = azure, azcontainer = azcontainer)
+  result <- erifunctions_io("delete.dir", file_loc = file_loc, azure = azure,
+                            azcontainer = azcontainer)
+  if (isTRUE(azure) && isTRUE(prune_catalog)) {
+    .eri_prune_catalog_under(file_loc, data_con = azcontainer)
+  }
+  result
+}
+
+# Remove catalog entries whose path falls under `prefix` (e.g. after deleting a
+# namespace). Fail-silent so a catalog problem never blocks the directory delete.
+#' @keywords internal
+.eri_prune_catalog_under <- function(prefix, data_con = NULL) {
+  tryCatch({
+    entries <- suppressMessages(eri_catalog_query(data_con = data_con))
+    if (nrow(entries) == 0L) return(invisible(0L))
+    norm <- sub("/+$", "", prefix)
+    hit  <- entries$path[entries$path == norm |
+                           startsWith(entries$path, paste0(norm, "/"))]
+    for (p in hit) suppressMessages(eri_catalog_remove(p, data_con = data_con))
+    if (length(hit) > 0L) {
+      cli::cli_alert_info("Removed {length(hit)} catalog entr{?y/ies} under {.path {norm}}.")
+    }
+    invisible(length(hit))
+  }, error = function(e) invisible(0L))
 }
 
 #' Upload any local file to Azure

--- a/man/eri_delete.Rd
+++ b/man/eri_delete.Rd
@@ -18,5 +18,7 @@ Defaults to \code{TRUE}, otherwise, interacts with files locally.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Thin wrapper around \code{\link[=erifunctions_io]{erifunctions_io()}} for deleting a file.
+Thin wrapper around \code{\link[=erifunctions_io]{erifunctions_io()}} for deleting a file. Note this does
+\strong{not} touch the data catalog — if you are tearing down a namespace, use
+\code{\link[=eri_dir_delete]{eri_dir_delete()}}, which also prunes catalog entries under the deleted path.
 }

--- a/man/eri_dir_delete.Rd
+++ b/man/eri_dir_delete.Rd
@@ -4,7 +4,12 @@
 \alias{eri_dir_delete}
 \title{Delete a directory}
 \usage{
-eri_dir_delete(file_loc, azure = TRUE, azcontainer = NULL)
+eri_dir_delete(
+  file_loc,
+  azure = TRUE,
+  azcontainer = NULL,
+  prune_catalog = azure
+)
 }
 \arguments{
 \item{file_loc}{\code{str} Path of file.}
@@ -14,9 +19,17 @@ Defaults to \code{TRUE}, otherwise, interacts with files locally.}
 
 \item{azcontainer}{\verb{Azure container} A container object returned by
 \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}.}
+
+\item{prune_catalog}{\code{lgl} If \code{TRUE} (default when \code{azure}), remove catalog
+entries under \code{file_loc} after the delete. Fail-silent: a catalog hiccup
+never blocks the delete.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Thin wrapper around \code{\link[=erifunctions_io]{erifunctions_io()}} for deleting a directory.
+Thin wrapper around \code{\link[=erifunctions_io]{erifunctions_io()}} for deleting a directory. When deleting
+from the \verb{data/} blob, it also \strong{prunes the data catalog}: any
+\code{\link[=eri_catalog_query]{eri_catalog_query()}} entry whose path falls under \code{file_loc} is removed, so
+deleting a namespace never leaves dangling rows that \code{\link[=eri_catalog_verify]{eri_catalog_verify()}}
+would later flag.
 }

--- a/tests/testthat/test-catalog.R
+++ b/tests/testthat/test-catalog.R
@@ -288,6 +288,33 @@ test_that("eri_catalog_query filters by data_source and data_type (the measure)"
   expect_equal(by_measure$path, e1$path)
 })
 
+# --- prune-under (eri_dir_delete catalog cleanup) -----------------------------
+
+test_that(".eri_prune_catalog_under removes only entries under the deleted prefix", {
+  removed <- character(0)
+  local_mocked_bindings(
+    eri_catalog_query = function(...) tibble::tibble(path = c(
+      "atlantis/malaria/surveillance/case/processed/a.parquet",
+      "atlantis/malaria/surveillance/case/processed/b.parquet",
+      "uga/oncho/programmatic/treatment/processed/c.parquet")),
+    eri_catalog_remove = function(path, ...) { removed <<- c(removed, path); invisible(TRUE) },
+    .package = "erifunctions"
+  )
+
+  n <- erifunctions:::.eri_prune_catalog_under("atlantis/")  # trailing slash tolerated
+  expect_equal(n, 2L)
+  expect_setequal(removed, c("atlantis/malaria/surveillance/case/processed/a.parquet",
+                             "atlantis/malaria/surveillance/case/processed/b.parquet"))
+})
+
+test_that(".eri_prune_catalog_under is a fail-silent no-op on an empty catalog", {
+  local_mocked_bindings(
+    eri_catalog_query = function(...) tibble::tibble(path = character()),
+    .package = "erifunctions"
+  )
+  expect_equal(erifunctions:::.eri_prune_catalog_under("atlantis"), 0L)
+})
+
 # --- verify -------------------------------------------------------------------
 
 test_that("eri_catalog_verify returns exists column", {

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -372,6 +372,13 @@ test_that("every bundled CMR sheet declares routing keys (no silently-skipped da
   }
 })
 
+test_that("eri_split_cmr summarizes absent sheets in one message (not a deferred pile)", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_uga_cmr(tmp)  # 3 sheets present; the uga schema routes more, so some are skipped
+  # The absent sheets are reported once as an informational summary, not warnings.
+  expect_message(eri_split_cmr(tmp, "uga", dry_run = TRUE), "Skipped [0-9]+ sheet")
+})
+
 test_that("eri_split_cmr aborts when the workbook has none of the routable sheets", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   writexl::write_xlsx(list(


### PR DESCRIPTION
## What

The two non-doc findings from the second fresh-user red-team pass.

- **[Major, Eli] `eri_dir_delete()` left dangling catalog rows.** Deleting a namespace removed the blobs but not the catalog entries, so `eri_catalog_verify()` then warned `… not found in Azure`. `eri_dir_delete()` now **prunes catalog entries whose path falls under the deleted prefix** (new `prune_catalog` argument, default `TRUE` for Azure deletes), via a fail-silent `.eri_prune_catalog_under()` helper — a catalog hiccup never blocks the delete.
- **[Nit, Dana] `eri_split_cmr()` deferred skipped-sheet warnings.** It emitted one `cli_warn` per absent sheet, which R defers to "There were N warnings (use warnings()…)". Now a single `cli_inform` summary: "Skipped N sheets not in <file>: …".

## Tests

- `.eri_prune_catalog_under` removes only entries under the deleted prefix (trailing slash tolerated) + a fail-silent no-op on an empty catalog.
- `eri_split_cmr` emits the one-line skip summary.
- The full suite caught a real bug in the process: `cli_inform("i" = …)` (named-arg form) errors with "message is missing" — must be `cli_inform(c("i" = …))`. Fixed.

## Verification

Full offline suite green: **FAIL 0 | PASS 1717**.

Companion to the Run-2 **doc-fixes** PR (#207). Part of #175 polish.