### PR TITLE
da-odk-guide: make the remaining captures live-accurate

### DIFF
--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -211,12 +211,12 @@ list_odk_form_users(con = con, project_id = project_id, form_id = form_id)
 #> # A tibble: 2 × 2
 #>   actorId roleId
 #>     <int>  <int>
-#> 1    1112      7
-#> 2    1153      2
+#> 1     198      7
+#> 2     250      2
 ```
 
 Each row pairs an `actorId` (an app user) with the `roleId` it holds on this form — your new collector
-(`roleId 2`, ODK's App User role) is now listed.
+(`actorId 250`, `roleId 2` = ODK's App User role) is now listed alongside anyone already assigned.
 
 ### Managing a whole team at once
 

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -208,7 +208,15 @@ Check the form's assignments — your new collector should be listed:
 
 ```{r list-form-users}
 list_odk_form_users(con = con, project_id = project_id, form_id = form_id)
+#> # A tibble: 2 × 2
+#>   actorId roleId
+#>     <int>  <int>
+#> 1    1112      7
+#> 2    1153      2
 ```
+
+Each row pairs an `actorId` (an app user) with the `roleId` it holds on this form — your new collector
+(`roleId 2`, ODK's App User role) is now listed.
 
 ### Managing a whole team at once
 
@@ -259,11 +267,12 @@ eri_odk_register(
 #> ✔ Registered "eri_test_river_prospection" (uga/demo) on <https://your-odk-server.org/>.
 
 eri_odk_list_registered(data_con = data_con)
-#> ℹ 1 registered form.
-#> # A tibble: 1 × 9
+#> ℹ 5 registered forms.
+#> # A tibble: 5 × 9
 #>   server_url               project_id form_id                    form_display_name … country disease added_by  added_at   last_synced
 #>   <chr>                         <int> <chr>                      <chr>                <chr>   <chr>   <chr>     <chr>      <chr>
-#> 1 https://your-odk-server…         11 eri_test_river_prospection ERI Test — River …   uga     demo    your.name 2026-06-26 NA
+#> 1 https://your-odk-server…         11 eri_test_river_prospection ERI Test — River …   uga     demo    your.name 2026-06-29 NA
+#> # ℹ 4 more rows — the registry is shared, so you also see teammates' registered forms
 ```
 
 ### Sync the submissions
@@ -275,7 +284,8 @@ layer, then stamps the registry with the sync time:
 eri_odk_sync(project_id = project_id, form_id = form_id, con = con, data_con = data_con)
 #> ℹ Downloading submissions for "eri_test_river_prospection" (uga/demo)...
 #> ℹ Downloaded 3 records from "eri_test_river_prospection".
-#> ✔ Synced 3 records from "eri_test_river_prospection" to uga/demo/research/raw/eri_test_river_prospection.parquet.
+#> ℹ Operation log: 'uga/demo/research/logs/20260629_135631_eri_odk_sync.yaml'
+#> ✔ Synced 3 records from "eri_test_river_prospection" to 'uga/demo/research/raw/eri_test_river_prospection.parquet'.
 ```
 
 Read it back to see what landed. ODK expands the form fields plus its own system columns (note the
@@ -313,16 +323,17 @@ eri_write(raw, staged_path, azcontainer = data_con)
 ```{r approve}
 # Channel-level approve (no measure yet); pass data_type = once you assign one.
 eri_approve("uga", "demo", "research", "2026-06", azcontainer = data_con)
-#> ℹ Approving the channel-level (no-measure) form; the catalog entry's data_type will be NA.
-#>   Pass data_type (e.g. "case", "aggregate", "treatment") to record a measure (ADR-0012).
-#> ✔ Catalog: registered eri_test_river_prospection_2026-06.parquet.
-#> ✔ Approved: eri_test_river_prospection_2026-06.parquet
-#> ✔ Approval log: uga/demo/research/processed/2026-06_approval_log.yaml
+#> ℹ Approving the channel-level (no-measure) form; the catalog entry's data_type will be "NA".
+#>   Pass `data_type` (e.g. "case", "aggregate", "treatment") to record a measure (ADR-0012).
+#> ✔ Catalog: registered 'eri_test_river_prospection_2026-06.parquet'.
+#> ✔ Approved: 'eri_test_river_prospection_2026-06.parquet'
+#> ✔ Approval log: 'uga/demo/research/processed/2026-06_approval_log.yaml'
 #> ── ✔ Approved "2026-06" ─────────────────────────────────
 #> Dataset: uga / demo / research
 #> Files: 1 moved to processed
 #> Approver: your.name
 #> Location: uga/demo/research/processed
+#> ℹ Operation log: 'uga/demo/research/logs/20260629_135633_eri_approve_2026-06.yaml'
 ```
 
 Your ODK submissions are now canonical, discoverable in the catalog like any other approved dataset:
@@ -330,10 +341,15 @@ Your ODK submissions are now canonical, discoverable in the catalog like any oth
 ```{r catalog}
 eri_catalog_query(country = "uga", disease = "demo", data_con = data_con)
 #> # A tibble: 1 × 13
-#>   path                              country disease data_source data_type layer …
-#>   <chr>                             <chr>   <chr>   <chr>       <chr>     <chr>
-#> 1 uga/demo/research/processed/eri…  uga     demo    research    NA        proces…
+#>   path   country disease data_source data_type layer  period  file_format row_count
+#>   <chr>  <chr>   <chr>   <chr>       <chr>     <chr>  <chr>   <chr>           <int>
+#> 1 uga/…  uga     demo    research    <NA>      proc…  2026-…  parquet            NA
+#> # ℹ 4 more variables: size_bytes <int>, registered_at <chr>,
+#> #   registered_by <chr>, last_verified_at <chr>
 ```
+
+(`data_type` is `<NA>` because we approved at the channel level; `row_count` is `NA` until the entry is
+verified. Assign a measure on approval — `eri_approve(…, data_type = "prevalence")` — to fill it in.)
 
 ## 4. Forms with repeat groups {#repeat-groups}
 


### PR DESCRIPTION
Closes #217. Doc-only follow-up.

Ran the full ODK guide pipeline live against the `eri_test_*` sandbox forms + the `uga/demo` Azure namespace (register → sync → stage → approve → catalog, plus app-user create/assign and repeat sync), captured the real output, and **cleaned everything up** (registry uga/demo entries: 0; `uga/demo` blob: deleted; demo app user: deleted; catalog entry: removed). This corrects the guide's `#>` to match reality:

- **`list_odk_form_users`** — was shown with no output; now the real `actorId`/`roleId` tibble.
- **`eri_odk_sync` / `eri_approve` / catalog** — real cli wording: quoted paths and values, `data_type will be "NA"`, the operation-log lines, and the real 13-column catalog tibble (`row_count` `NA`, `<NA>` measure).
- **`eri_odk_list_registered`** — the shared registry returns **teammates' real registrations**, so this stays **masked**: the demo row + "N more rows — the registry is shared," rather than publishing real forms/people.

Conventions kept: server URL → `your-odk-server.org` placeholder; approver → `your.name`. `list_odk_projects` stays representative (its real output is the org's full project inventory). §4 (repeat download/sync) already matched the live output.

No code change. Vignette knits.