### PR TITLE
eri_odk_upload follow-ups: mapping arg + /fields path fix + live-captured guide

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@
   per-row outcome tibble (`created` / `skipped` / `failed`) and continues past a bad row rather than
   aborting the batch. Attachments at creation are out of scope (an ODK API limitation). Adds a dependency
   on `xml2`. See [ADR-0013](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0013-odk-submission-backfill.md).
+- **`mapping` argument** (#213) — for extracts whose headers don't already match the form, pass
+  `mapping = c(input_header = "field-column", …)` to rename columns to field names before validation
+  (e.g. a paper CSV with `village` → `site_name`); columns you don't list are left as-is. The
+  `da-odk-guide` "Backfilling records into a form" section is now **captured live** against the
+  `eri_test_river_prospection` sandbox form (real `created` / 409-`skipped` round-trip), and the
+  field↔column mapping now normalizes ODK Central's root-relative `/fields` paths (e.g. `/site_name`)
+  so submissions carry their data on servers that omit the instance-root name from field paths.
 
 ## Feature: harden analyst attribution + `eri_odk_purge()` for sandbox cleanup (#175 polish)
 

--- a/R/odk_upload.R
+++ b/R/odk_upload.R
@@ -150,7 +150,16 @@
 
   rename_one <- function(tbl) {
     hit <- intersect(names(mapping), names(tbl))
-    if (length(hit)) names(tbl)[match(hit, names(tbl))] <- unname(mapping[hit])
+    if (length(hit)) {
+      targets <- unname(mapping[hit])
+      collide <- intersect(targets, setdiff(names(tbl), hit))
+      if (length(collide))
+        cli::cli_warn(c(
+          "{.arg mapping} target{?s} {.val {collide}} already exist in the table; the mapped column will duplicate the name.",
+          "i" = "Rename or drop the existing column before mapping onto it."
+        ))
+      names(tbl)[match(hit, names(tbl))] <- targets
+    }
     tbl
   }
   used <- intersect(names(mapping), c(names(input$parent), unlist(lapply(input$children, names))))
@@ -407,12 +416,13 @@
 #' eri_odk_upload(tabs, project_id = 7, form_id = "RiverProspection",
 #'                con = con, key_col = "KEY")
 #'
-#' # A paper CSV whose headers don't match the form: map them.
-#' paper <- read.csv("historical_records.csv")   # cols: village, date_seen, stage
+#' # A paper CSV whose headers don't match the form: map them. `key_col` names a
+#' # column left unmapped (mapping is applied first), so key on `rec`, not `village`.
+#' paper <- read.csv("historical_records.csv")   # cols: village, date_seen, stage, rec
 #' eri_odk_upload(paper, project_id = 7, form_id = "RiverProspection", con = con,
 #'                mapping = c(village = "site_name", date_seen = "prospection_date",
 #'                            stage = "river_stage"),
-#'                key_col = "village", dry_run = TRUE)
+#'                key_col = "rec", dry_run = TRUE)
 #' }
 #' @export
 eri_odk_upload <- function(

--- a/R/odk_upload.R
+++ b/R/odk_upload.R
@@ -71,11 +71,16 @@
   if (inherits(inst_root, "xml_missing"))
     cli::cli_abort("Could not locate the primary instance in form {.val {form_id}}'s XML.")
 
+  root_name <- xml2::xml_name(inst_root)
+  choices   <- .odk_extract_choices(doc)
+  # Form-XML refs include the root (`/data/...`); normalize to match the `/fields` paths.
+  if (length(choices)) names(choices) <- .odk_norm_path(names(choices), root_name)
+
   list(
-    root_name = xml2::xml_name(inst_root),
+    root_name = root_name,
     id        = xml2::xml_attr(inst_root, "id"),
     version   = xml2::xml_attr(inst_root, "version"),
-    choices   = .odk_extract_choices(doc)
+    choices   = choices
   )
 }
 
@@ -133,6 +138,33 @@
   cli::cli_abort("{.arg data} must be a file path, a data.frame, or a named list of tables.")
 }
 
