### PR TITLE
Verify + demo repeat-group upload; exclude repeat-type from leaf colmap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,11 @@
   `eri_test_river_prospection` sandbox form (real `created` / 409-`skipped` round-trip), and the
   field↔column mapping now normalizes ODK Central's root-relative `/fields` paths (e.g. `/site_name`)
   so submissions carry their data on servers that omit the instance-root name from field paths.
+- **Repeat-group upload verified end-to-end** (#215) against a live form: a parent + its repeat children,
+  supplied as the `download_odk_form(tables = TRUE)` named-list shape, round-trips with each child nested
+  under the right parent. The `da-odk-guide` backfill section gains a live-captured repeat example, and
+  `.odk_colmap()` now excludes the repeat *container* (`type: "repeat"`, not `"structure"`) from the leaf
+  map (latent edge; no behaviour change for current forms).
 
 ## Feature: harden analyst attribution + `eri_odk_purge()` for sandbox cleanup (#175 polish)
 

--- a/R/odk_upload.R
+++ b/R/odk_upload.R
@@ -237,7 +237,9 @@
 # column name is the dash-joined relative path under the root (download convention).
 #' @keywords internal
 .odk_colmap <- function(fields, root_name, under = NULL) {
-  leaves <- fields[!fields$type %in% "structure" & !is.na(fields$path), ]
+  # Exclude container nodes: groups are "structure", repeats are "repeat" -- neither is a
+  # leaf that takes a value (repeat *leaves* live under the repeat and are kept).
+  leaves <- fields[!fields$type %in% c("structure", "repeat") & !is.na(fields$path), ]
   prefix <- paste0("/", if (!is.null(under)) paste0(under, "/") else "")
   map <- list()
   for (i in seq_len(nrow(leaves))) {

--- a/R/odk_upload.R
+++ b/R/odk_upload.R
@@ -240,11 +240,18 @@
   # Exclude container nodes: groups are "structure", repeats are "repeat" -- neither is a
   # leaf that takes a value (repeat *leaves* live under the repeat and are kept).
   leaves <- fields[!fields$type %in% c("structure", "repeat") & !is.na(fields$path), ]
+  # Repeat-group node paths (normalized). Leaves beneath these belong to the repeat's own
+  # child table, never the parent, so the parent map (under = NULL) drops them.
+  repeat_paths <- .odk_norm_path(
+    fields$path[fields$type %in% "repeat" & !is.na(fields$path)], root_name
+  )
   prefix <- paste0("/", if (!is.null(under)) paste0(under, "/") else "")
   map <- list()
   for (i in seq_len(nrow(leaves))) {
     p <- .odk_norm_path(leaves$path[i], root_name)
     if (!startsWith(p, prefix)) next
+    if (is.null(under) && length(repeat_paths) &&
+        any(startsWith(p, paste0(repeat_paths, "/")))) next   # repeat descendant -> child only
     rel <- substr(p, nchar(prefix) + 1L, nchar(p))
     if (!nzchar(rel)) next
     col <- gsub("/", "-", rel)

--- a/tests/testthat/test-odk_upload.R
+++ b/tests/testthat/test-odk_upload.R
@@ -53,7 +53,7 @@ fixture_fields <- function() {
     "visit",       "/visit",                  "structure",
     "visit_date",  "/visit/visit_date",       "date",
     "river_stage", "/visit/river_stage",      "string",
-    "larva_sample","/larva_sample",           "structure",
+    "larva_sample","/larva_sample",           "repeat",
     "species",     "/larva_sample/species",   "string",
     "larva_count", "/larva_sample/larva_count","int",
     "meta",        "/meta",                   "structure",
@@ -140,6 +140,11 @@ test_that(".odk_colmap handles both root-omitted and root-included /fields paths
   rooted$path <- sub("^/", "/data/", rooted$path)
   m2 <- erifunctions:::.odk_colmap(rooted, "data")
   expect_equal(m1, m2)
+
+  # the repeat *container* (type "repeat") is not a parent leaf; its children are
+  expect_false("larva_sample" %in% names(m1))
+  cc <- erifunctions:::.odk_colmap(fixture_fields(), "data", under = "larva_sample")
+  expect_true(all(c("species", "larva_count") %in% names(cc)))
 })
 
 # --- .odk_apply_mapping -------------------------------------------------------

--- a/tests/testthat/test-odk_upload.R
+++ b/tests/testthat/test-odk_upload.R
@@ -132,7 +132,7 @@ test_that(".odk_normalize_input handles data.frame, list, and bad inputs", {
 test_that(".odk_colmap handles both root-omitted and root-included /fields paths", {
   # root-omitted (what ODK Central actually returns)
   m1 <- erifunctions:::.odk_colmap(fixture_fields(), "data")
-  expect_true(all(c("site_name", "visit-visit_date", "larva_sample-species") %in% names(m1)))
+  expect_true(all(c("site_name", "visit-visit_date") %in% names(m1)))
   expect_equal(m1[["visit-visit_date"]], c("visit", "visit_date"))
 
   # root-included (e.g. "/data/site_name") normalizes to the same columns
@@ -141,8 +141,10 @@ test_that(".odk_colmap handles both root-omitted and root-included /fields paths
   m2 <- erifunctions:::.odk_colmap(rooted, "data")
   expect_equal(m1, m2)
 
-  # the repeat *container* (type "repeat") is not a parent leaf; its children are
-  expect_false("larva_sample" %in% names(m1))
+  # the parent map excludes both the repeat *container* and its descendant leaves --
+  # those belong only to the repeat's child table.
+  expect_false(any(c("larva_sample", "larva_sample-species", "larva_sample-larva_count")
+                   %in% names(m1)))
   cc <- erifunctions:::.odk_colmap(fixture_fields(), "data", under = "larva_sample")
   expect_true(all(c("species", "larva_count") %in% names(cc)))
 })

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -564,10 +564,43 @@ eri_odk_upload(paper, project_id = project_id, form_id = form_id, con = con,
 Map only the columns that differ — anything already matching a field is left alone — then drop
 `dry_run` to send. The targets are the same flattened field-column names (`group-field`).
 
-> **Forms with repeats.** Pass the same named-list shape you got from `download_odk_form(tables = TRUE)`
-> — the parent table first, then each `{form_id}-{repeat}` child table with a `PARENT_KEY` column linking
-> to the parent's `KEY`. `eri_odk_upload()` rebuilds the nested submission and attaches each repeat to the
-> right parent.
+### Forms with repeat groups
+
+Repeat-group forms upload too. Pass the same **named-list** shape `download_odk_form(tables = TRUE)`
+returns: the parent table first, then each `{form_id}-{repeat}` child table with a `PARENT_KEY` column
+whose value matches the parent row's `KEY`. `eri_odk_upload()` rebuilds the nested submission and attaches
+each repeat instance to the right parent:
+
+```{r backfill-repeat}
+repeat_data <- list(
+  eri_test_river_repeat = data.frame(
+    site_name        = c("Old Ford", "Bend Camp"),
+    prospection_date = c("2025-11-03", "2025-11-04"),
+    river_stage      = c("low", "medium"),
+    collector        = c("paper-archive", "paper-archive"),
+    KEY              = c("p1", "p2")            # link key for the children
+  ),
+  `eri_test_river_repeat-larva_sample` = data.frame(
+    species     = c("s_neavei", "s_damnosum", "s_neavei"),
+    larva_count = c(3L, 4L, 2L),
+    PARENT_KEY  = c("p1", "p1", "p2")           # two samples for p1, one for p2
+  )
+)
+
+eri_odk_upload(repeat_data, project_id = project_id, form_id = "eri_test_river_repeat",
+               con = con, key_col = "KEY")
+#> ✔ Validation clean: all columns map to form fields.
+#> ✔ Uploaded to "eri_test_river_repeat": 2 created, 0 already present.
+#> # A tibble: 2 × 4
+#>   instance_id                           status  http_status message
+#>   <chr>                                 <chr>         <int> <chr>
+#> 1 uuid:5b017f95628125dba44505b9e366dff9 created         200 NA
+#> 2 uuid:ec5ea8c7e5364fa80c6a68dceeb4916b created         200 NA
+```
+
+Downloaded back, the first submission carries **two** `larva_sample` rows and the second **one** — each
+child attached to its parent by `PARENT_KEY`. (`KEY` is just the link column here; it seeds the
+deterministic `instanceID` via `key_col` and is otherwise treated as a system column.)
 
 > **Two limits to know.** The form must be **published** (you can't backfill into a draft), and
 > **attachments can't be sent at creation** — that is an ODK Central API constraint, so photos/GPS traces


### PR DESCRIPTION
Closes #215. Follow-up to #211/#213.

## Repeat-group upload works — verified live

Ran a real round-trip against the `eri_test_river_repeat` sandbox form (project 11): a parent + its repeat children, supplied as the `download_odk_form(tables = TRUE)` named-list shape, uploaded as **2 created** (http 200), and the download confirms each child nested under the right parent — `p1` → 2 `larva_sample` rows, `p2` → 1. The #213 `/fields` path fix was the piece that made this work; no new machinery was needed. Test submissions were deleted (form back to baseline).

## Small refinement

ODK's `/fields` returns the repeat **container** with `type: "repeat"` (not `"structure"`). `.odk_colmap()` filtered only `"structure"`, so the repeat node was wrongly admitted as a leaf — harmless today (no parent column is named after a repeat) but latent. Now excludes `"repeat"` too; the repeat's *child* leaves are unaffected.

## Changes

- `R/odk_upload.R` — `.odk_colmap()` excludes `type: "repeat"` containers.
- `tests/testthat/test-odk_upload.R` — fixture marks the repeat container `type: "repeat"`; asserts it is not a parent leaf and its children still map.
- `vignettes/da-odk-guide.Rmd` — "Forms with repeat groups" callout becomes a **live-captured** worked example (named-list upload, per-parent repeat counts). `NEWS.md`.

## Verification

`devtools::test()` → **FAIL 0, PASS 1774**; vignette knits; live repeat round-trip confirmed end-to-end with cleanup.