### PR TITLE
Reorganize articles into a role-first help section + getting-started landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ reference, and the project roadmap. This README is the quick orientation.
 ## Guides
 
 These copy-paste, start-to-finish walkthroughs are the fastest way to learn the system. Read them
-on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/).
+on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/), which groups
+them **Get started → your role → topic deep-dives → contributing**. The
+[**Getting started**](https://thecartercenter.github.io/erifunctions/articles/getting-started.html)
+article is the front door.
 
 **New here? Do these in order** (then dip into the rest as your work needs them). First, run
 `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure) every guide

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -47,22 +47,54 @@ navbar:
       href: https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md
 
 articles:
-- title: Workflows
-  navbar: Workflows
+- title: Get started
+  navbar: Get started
+  desc: >
+    New here? Read these first — the data-addressing model and your role's path, then how to
+    connect to the services erifunctions talks to.
   contents:
+  - getting-started
   - connections-guide
-  - epi-research-guide
+
+- title: For data analysts
+  navbar: Data analysts
+  desc: >
+    The daily DA workflow, in order: stand up a space, bring data through the
+    raw → staged → approved gate, then keep the backlog clean. CMR and ODK as those feeds arrive.
+  contents:
   - da-onboard-guide
   - da-ingest-guide
   - da-cmr-guide
   - da-odk-guide
   - da-logs-guide
-  - epi-dq-guide
-  - dq-pipeline
-  - epi-analytics
+
+- title: For epidemiologists
+  navbar: Epidemiologists
+  desc: >
+    Source approved data, reconcile free-text places to admin units, quality-check an extract for
+    epidemiological sense, and compute programme indicators.
+  contents:
+  - epi-research-guide
   - epi-reconcile-guide
+  - epi-dq-guide
+  - epi-analytics
+
+- title: Topic deep-dives
+  navbar: Topics
+  desc: >
+    How the engines work, beyond the role walkthroughs: the data-quality pipeline, spatial
+    sourcing and joins, and sharing via SharePoint and Teams.
+  contents:
+  - dq-pipeline
   - spatial-workflow
   - sharepoint-workflow
+
+- title: Extending the package
+  navbar: Contributing
+  desc: >
+    Add a new country, disease, or programme — author its schema and disease analytics, and
+    contribute them to the package.
+  contents:
   - adding-a-program
 
 reference:

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -32,26 +32,58 @@ the guides assume. Then follow your role's path; dip into the rest as your work 
 
 ## Guides
 
-| Role | Task | Guide | Status |
-|------|------|-------|--------|
-| Epidemiologist | Run a research study end-to-end (start → version → source data → analyse → tag → resume → handle new data → clean up) | [`epi-research-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | ✅ Shipped |
-| Data Analyst | Upload & process a monthly country report (CMR) | [`da-cmr-guide`](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | ✅ Shipped |
-| Data Analyst | Ingest → stage → approve a surveillance dataset | [`da-ingest-guide`](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | ✅ Shipped |
-| Data Analyst | Work with ODK Central (connect → monitor → manage → pull) | [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | ✅ Shipped |
-| Data Analyst | Onboard a new country / disease / data type | [`da-onboard-guide`](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | ✅ Shipped |
-| Data Analyst | Triage the error / DQ log backlog | [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | ✅ Shipped |
-| Epidemiologist | Reconcile free-text localities to admin units for sourcing | [`epi-reconcile-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | ✅ Shipped |
-| Epidemiologist | Run the DQ pipeline on a new extract | [`epi-dq-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html) | ✅ Shipped |
-| Either | Authenticate and connect to Azure / ODK / SharePoint / Teams | [`connections-guide`](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) | ✅ Shipped |
+Grouped the same way as the [documentation site's Articles menu](https://thecartercenter.github.io/erifunctions/articles/):
+**Get started → your role → topic deep-dives → contributing.**
+
+### Get started
+
+| Task | Guide | Status |
+|------|-------|--------|
+| Orientation: the data model + your role's path | [`getting-started`](https://thecartercenter.github.io/erifunctions/articles/getting-started.html) | ✅ Shipped |
+| Authenticate and connect to Azure / ODK / SharePoint / Teams | [`connections-guide`](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) | ✅ Shipped |
+
+### For data analysts
+
+| Task | Guide | Status |
+|------|-------|--------|
+| Onboard a new country / disease / data type | [`da-onboard-guide`](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | ✅ Shipped |
+| Ingest → stage → approve a surveillance dataset | [`da-ingest-guide`](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | ✅ Shipped |
+| Upload, split & approve a monthly country report (CMR) | [`da-cmr-guide`](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | ✅ Shipped |
+| Work with ODK Central (connect → monitor → manage → pull) | [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | ✅ Shipped |
+| Triage the error / DQ log backlog | [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | ✅ Shipped |
+
+### For epidemiologists
+
+| Task | Guide | Status |
+|------|-------|--------|
+| Run a research study end-to-end (source → analyse → tag → resume → update) | [`epi-research-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | ✅ Shipped |
+| Reconcile free-text localities to admin units for sourcing | [`epi-reconcile-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | ✅ Shipped |
+| Catch anomalies in a new extract (QC before analysis) | [`epi-dq-guide`](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html) | ✅ Shipped |
+| Incidence, epiweeks, epidemic curves, disease helpers | [`epi-analytics`](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | ✅ Shipped |
+
+### Topic deep-dives
+
+| Task | Guide | Status |
+|------|-------|--------|
+| The schema-driven DQ pipeline + anomaly detectors (reference) | [`dq-pipeline`](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | ✅ Shipped |
+| Admin boundaries, population, spatial joins & maps | [`spatial-workflow`](https://thecartercenter.github.io/erifunctions/articles/spatial-workflow.html) | ✅ Shipped |
+| Share files via SharePoint and post to Teams | [`sharepoint-workflow`](https://thecartercenter.github.io/erifunctions/articles/sharepoint-workflow.html) | ✅ Shipped |
+
+### Extending the package
+
+| Task | Guide | Status |
+|------|-------|--------|
+| Add a new country, disease, or program (schema + analytics) | [`adding-a-program`](https://thecartercenter.github.io/erifunctions/articles/adding-a-program.html) | ✅ Shipped |
 
 ## Adding a guide
 
-A new guide is a pkgdown article in `vignettes/` (so it appears on the site under **Workflows**),
-following the pattern set by [`epi-research-guide.Rmd`](../vignettes/epi-research-guide.Rmd):
+A new guide is a pkgdown article in `vignettes/`, following the pattern set by
+[`epi-research-guide.Rmd`](../vignettes/epi-research-guide.Rmd):
 
 1. A **worked example on safe data** (public sample data, or Azure data the user already has) so
    it runs on any laptop.
 2. **Copy-paste chunks read and run in order** — not a single sourced script — so the reader
    learns the steps, not just the outcome.
 3. A **clean-up section** that removes anything the walkthrough created.
-4. Add the article to `_pkgdown.yml` (`articles:` → Workflows) and flip its row here to ✅.
+4. Add the article to `_pkgdown.yml` under the right `articles:` group (**Get started / Data analysts
+   / Epidemiologists / Topics / Contributing**) and add a row here in the matching section.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,0 +1,103 @@
+---
+title: "Getting started with erifunctions"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting started with erifunctions}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+`erifunctions` is the Carter Center ERI team's R package — the way **Data Analysts** and
+**Epidemiologists** work with TCC's Azure-centred data system across countries (Haiti, DR, Uganda,
+OEPA, …) and diseases (malaria, oncho, LF, SCH, STH). You install it, authenticate through your
+browser, and call functions; you don't edit the package. This page is the **front door**: learn the
+one idea every guide assumes, then follow your role's path.
+
+## 1. Install and connect
+
+```{r install}
+install.packages("remotes")
+remotes::install_github("thecartercenter/erifunctions")
+library(erifunctions)
+```
+
+Azure access is **zero-config** — the first command that needs it opens your browser to sign in. ODK,
+SharePoint, and Teams need a little setup. The **[Connecting to Azure, ODK, SharePoint &
+Teams](connections-guide.html)** guide walks through each and how to confirm it works — including the
+one thing to do **before your first governed action**: set `ERI_ANALYST_ID` so approvals and logs
+carry your name, not your OS username.
+
+## 2. Learn the one idea: how data is addressed
+
+Every dataset lives in the `data/` Azure blob under a five-axis path
+([ADR-0012](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md)):
+
+```
+data/{country}/{disease}/{data_source}/{data_type}/{layer}/
+```
+
+The idea that makes the whole system click: **how the data arrives (`data_source`) is separate from
+what it measures (`data_type`)**. The same `surveillance` channel is a `case` line-list in one country
+and an `aggregate` weekly count in another; one CMR fans out to `treatment`, `mmdp`, and survey
+measures across diseases.
+
+Run `eri_data_model()` once — it prints the whole vocabulary, so you never have to guess a value:
+
+```{r data-model}
+eri_data_model()
+#> ── Data-addressing model (ADR-0012) ──
+#> Path: 'data/{country}/{disease}/{data_source}/{data_type}/{layer}/'
+#>
+#> ── data_source (channel / how the data arrives) ──
+#> • surveillance -- Direct disease-output feed (e.g. a MoH surveillance system).
+#> • programmatic -- Programmatic activity/coverage data (CMR, MDA feeds); spans diseases.
+#> • research     -- Research surveys/studies; DA-managed, flexible measure.
+#>   (… plus the measures, formats, and layers, and the transitional cmr/odk tokens.)
+```
+
+Everything moves through three **layers** — `raw/` (as received) → `staged/` (DQ-checked) →
+`processed/` (the canonical data the whole team trusts). Nothing reaches `processed/` without a human
+calling `eri_approve()`.
+
+## 3. Follow your role's path
+
+The guides are short, copy-paste, run-it-live walkthroughs on safe sandbox data. Do your role's set
+**in order**; dip into the rest as your work needs them.
+
+### New Data Analyst
+
+1. [Connecting to the services](connections-guide.html)
+2. [Onboarding a new country / disease / data type](da-onboard-guide.html) — stand up the space
+3. [Ingesting a surveillance dataset](da-ingest-guide.html) — raw → DQ → staged → **approved**
+4. [Triaging the error & DQ log backlog](da-logs-guide.html) — find what failed and close it out
+
+Then, as those feeds arrive: [monthly **CMR** reports](da-cmr-guide.html) and
+[**ODK Central** forms](da-odk-guide.html).
+
+### New Epidemiologist
+
+1. [Connecting to the services](connections-guide.html)
+2. [A complete research workflow](epi-research-guide.html) — source approved data, analyse, tag a version
+3. [Reconciling localities to admin units](epi-reconcile-guide.html) — messy place names → canonical units
+4. [Catching anomalies in a new extract](epi-dq-guide.html) — QC for epidemiological sense
+
+Then the [epi analytics helpers](epi-analytics.html) for incidence, epiweeks, and curves.
+
+## 4. Going deeper
+
+- **Topic deep-dives** explain the engines behind the role guides: the
+  [data-quality pipeline](dq-pipeline.html), the [spatial workflow](spatial-workflow.html), and
+  [SharePoint & Teams](sharepoint-workflow.html).
+- **Extending the package** — [adding a new program](adding-a-program.html): contribute a schema and
+  disease analytics for a new country/disease.
+- The [function reference](../reference/index.html) groups every function by purpose, and the
+  [roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) tracks where the
+  system is headed.


### PR DESCRIPTION
## What

Reorganizes the documentation **Articles** menu from one flat 14-item "Workflows" dropdown into **five role-first groups**, and adds a **Getting started** landing article as the site front door.

Both fresh-user red-team passes flagged the flat list as overwhelming with no "you're a DA — start here" path. This makes the site, README, and `docs/guides.md` all tell the same grouped story.

## The five groups

| Group (navbar heading) | Articles |
|---|---|
| **Get started** | `getting-started` (new), `connections-guide` |
| **For data analysts** | onboard → ingest → cmr → odk → logs |
| **For epidemiologists** | research → reconcile → dq → analytics |
| **Topic deep-dives** | `dq-pipeline`, `spatial-workflow`, `sharepoint-workflow` |
| **Extending the package** | `adding-a-program` |

Role-first because that's the question a user actually has; the DA/Epi groups are in learning order; the role *QC walkthroughs* (`epi-dq-guide`) sit with their role while the *engine references* (`dq-pipeline`, `spatial-workflow`) move to Topics.

## Changes

- **`_pkgdown.yml`**: 5 `articles:` groups, each with a `navbar:` heading and a `desc:` (so the `/articles/` index reads like a real contents page, not just links).
- **`vignettes/getting-started.Rmd`** (new): the front door — install/connect, the one idea (`data_source` vs `data_type`, run `eri_data_model()` first), and each role's ordered path, then where to go deeper.
- **`docs/guides.md`**: the GitHub-facing matrix regrouped the same way; the "adding a guide" steps point at the right group.
- **`README.md`**: guides intro names the groups and links the Getting started article.

## Verification

Pure docs/config. `getting-started.Rmd` knits clean; all **15 articles resolve to vignette files** (no listed-but-missing / on-disk-but-unlisted). pkgdown render + the grouped navbar are CI-verified (no pandoc on the dev box).