+# Rename columns per a `mapping` (input header -> canonical field-column name), applied to
+# the parent and every child table. A rename only fires where the source column is present,
+# so the same mapping can be handed every table harmlessly. Returns the renamed input list.
+#' @keywords internal
+.odk_apply_mapping <- function(input, mapping) {
+  if (is.null(mapping) || length(mapping) == 0L) return(input)
+  mapping <- unlist(mapping)
+  if (is.null(names(mapping)) || any(!nzchar(names(mapping))))
+    cli::cli_abort("{.arg mapping} must be named: {.code c(input_header = \"field-column\")}.")
+
+  rename_one <- function(tbl) {
+    hit <- intersect(names(mapping), names(tbl))
+    if (length(hit)) names(tbl)[match(hit, names(tbl))] <- unname(mapping[hit])
+    tbl
+  }
+  used <- intersect(names(mapping), c(names(input$parent), unlist(lapply(input$children, names))))
+  if (length(setdiff(names(mapping), used)))
+    cli::cli_warn(c(
+      "{.arg mapping} source column{?s} {.val {setdiff(names(mapping), used)}} not found in any table.",
+      "i" = "Map from the column names as they appear in {.arg data}."
+    ))
+
+  input$parent   <- rename_one(input$parent)
+  input$children <- lapply(input$children, rename_one)
+  input
+}
+
 # --- Deterministic instanceID -------------------------------------------------
 
 # uuid:<hash> derived from the key column(s), or the whole row when none given, so a
@@ -183,15 +215,24 @@
 
 # --- Validation ---------------------------------------------------------------
 
+# Normalize an ODK node path to a single convention: relative to the instance root, with
+# the root element name stripped. ODK Central's `/fields` endpoint returns paths *without*
+# the root (e.g. `/site_name`), while form-XML `ref`/`nodeset` attributes include it
+# (`/data/site_name`); normalizing both to `/site_name` lets them line up. Idempotent.
+#' @keywords internal
+.odk_norm_path <- function(path, root_name) {
+  sub(paste0("^/", root_name, "/"), "/", path)
+}
+
 # Build column -> relative-path map from the fields list (leaf fields only). The expected
 # column name is the dash-joined relative path under the root (download convention).
 #' @keywords internal
 .odk_colmap <- function(fields, root_name, under = NULL) {
   leaves <- fields[!fields$type %in% "structure" & !is.na(fields$path), ]
-  prefix <- paste0("/", root_name, "/", if (!is.null(under)) paste0(under, "/") else "")
+  prefix <- paste0("/", if (!is.null(under)) paste0(under, "/") else "")
   map <- list()
   for (i in seq_len(nrow(leaves))) {
-    p <- leaves$path[i]
+    p <- .odk_norm_path(leaves$path[i], root_name)
     if (!startsWith(p, prefix)) next
     rel <- substr(p, nchar(prefix) + 1L, nchar(p))
     if (!nzchar(rel)) next
@@ -223,13 +264,14 @@
     add("parent", col, NA_integer_, "column does not match any form field")
 
   # Missing required fields are reported by ODK at POST; here we surface unmapped columns
-  # and best-effort type/choice problems on mapped ones.
-  type_of <- stats::setNames(fields$type, fields$path)
+  # and best-effort type/choice problems on mapped ones. Keys are normalized (root stripped)
+  # so the field-type and choice lookups line up regardless of ODK's path convention.
+  type_of <- stats::setNames(fields$type, .odk_norm_path(fields$path, tmpl$root_name))
   choices <- tmpl$choices
 
   check_cell <- function(tbl_name, col, parts, value, rowi, under = NULL) {
     if (is.na(value) || !nzchar(as.character(value))) return(invisible())
-    path <- paste0("/", tmpl$root_name, "/", if (!is.null(under)) paste0(under, "/") else "",
+    path <- paste0("/", if (!is.null(under)) paste0(under, "/") else "",
                    paste(parts, collapse = "/"))
     ty <- type_of[[path]]
     if (!is.null(ty)) {
@@ -329,6 +371,13 @@
 #' @param key_col `chr` Column name(s) whose values seed the deterministic
 #'   `instanceID`. `NULL` (default) hashes the whole parent row. To preserve the
 #'   original submission identity on a round-trip, pass the id column (e.g. `"KEY"`).
+#'   Names refer to the columns *after* any `mapping` is applied.
+#' @param mapping Named character vector mapping **input column headers to
+#'   field-column names**, for extracts whose headers don't already match the
+#'   form (e.g. a paper CSV): `c(village = "site_name", date_seen = "visit-date")`.
+#'   Targets use the same `download_odk_form()` flattening (`group-field`). The
+#'   rename is applied to the parent and every child table before validation, so
+#'   columns you don't list are left as-is. `NULL` (default) maps nothing.
 #' @param dry_run `lgl` If `TRUE`, run validation only and POST nothing; returns
 #'   the validation-issue tibble.
 #' @param data_con Azure container for optional operation logging; `NULL` skips it.
@@ -357,6 +406,13 @@
 #' # Create the submissions (re-runs skip already-present rows via HTTP 409).
 #' eri_odk_upload(tabs, project_id = 7, form_id = "RiverProspection",
 #'                con = con, key_col = "KEY")
+#'
+#' # A paper CSV whose headers don't match the form: map them.
+#' paper <- read.csv("historical_records.csv")   # cols: village, date_seen, stage
+#' eri_odk_upload(paper, project_id = 7, form_id = "RiverProspection", con = con,
+#'                mapping = c(village = "site_name", date_seen = "prospection_date",
+#'                            stage = "river_stage"),
+#'                key_col = "village", dry_run = TRUE)
 #' }
 #' @export
 eri_odk_upload <- function(
@@ -367,12 +423,13 @@ eri_odk_upload <- function(
     url      = Sys.getenv("ODK_URL"),
     auth     = Sys.getenv("ODK_TOKEN"),
     key_col  = NULL,
+    mapping  = NULL,
     dry_run  = FALSE,
     data_con = NULL
 ) {
   creds <- .odk_creds(con, url, auth)
 
-  input    <- .odk_normalize_input(data, form_id)
+  input    <- .odk_apply_mapping(.odk_normalize_input(data, form_id), mapping)
   parent   <- input$parent
   children <- input$children
 

--- a/docs/adr/0013-odk-submission-backfill.md
+++ b/docs/adr/0013-odk-submission-backfill.md
@@ -84,7 +84,8 @@ rules that make the operation safe, repeatable, and auditable.**
   - **Form-definition upload** (XLSForm → a new ODK form) — a different endpoint and a separate
     feature; this ADR is only about *submissions*.
   - **An explicit arbitrary-header `mapping` argument** (for extracts whose columns don't follow the
-    download convention) — deferred to a fast-follow; v1 requires field-name-matching columns.
+    download convention) — deferred from v1 to a fast-follow (delivered in #213); v1 required
+    field-name-matching columns.
   - **Random per-row UUIDs** — rejected; they make re-runs duplicate (rule 1).
 
 ## References

--- a/man/eri_odk_upload.Rd
+++ b/man/eri_odk_upload.Rd
@@ -100,11 +100,12 @@ eri_odk_upload(tabs, project_id = 7, form_id = "RiverProspection",
 eri_odk_upload(tabs, project_id = 7, form_id = "RiverProspection",
                con = con, key_col = "KEY")
 
-# A paper CSV whose headers don't match the form: map them.
-paper <- read.csv("historical_records.csv")   # cols: village, date_seen, stage
+# A paper CSV whose headers don't match the form: map them. `key_col` names a
+# column left unmapped (mapping is applied first), so key on `rec`, not `village`.
+paper <- read.csv("historical_records.csv")   # cols: village, date_seen, stage, rec
 eri_odk_upload(paper, project_id = 7, form_id = "RiverProspection", con = con,
                mapping = c(village = "site_name", date_seen = "prospection_date",
                            stage = "river_stage"),
-               key_col = "village", dry_run = TRUE)
+               key_col = "rec", dry_run = TRUE)
 }
 }

--- a/man/eri_odk_upload.Rd
+++ b/man/eri_odk_upload.Rd
@@ -12,6 +12,7 @@ eri_odk_upload(
   url = Sys.getenv("ODK_URL"),
   auth = Sys.getenv("ODK_TOKEN"),
   key_col = NULL,
+  mapping = NULL,
   dry_run = FALSE,
   data_con = NULL
 )
@@ -32,7 +33,15 @@ the \code{ODK_URL} / \code{ODK_TOKEN} environment variables.}
 
 \item{key_col}{\code{chr} Column name(s) whose values seed the deterministic
 \code{instanceID}. \code{NULL} (default) hashes the whole parent row. To preserve the
-original submission identity on a round-trip, pass the id column (e.g. \code{"KEY"}).}
+original submission identity on a round-trip, pass the id column (e.g. \code{"KEY"}).
+Names refer to the columns \emph{after} any \code{mapping} is applied.}
+
+\item{mapping}{Named character vector mapping \strong{input column headers to
+field-column names}, for extracts whose headers don't already match the
+form (e.g. a paper CSV): \code{c(village = "site_name", date_seen = "visit-date")}.
+Targets use the same \code{download_odk_form()} flattening (\code{group-field}). The
+rename is applied to the parent and every child table before validation, so
+columns you don't list are left as-is. \code{NULL} (default) maps nothing.}
 
 \item{dry_run}{\code{lgl} If \code{TRUE}, run validation only and POST nothing; returns
 the validation-issue tibble.}
@@ -90,5 +99,12 @@ eri_odk_upload(tabs, project_id = 7, form_id = "RiverProspection",
 # Create the submissions (re-runs skip already-present rows via HTTP 409).
 eri_odk_upload(tabs, project_id = 7, form_id = "RiverProspection",
                con = con, key_col = "KEY")
+
+# A paper CSV whose headers don't match the form: map them.
+paper <- read.csv("historical_records.csv")   # cols: village, date_seen, stage
+eri_odk_upload(paper, project_id = 7, form_id = "RiverProspection", con = con,
+               mapping = c(village = "site_name", date_seen = "prospection_date",
+                           stage = "river_stage"),
+               key_col = "village", dry_run = TRUE)
 }
 }

--- a/tests/testthat/test-odk_upload.R
+++ b/tests/testthat/test-odk_upload.R
@@ -44,29 +44,34 @@ fixture_form_xml <- function() {
   </h:html>'
 }
 
+# Paths mirror what ODK Central's /fields endpoint really returns: relative to the
+# instance root, with the root element name omitted (e.g. "/site_name", not "/data/...").
 fixture_fields <- function() {
   tibble::tribble(
-    ~name,         ~path,                          ~type,
-    "site_name",   "/data/site_name",              "string",
-    "visit",       "/data/visit",                  "structure",
-    "visit_date",  "/data/visit/visit_date",       "date",
-    "river_stage", "/data/visit/river_stage",      "string",
-    "larva_sample","/data/larva_sample",           "structure",
-    "species",     "/data/larva_sample/species",   "string",
-    "larva_count", "/data/larva_sample/larva_count","int",
-    "meta",        "/data/meta",                   "structure",
-    "instanceID",  "/data/meta/instanceID",        "string"
+    ~name,         ~path,                     ~type,
+    "site_name",   "/site_name",              "string",
+    "visit",       "/visit",                  "structure",
+    "visit_date",  "/visit/visit_date",       "date",
+    "river_stage", "/visit/river_stage",      "string",
+    "larva_sample","/larva_sample",           "structure",
+    "species",     "/larva_sample/species",   "string",
+    "larva_count", "/larva_sample/larva_count","int",
+    "meta",        "/meta",                   "structure",
+    "instanceID",  "/meta/instanceID",        "string"
   )
 }
 
-# tmpl as .odk_form_template() would return it (parsed from fixture_form_xml()).
+# tmpl as .odk_form_template() would return it (parsed from fixture_form_xml()): choice
+# keys are normalized (root stripped) to line up with the /fields paths.
 fixture_tmpl <- function() {
   doc <- xml2::read_xml(fixture_form_xml())
+  ch  <- erifunctions:::.odk_extract_choices(doc)
+  names(ch) <- erifunctions:::.odk_norm_path(names(ch), "data")
   list(
     root_name = "data",
     id        = "rivertest",
     version   = "3",
-    choices   = erifunctions:::.odk_extract_choices(doc)
+    choices   = ch
   )
 }
 
@@ -120,6 +125,50 @@ test_that(".odk_normalize_input handles data.frame, list, and bad inputs", {
     ),
     "rivertest-"
   )
+})
+
+# --- .odk_colmap path conventions ---------------------------------------------
+
+test_that(".odk_colmap handles both root-omitted and root-included /fields paths", {
+  # root-omitted (what ODK Central actually returns)
+  m1 <- erifunctions:::.odk_colmap(fixture_fields(), "data")
+  expect_true(all(c("site_name", "visit-visit_date", "larva_sample-species") %in% names(m1)))
+  expect_equal(m1[["visit-visit_date"]], c("visit", "visit_date"))
+
+  # root-included (e.g. "/data/site_name") normalizes to the same columns
+  rooted <- fixture_fields()
+  rooted$path <- sub("^/", "/data/", rooted$path)
+  m2 <- erifunctions:::.odk_colmap(rooted, "data")
+  expect_equal(m1, m2)
+})
+
+# --- .odk_apply_mapping -------------------------------------------------------
+
+test_that(".odk_apply_mapping renames matching columns in parent and children", {
+  input <- list(
+    parent = tibble::tibble(village = "S1", stage = "low", record_id = "h1"),
+    children = list(larva_sample = tibble::tibble(bug = "anopheles", PARENT_KEY = "a"))
+  )
+  out <- erifunctions:::.odk_apply_mapping(
+    input, c(village = "site_name", stage = "visit-river_stage", bug = "species")
+  )
+  expect_true(all(c("site_name", "visit-river_stage", "record_id") %in% names(out$parent)))
+  expect_false("village" %in% names(out$parent))
+  expect_true("species" %in% names(out$children$larva_sample))  # child renamed too
+  expect_true("PARENT_KEY" %in% names(out$children$larva_sample))  # untouched
+})
+
+test_that(".odk_apply_mapping warns on a source column that matches no table", {
+  input <- list(parent = tibble::tibble(village = "S1"), children = list())
+  expect_warning(
+    erifunctions:::.odk_apply_mapping(input, c(village = "site_name", ghost = "nope")),
+    "not found in any table"
+  )
+})
+
+test_that(".odk_apply_mapping is a no-op for NULL/empty mapping", {
+  input <- list(parent = tibble::tibble(x = 1), children = list())
+  expect_identical(erifunctions:::.odk_apply_mapping(input, NULL), input)
 })
 
 # --- .odk_build_instance ------------------------------------------------------
@@ -229,6 +278,34 @@ test_that("eri_odk_upload dry_run validates and POSTs nothing", {
   ))
   expect_equal(posted, 0L)                          # nothing sent
   expect_true(any(out$column == "bad"))             # validation tibble returned
+})
+
+test_that("eri_odk_upload applies mapping so non-conventional headers validate clean", {
+  posted <- list()
+  local_mocked_bindings(
+    .odk_form_fields     = function(...) fixture_fields(),
+    .odk_form_template   = function(...) fixture_tmpl(),
+    .odk_post_submission = function(creds, project_id, form_id, xml) {
+      posted[[length(posted) + 1L]] <<- xml
+      list(status = "created", http = 201L, message = NA_character_)
+    },
+    .package = "erifunctions"
+  )
+
+  paper <- tibble::tibble(
+    village = "S1", stage = "low", seen = "2026-06-01", rec = "h1"
+  )
+  res <- suppressMessages(eri_odk_upload(
+    paper, project_id = 1L, form_id = "rivertest", url = "https://x/", auth = "tok",
+    mapping = c(village = "site_name", stage = "visit-river_stage",
+                seen = "visit-visit_date"),
+    key_col = "rec"
+  ))
+  expect_equal(res$status, "created")
+  # the mapped values made it into the submission under the real field paths
+  doc <- xml2::read_xml(posted[[1]])
+  expect_equal(xml2::xml_text(xml2::xml_find_first(doc, "/data/site_name")), "S1")
+  expect_equal(xml2::xml_text(xml2::xml_find_first(doc, "/data/visit/river_stage")), "low")
 })
 
 test_that("eri_odk_upload reports per-row outcomes and never aborts the batch", {

--- a/tests/testthat/test-odk_upload.R
+++ b/tests/testthat/test-odk_upload.R
@@ -171,6 +171,17 @@ test_that(".odk_apply_mapping is a no-op for NULL/empty mapping", {
   expect_identical(erifunctions:::.odk_apply_mapping(input, NULL), input)
 })
 
+test_that(".odk_apply_mapping warns when a target collides with an existing column", {
+  input <- list(
+    parent = tibble::tibble(village = "S1", site_name = "already-here"),
+    children = list()
+  )
+  expect_warning(
+    erifunctions:::.odk_apply_mapping(input, c(village = "site_name")),
+    "already exist"
+  )
+})
+
 # --- .odk_build_instance ------------------------------------------------------
 
 test_that(".odk_build_instance nests groups, duplicates repeats, and sets instanceID", {

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -474,8 +474,8 @@ to land in ODK Central so they sit alongside the field submissions and flow thro
 [`eri_odk_upload()`](../reference/eri_odk_upload.html) does exactly that: it reads a table and **creates
 one submission per row** on an existing **published** form.
 
-The mapping is the mirror image of a download: columns are matched to form fields **by name**, using the
-same flattening you saw above — a field at `/data/visit/date` is the column `visit-date`, and repeat
+It is the mirror image of a download: columns are matched to form fields **by name**, using the same
+flattening you saw above — a field nested in a `visit` group is the column `visit-date`, and repeat
 groups are supplied as the same `{form_id}-{repeat}` child tables linked by `PARENT_KEY`. So a
 `download_odk_form(tables = TRUE)` result is itself a valid input — **download and upload round-trip.**
 
@@ -515,10 +515,10 @@ eri_odk_upload(backfill, project_id = project_id, form_id = form_id,
 #> ✔ Validation clean: all columns map to form fields.
 #> ✔ Uploaded to "eri_test_river_prospection": 2 created, 0 already present.
 #> # A tibble: 2 × 4
-#>   instance_id     status  http_status message
-#>   <chr>           <chr>         <int> <chr>
-#> 1 uuid:9f2c1a…    created         201 NA
-#> 2 uuid:4a7b86…    created         201 NA
+#>   instance_id                           status  http_status message
+#>   <chr>                                 <chr>         <int> <chr>
+#> 1 uuid:682c06225e8949547e6c34a6b6834ee4 created         200 NA
+#> 2 uuid:80a4e16d30398e85e78b4c18799a63ab created         200 NA
 ```
 
 The `instanceID` of each submission is **derived deterministically** from `key_col` (here `record_id`).
@@ -533,6 +533,36 @@ eri_odk_upload(backfill, project_id = project_id, form_id = form_id,
 
 — and if you fix a couple of rows and run again, only those change while the rest skip. A bad row never
 aborts the batch: it comes back as `failed` (with the server's message) while its neighbours load.
+
+### Headers that don't match the form
+
+A paper or legacy spreadsheet rarely uses the form's exact column names. Rather than editing the source
+file, pass a **`mapping`** — `c(your_header = "field-column", …)` — and `eri_odk_upload()` renames the
+columns before it validates:
+
+```{r backfill-mapping}
+paper <- data.frame(
+  village   = c("Old Ford", "Bend Camp"),
+  date_seen = c("2025-11-03", "2025-11-04"),
+  stage     = c("low", "medium"),
+  flies     = c(12L, 7L),
+  recorder  = c("paper-archive", "paper-archive"),
+  rec       = c("hist-101", "hist-102")
+)
+
+eri_odk_upload(paper, project_id = project_id, form_id = form_id, con = con,
+               mapping = c(village = "site_name", date_seen = "prospection_date",
+                           stage = "river_stage", flies = "blackfly_count",
+                           recorder = "collector"),
+               key_col = "rec", dry_run = TRUE)
+#> ✔ Validation clean: all columns map to form fields.
+#> ℹ `dry_run` is on -- no submissions were sent.
+#> # A tibble: 0 × 4
+#> # ℹ 4 variables: table <chr>, column <chr>, row <int>, issue <chr>
+```
+
+Map only the columns that differ — anything already matching a field is left alone — then drop
+`dry_run` to send. The targets are the same flattened field-column names (`group-field`).
 
 > **Forms with repeats.** Pass the same named-list shape you got from `download_odk_form(tables = TRUE)`
 > — the parent table first, then each `{form_id}-{repeat}` child table with a `PARENT_KEY` column linking


### PR DESCRIPTION
Closes #213. Builds on #212 (ADR-0013).

## What

The two fast-follows from `eri_odk_upload()`:

1. **`mapping=` argument** — for extracts whose headers don't already match the form (a paper CSV, a legacy export), pass `mapping = c(input_header = "field-column", …)` to rename columns to field names before validation. Applied to the parent and every child table; columns you don't list are left as-is; a source column that matches no table warns.

2. **Live-captured guide** — the `da-odk-guide` "Backfilling records into a form" section now shows **real** output captured against the `eri_test_river_prospection` sandbox form (project 11): the `created` / 409-`skipped` round-trip and a `mapping` example. All writes were scoped to that sandbox form and cleaned up.

## Bug the live capture caught (and this PR fixes)

ODK Central's `GET .../forms/{id}/fields` returns paths **relative to the instance root with the root element name omitted** (e.g. `/site_name`), not `/<root>/site_name` as the original code assumed. The mismatch meant `colmap` matched nothing, so `eri_odk_upload()` POSTed **empty** submissions (only `instanceID`) while validation falsely flagged every real column as "unknown". The unit tests passed only because the fixture used the wrong convention.

Fix: a `.odk_norm_path()` normalizer strips the root from both `/fields` paths and form-XML choice `ref`s, so the two line up regardless of whether a server includes the root. The fixture is corrected to the real convention, and tests now cover **both** conventions plus mapping. Verified live: submissions now carry their field values (downloaded them back to confirm), then deleted.

## Changes

- `R/odk_upload.R` — `mapping` arg + `.odk_apply_mapping()`; `.odk_norm_path()` + normalization in `.odk_colmap`/`.odk_form_template`/`.odk_validate_upload`. Roxygen + `man/` regenerated.
- `tests/testthat/test-odk_upload.R` — fixture corrected; new tests for mapping, the warn path, and both path conventions.
- `vignettes/da-odk-guide.Rmd` — live-captured backfill section + mapping subsection. `NEWS.md`.

## Verification

- `devtools::test()` → **FAIL 0, PASS 1771** (pre-existing reports-excel/spatial warnings unchanged).
- Vignette knits (parse-checked); guide `#>` is now real captured output.
- Live round-trip run end-to-end against the sandbox form, with cleanup (form back to its original 3 submissions).