### PR TITLE
DA training bundle: cheat sheets, onboarding path, orientation deck

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # erifunctions (development version)
 
+## Docs: Data Analyst training bundle — cheat sheets, onboarding path, orientation deck (#219)
+
+- **New quick-reference cards** under `docs/training/`: a **DA cheat sheet** (the ~15 functions a DA
+  uses, the 5-axis path, and a "which pipeline?" decision tree), a **data-model card** (channel vs.
+  measure), and **connections** and **troubleshooting** cards. Aimed at a "still learning R" analyst as
+  a desk reference.
+- **New `docs/onboarding.md`** — a paced Week-0 → Week-2 onboarding path with checkpoints and a
+  competency checklist, built on the existing sandbox namespaces (`atlantis`, `uga/demo`, the
+  `eri_test_*` ODK forms). Linked from the README, the guide index, and the getting-started article.
+- **New orientation deck** (`docs/training/orientation-deck.qmd`, revealjs) for a first training session.
+
 ## Feature: `eri_odk_upload()` — bulk-create ODK submissions from a table (ADR-0013, #211)
 
 - **New `eri_odk_upload(data, project_id, form_id, …)`** — the inverse of `download_odk_form()` /

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ track through the guides below — and keep the quick-reference cards open as yo
 - [Data-model card](docs/training/data-model-card.md) — channel (`data_source`) vs. measure (`data_type`)
 - [Connections & secrets card](docs/training/connections-card.md) · [Troubleshooting card](docs/training/troubleshooting-card.md)
 - [Orientation deck](docs/training/orientation-deck.qmd) — the big picture for a first training session
+  (Quarto source; `quarto render` it to slides)
 
 **New here? Do these in order** (then dip into the rest as your work needs them). First, run
 `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure) every guide

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ them **Get started → your role → topic deep-dives → contributing**. The
 [**Getting started**](https://thecartercenter.github.io/erifunctions/articles/getting-started.html)
 article is the front door.
 
+**New Data Analyst?** Start with the **[onboarding path](docs/onboarding.md)** — a paced Week-0 → Week-2
+track through the guides below — and keep the quick-reference cards open as you work:
+
+- [DA cheat sheet](docs/training/da-cheatsheet.md) — the ~15 functions you use, the path model, and the
+  "which pipeline?" decision tree
+- [Data-model card](docs/training/data-model-card.md) — channel (`data_source`) vs. measure (`data_type`)
+- [Connections & secrets card](docs/training/connections-card.md) · [Troubleshooting card](docs/training/troubleshooting-card.md)
+- [Orientation deck](docs/training/orientation-deck.qmd) — the big picture for a first training session
+
 **New here? Do these in order** (then dip into the rest as your work needs them). First, run
 `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure) every guide
 assumes.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -20,7 +20,8 @@ This page is the **menu and the backlog**: what exists today, and what is still 
 the quick-reference cards in [`training/`](training/) open — the
 [DA cheat sheet](training/da-cheatsheet.md), the [data-model card](training/data-model-card.md), and the
 [connections](training/connections-card.md) / [troubleshooting](training/troubleshooting-card.md) cards.
-There's an [orientation deck](training/orientation-deck.qmd) for a first training session.
+There's an [orientation deck](training/orientation-deck.qmd) (Quarto source — `quarto render` it to
+slides) for a first training session.
 
 First run `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure)
 the guides assume. Then follow your role's path; dip into the rest as your work needs them.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -16,6 +16,12 @@ This page is the **menu and the backlog**: what exists today, and what is still 
 
 ## New here? Do these in order
 
+**New Data Analysts:** follow the paced **[onboarding path](onboarding.md)** (Week 0 → Week 2), and keep
+the quick-reference cards in [`training/`](training/) open — the
+[DA cheat sheet](training/da-cheatsheet.md), the [data-model card](training/data-model-card.md), and the
+[connections](training/connections-card.md) / [troubleshooting](training/troubleshooting-card.md) cards.
+There's an [orientation deck](training/orientation-deck.qmd) for a first training session.
+
 First run `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure)
 the guides assume. Then follow your role's path; dip into the rest as your work needs them.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,109 @@
+# Onboarding a new Data Analyst
+
+This is the **starting URL** for a new ERI Data Analyst. It strings the reference and the run-it-live
+guides into a paced path with checkpoints, so onboarding is repeatable and self-serve rather than
+tribal knowledge. It lives in the repo so it versions with the package — when a guide or function
+changes, this path changes with it.
+
+> **Who this is for:** a new DA who can run R scripts and edit code but isn't yet fluent. Every step is
+> copy-paste on **safe sandbox data** — you cannot harm real country data by following it.
+
+## How the learning is kept safe
+
+You practice in throwaway namespaces that are designed to be created and deleted:
+
+- **`atlantis`** — a make-believe country for the ingest/onboard guides.
+- **`uga/demo`** — a sandbox country/disease for the ODK pipeline (not the real `uga/oncho`).
+- **`eri_test_river_prospection` / `eri_test_river_repeat`** — practice ODK forms in the ODK `testing`
+  project.
+
+Every guide ends with a **Clean up** section that removes what it created. Real `processed/` data is
+never deleted casually — the sandbox is where you make mistakes.
+
+---
+
+## Week 0 — Setup (before day one)
+
+Get the environment standing so day one is learning, not yak-shaving. Use the
+[connections card](training/connections-card.md).
+
+- [ ] Install **R + RStudio**.
+- [ ] Install the package: `renv` + `remotes::install_github("thecartercenter/erifunctions")`.
+- [ ] **Azure access granted** — your account needs RBAC on the `data` blob (a ticket to an ERI admin;
+      this is the long-lead item — start it first).
+- [ ] **ODK Central account** with access to the `testing` project.
+- [ ] `.Renviron` set: `ERI_ANALYST_ID`, `ODK_URL/USER/PASS` (see the connections card). **Restart R.**
+- [ ] **Verify:** `eri_list("", azcontainer = get_azure_storage_connection("data"))` returns a tibble,
+      and `list_odk_projects(con = init_odk_connection())` lists projects.
+
+✅ **Gate:** you can connect to Azure and ODK.
+
+## Day 1 — Orientation
+
+- [ ] Read [`getting-started`](https://thecartercenter.github.io/erifunctions/articles/getting-started.html).
+- [ ] Run **`eri_data_model()`** and read the [data-model card](training/data-model-card.md) until the
+      *channel vs. measure* split makes sense. This is the one idea everything rests on.
+- [ ] Skim the orientation deck (`training/orientation-deck.qmd`) for the big picture: the Azure
+      three-layer + 5-axis system, the human-gated pipeline, and where your 11 tasks live.
+- [ ] Keep the [DA cheat sheet](training/da-cheatsheet.md) open from here on.
+
+✅ **Gate:** you can explain what the five path axes mean and why `eri_approve()` is the gate.
+
+## Days 2–4 — The ingestion spine (do it live)
+
+Work these guides in order, on the sandbox, running every chunk. Stop at each checkpoint.
+
+- [ ] [`connections-guide`](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html)
+      — connect to all four services.
+- [ ] [`da-onboard-guide`](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html)
+      — stand up a new `atlantis` space (schema + dirs). *Checkpoint: you scaffolded a space and
+      validated its schema.*
+- [ ] [`da-ingest-guide`](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html)
+      — raw → DQ → staged → **approve** a surveillance extract. *Checkpoint: you approved a dataset and
+      saw it in the catalog.*
+- [ ] [`da-cmr-guide`](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html)
+      — upload → split → approve a monthly CMR. *Checkpoint: you split a CMR per disease.*
+- [ ] [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html)
+      — connect → monitor → register → sync → approve an ODK form. *Checkpoint: you synced submissions
+      into the pipeline.*
+- [ ] [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html)
+      — triage and resolve a log. *Checkpoint: you closed an item in the backlog.*
+
+✅ **Gate:** you can take a file from each of the three channels through to `processed/` on the sandbox.
+
+## Week 2 — Downstream work + shadowing
+
+The downstream guides (QC + country feedback, routine reporting, final survey reports, ad-hoc requests)
+ship as they land — check the [guide index](guides.md) for what's available. Then:
+
+- [ ] **Pair** with a senior DA on a real (but sandboxed) task end-to-end.
+- [ ] Take a **first supervised real task** — a real ingest or QC review, reviewed before you approve.
+- [ ] Make your **first contribution**: fix a typo or unclear line in a guide via a PR. This teaches the
+      issue → branch → PR workflow and how the docs are maintained.
+
+✅ **Gate:** you completed one real task under supervision and opened one PR.
+
+---
+
+## Competency checklist (DA + mentor sign off)
+
+A DA is "onboarded" when both of you can tick every box from observed work, not a quiz:
+
+- [ ] Connects to Azure + ODK; knows where secrets live and why.
+- [ ] Reads a dataset's five axes and picks the right `data_source` / `data_type`.
+- [ ] Ingests + approves a **surveillance** extract (case or aggregate).
+- [ ] Uploads, splits, and approves a **CMR**.
+- [ ] Registers, syncs, and approves an **ODK** form.
+- [ ] Runs `run_dq_checks()` and reads the flags.
+- [ ] Triages the log backlog with `eri_logs()` / `eri_logs_resolve()`.
+- [ ] Produces one routine figure/table for an output.
+- [ ] Knows the boundaries: never deletes `processed/`; ODK **forms are authored in the ODK UI**, the
+      package begins at *sync*; real country data never leaves the system.
+
+## Staying productive after onboarding
+
+- The [DA cheat sheet](training/da-cheatsheet.md) and the cards are your desk reference.
+- The [guide index](guides.md) is the **"how do I do X?"** lookup — start there, not the function
+  reference.
+- Keep a **buddy/mentor** for the first month; questions are faster than docs at first.
+- When you hit something the guides don't cover, that's a gap worth filing — open an issue.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -33,7 +33,7 @@ Get the environment standing so day one is learning, not yak-shaving. Use the
       this is the long-lead item — start it first).
 - [ ] **ODK Central account** with access to the `testing` project.
 - [ ] `.Renviron` set: `ERI_ANALYST_ID`, `ODK_URL/USER/PASS` (see the connections card). **Restart R.**
-- [ ] **Verify:** `eri_list("", azcontainer = get_azure_storage_connection("data"))` returns a tibble,
+- [ ] **Verify:** `eri_list("", azcontainer = get_azure_storage_connection(storage_name = "data"))` returns a tibble,
       and `list_odk_projects(con = init_odk_connection())` lists projects.
 
 ✅ **Gate:** you can connect to Azure and ODK.

--- a/docs/training/connections-card.md
+++ b/docs/training/connections-card.md
@@ -1,0 +1,63 @@
+# Connections & secrets card
+
+*The four services erifunctions talks to, how you sign in, and the one-liner that proves it works. Full
+detail: the [connections guide](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html).*
+
+---
+
+## At a glance
+
+| Service | Connect with | Sign-in | Setup | Verify it works |
+|---------|--------------|---------|-------|-----------------|
+| **Azure** (the data) | `get_azure_storage_connection("data")` | browser (your CC account) | **none** | `eri_list("", azcontainer = data_con)` |
+| **ODK Central** | `init_odk_connection()` | email + password | 3 lines in `.Renviron` | `list_odk_projects(con = con)` |
+| **SharePoint** | `eri_sharepoint_connect(site_url)` | browser | site URL only | `eri_sharepoint_list(site, path)` |
+| **Teams** (optional) | `get_teams_connection()` | token / webhook | a webhook URL | `eri_teams_send(message = "…")` |
+
+Azure and SharePoint are **zero-config** — your browser opens on first use and the sign-in is remembered
+for the session. ODK needs three lines. Teams is optional.
+
+---
+
+## Your `.Renviron` (the only place secrets live)
+
+Open with `usethis::edit_r_environ()`, edit, **then restart R**. Never put secrets in a script or commit
+them.
+
+```
+# Your identity — appears in every approval/access log. SET THIS FIRST.
+ERI_ANALYST_ID=firstname.lastname
+
+# ODK Central
+ODK_URL=https://your-odk-server.org/
+ODK_USER=you@example.org
+ODK_PASS=your-password
+
+# Optional — Teams notifications
+# ERIFUNCTIONS_TEAMS_WEBHOOK=https://outlook.office.com/webhook/…
+```
+
+> **Set `ERI_ANALYST_ID` before your first governed action** (approve, register, sync). Unset, you are
+> recorded as `"<os-user> (unverified)"`. A team/CI run can *require* it with `ERI_REQUIRE_ANALYST_ID=true`.
+
+---
+
+## First-day verify sequence
+
+```r
+library(erifunctions)
+data_con <- get_azure_storage_connection("data")   # browser opens once
+eri_list("", azcontainer = data_con)               # a tibble back = you're in
+
+con <- init_odk_connection()                        # ✔ Connected … session expires …
+list_odk_projects(con = con)                        # the projects you can see
+```
+
+## When it doesn't work
+
+| Symptom | Meaning | Fix |
+|---------|---------|-----|
+| Azure `403 Forbidden` | Your account lacks access (RBAC) — **not** a code bug | Ask an ERI admin to grant access |
+| `ODK username is required` | `ODK_USER` / `ODK_PASS` unset | Add them to `.Renviron`, **restart R** |
+| Browser re-opens unexpectedly | Cached session expired | Sign in again — sessions are per-session |
+| Teams device-code blocked | Conditional-access policy | Use an incoming webhook instead |

--- a/docs/training/connections-card.md
+++ b/docs/training/connections-card.md
@@ -9,7 +9,7 @@ detail: the [connections guide](https://thecartercenter.github.io/erifunctions/a
 
 | Service | Connect with | Sign-in | Setup | Verify it works |
 |---------|--------------|---------|-------|-----------------|
-| **Azure** (the data) | `get_azure_storage_connection("data")` | browser (your CC account) | **none** | `eri_list("", azcontainer = data_con)` |
+| **Azure** (the data) | `get_azure_storage_connection(storage_name = "data")` | browser (your CC account) | **none** | `eri_list("", azcontainer = data_con)` |
 | **ODK Central** | `init_odk_connection()` | email + password | 3 lines in `.Renviron` | `list_odk_projects(con = con)` |
 | **SharePoint** | `eri_sharepoint_connect(site_url)` | browser | site URL only | `eri_sharepoint_list(site, path)` |
 | **Teams** (optional) | `get_teams_connection()` | token / webhook | a webhook URL | `eri_teams_send(message = "…")` |
@@ -46,7 +46,7 @@ ODK_PASS=your-password
 
 ```r
 library(erifunctions)
-data_con <- get_azure_storage_connection("data")   # browser opens once
+data_con <- get_azure_storage_connection(storage_name = "data")   # browser opens once
 eri_list("", azcontainer = data_con)               # a tibble back = you're in
 
 con <- init_odk_connection()                        # ✔ Connected … session expires …

--- a/docs/training/da-cheatsheet.md
+++ b/docs/training/da-cheatsheet.md
@@ -1,0 +1,105 @@
+# erifunctions — Data Analyst cheat sheet
+
+*One page. The functions you actually use, the path model, and which pipeline to reach for. Pair with
+[`data-model-card.md`](data-model-card.md) for the channel-vs-measure decision, and the
+[run-it-live guides](https://thecartercenter.github.io/erifunctions/articles/) when you want the full
+walkthrough.*
+
+---
+
+## The data system in one picture
+
+Everything lives in the Azure **`data/`** blob under a canonical 5-axis path. Build it with
+`eri_data_path()` — never hand-type it.
+
+```
+data/ {country} / {disease} / {data_source} / {data_type} / {layer} / file
+        dr         malaria     surveillance    case          raw        as-received
+        uga        oncho       programmatic    treatment     staged     DQ-checked, awaiting sign-off
+        ht         lf          research        prevalence    processed  approved — the team trusts this
+```
+
+- **`data_source` = the channel** (how the data arrives): `surveillance` · `programmatic` · `research`.
+- **`data_type` = the measure** (what it counts): `case` · `aggregate` · `treatment` · `mmdp` ·
+  `training` · `survey` · `tas` · `prevalence` · `entomology`.
+- Run **`eri_data_model()`** once to print the full, current vocabulary. Unknown values *warn, not
+  error* — a new country/disease/source/measure is a normal gap, not a bug.
+
+> **The golden rule:** nothing reaches **`processed/`** without **`eri_approve()`** — the human gate.
+> It moves staged → processed, writes an approval log, and registers the file in the catalog. Never
+> hand-edit or delete `processed/` data.
+
+---
+
+## Which pipeline do I use?
+
+```
+What did you receive?
+│
+├─ A monthly country CMR Excel (eth/nga/sdn/ssd/uga/tcd/mad)
+│     → eri_stage_cmr() → eri_split_cmr() → eri_approve(..., "programmatic", <measure>)
+│
+├─ A malaria surveillance extract (line-list or aggregate, e.g. dr/ht)
+│     → eri_ingest()                      [registered countries: one call, dual-writes]
+│       or the primitives below           [sandbox / new space]
+│
+├─ ODK survey submissions
+│     → eri_odk_register() → eri_odk_sync() → (clean) → eri_approve(..., "research", ...)
+│
+└─ A brand-new country / disease / data-type space (nothing exists yet)
+      → eri_onboard_country() / eri_onboard_disease() / eri_onboard_cmr()  (do this FIRST)
+```
+
+**The general primitive pipeline** (works on any data, incl. the practice sandbox):
+
+```r
+raw    <- eri_read(eri_data_path(c, d, src, mea, "raw", file), azcontainer = data_con)
+schema <- load_dq_schema(c, d, src, mea)            # bundled YAML under inst/schemas/
+res    <- run_dq_checks(raw, schema); dq_report(res)
+eri_write(res$data, eri_data_path(c, d, src, mea, "staged", file), azcontainer = data_con)
+eri_approve(c, d, src, period, data_type = mea, azcontainer = data_con)   # the gate
+```
+
+---
+
+## The ~15 functions a DA actually uses
+
+| Need | Function | Canonical call |
+|------|----------|----------------|
+| Connect to data | `get_azure_storage_connection` | `get_azure_storage_connection("data")` |
+| Connect to ODK | `init_odk_connection` | `init_odk_connection()` (creds in `.Renviron`) |
+| Build a path | `eri_data_path` | `eri_data_path(country, disease, source, measure, layer, file)` |
+| See the vocabulary | `eri_data_model` | `eri_data_model()` |
+| List / read / write | `eri_list` · `eri_read` · `eri_write` | `eri_read(path, azcontainer = data_con)` |
+| Ingest surveillance | `eri_ingest` | `eri_ingest(path, country, disease, data_source, data_type)` |
+| Stage a CMR | `eri_stage_cmr` | `eri_stage_cmr(country, period)` |
+| Split a CMR per disease | `eri_split_cmr` | `eri_split_cmr(path, country)` |
+| DQ a dataset | `load_dq_schema` + `run_dq_checks` + `dq_report` | `run_dq_checks(data, schema)` |
+| **Approve (the gate)** | `eri_approve` | `eri_approve(country, disease, data_source, period, data_type =)` |
+| Find approved data | `eri_catalog_query` | `eri_catalog_query(country =, disease =)` |
+| Register an ODK form | `eri_odk_register` | `eri_odk_register(project_id, form_id, country, disease, server_url, data_con)` |
+| Pull ODK submissions | `eri_odk_sync` | `eri_odk_sync(project_id, form_id, con, data_con)` |
+| Backfill ODK from a table | `eri_odk_upload` | `eri_odk_upload(data, project_id, form_id, key_col =)` |
+| Monitor a survey | `eri_survey_status` | `eri_survey_status(project_id, form_id, con)` |
+| Triage errors / DQ backlog | `eri_logs` · `eri_logs_resolve` | `eri_logs(status = "error")` → `eri_logs_resolve(log_path, note =)` |
+
+*Signatures to mind:* `eri_onboard_disease(disease, country, …)` takes **disease first** (unlike the
+others); `eri_approve()`'s **5th arg is `data_type`** (the measure) — omit it and the catalog records
+the measure as `NA`.
+
+---
+
+## Quick analytics (for initial epi QC products)
+
+```r
+eri_case_summary(data, group_cols, date_col =, count_col =)   # counts by group/period
+eri_incidence_rate(cases, pop, multiplier = 1000)             # rate per 1,000
+eri_epidemic_curve(data, date_col, count_col =, period = "week")
+# disease helpers: eri_lf_tas_summary(), eri_oncho_program_levels(), eri_lf_pooled_prev() …
+```
+
+## Don't reinvent — search first
+
+Before writing new code, reuse `azure_io()` / `eri_read()` / `eri_write()` / `eri_data_path()` and the
+DQ / catalog / logs machinery. If a problem is general, it probably already has a helper (and if it
+truly doesn't, that's an ADR-worthy decision, not a one-off script).

--- a/docs/training/da-cheatsheet.md
+++ b/docs/training/da-cheatsheet.md
@@ -66,7 +66,7 @@ eri_approve(c, d, src, period, data_type = mea, azcontainer = data_con)   # the 
 
 | Need | Function | Canonical call |
 |------|----------|----------------|
-| Connect to data | `get_azure_storage_connection` | `get_azure_storage_connection("data")` |
+| Connect to data | `get_azure_storage_connection` | `get_azure_storage_connection(storage_name = "data")` |
 | Connect to ODK | `init_odk_connection` | `init_odk_connection()` (creds in `.Renviron`) |
 | Build a path | `eri_data_path` | `eri_data_path(country, disease, source, measure, layer, file)` |
 | See the vocabulary | `eri_data_model` | `eri_data_model()` |

--- a/docs/training/data-model-card.md
+++ b/docs/training/data-model-card.md
@@ -1,0 +1,81 @@
+# Data-model decision card — channel vs. measure
+
+*The one concept everything else rests on. If you can answer the four questions below for a dataset,
+you can address it, ingest it, and approve it. Run `eri_data_model()` to see the live list of allowed
+values.*
+
+---
+
+## A path has five axes
+
+```
+data / {country} / {disease} / {data_source} / {data_type} / {layer}
+```
+
+Two of them — `data_source` and `data_type` — are the ones people mix up. They are **independent**:
+
+| Axis | Plain-English question | It is NOT… |
+|------|------------------------|------------|
+| **`data_source`** (the *channel*) | *How did this data reach us?* | not the disease, not the file format |
+| **`data_type`** (the *measure*) | *What does each row count?* | not the channel, not derivable from the disease |
+
+**They don't determine each other.** The same channel carries different measures, and the same
+(channel, disease) gives a *different* measure per country:
+
+- One **CMR** (programmatic) fans out to **7 measures across 3 diseases** (treatment, MMDP, training,
+  surveys…).
+- DR malaria **surveillance** is **`case`** (one row per patient); Haiti malaria surveillance is
+  **`aggregate`** (facility × month counts). Same source, same disease — different measure.
+
+---
+
+## Answer these four, in order
+
+1. **country** — `dr`, `ht`, `eth`, `uga`, `nga`, `sdn`, `ssd`, `tcd`, `mad`, `oepa`, …
+2. **disease** — `malaria`, `oncho`, `lf`, `sch`, `sth` (free text; lowercase).
+3. **data_source (channel)** — pick one:
+   - **`surveillance`** — routine MoH feed (DR/Haiti malaria). Output: cases or aggregate counts.
+   - **`programmatic`** — country-team activity/coverage data: CMR, or a direct MDA feed. Spans
+     diseases (split per disease on ingest).
+   - **`research`** — survey instruments launched + monitored via ODK, then cleaned into a final
+     analytic dataset (TAS, prevalence, entomology).
+4. **data_type (measure)** — what the rows count:
+   `case` · `aggregate` · `treatment` · `mmdp` · `training` · `survey` · `tas` · `prevalence` ·
+   `entomology`.
+
+```
+                      ┌─ case            (line-list, one row per patient)
+   surveillance ──────┤
+                      └─ aggregate       (facility/period counts)
+
+                      ┌─ treatment       (MDA coverage)
+   programmatic ──────┼─ mmdp · training
+                      └─ survey
+
+                      ┌─ tas
+   research (ODK) ────┼─ prevalence
+                      └─ entomology
+```
+
+---
+
+## Worked examples
+
+| You have… | country | disease | data_source | data_type |
+|-----------|---------|---------|-------------|-----------|
+| DR malaria line-list | `dr` | `malaria` | `surveillance` | `case` |
+| Haiti malaria monthly facility counts | `ht` | `malaria` | `surveillance` | `aggregate` |
+| Uganda CMR "RB Treatment" sheet | `uga` | `oncho` | `programmatic` | `treatment` |
+| Uganda CMR "LF MMDP" sheet | `uga` | `lf` | `programmatic` | `mmdp` |
+| A TAS survey pulled from ODK | `uga` | `lf` | `research` | `tas` |
+
+---
+
+## Two things that trip people up
+
+- **`format` ≠ `data_source`.** "CMR" and "ODK" are input *formats*, recorded in a `format` field —
+  not channels. A CMR is `programmatic`; an ODK form is `research`. (The `cmr`/`odk` path tokens you may
+  see in older data are transitional and being retired — ADR-0012.)
+- **A missing combination is normal.** If `load_dq_schema()` / `eri_data_path()` doesn't recognise a
+  value, you get a **warning**, not an error — adding a new country/disease/source/measure is a *data*
+  change (a schema + a registry entry), not a code change. See `da-onboard-guide`.

--- a/docs/training/orientation-deck.qmd
+++ b/docs/training/orientation-deck.qmd
@@ -1,0 +1,153 @@
+---
+title: "erifunctions for Data Analysts"
+subtitle: "Orientation — the data system, the pipeline, and your tasks"
+format:
+  revealjs:
+    theme: simple
+    slide-number: true
+    incremental: false
+# Render with: quarto render orientation-deck.qmd
+# (or open in RStudio and click Render). Export to PowerPoint with: format: pptx
+---
+
+## What erifunctions is
+
+The ERI team's R package — the **API to TCC's Azure data system** across countries
+(Haiti, DR, Uganda, OEPA, …) and diseases (malaria, oncho, LF, SCH, STH).
+
+- You are a **domain expert**, not a software developer.
+- You **install it and call functions** — you don't edit the package.
+- Every function is built to make *your* work clearer and more reliable.
+
+::: notes
+Set expectations: this is a tool you use, not a codebase you maintain. The whole design optimizes for
+analyst clarity and reliability.
+:::
+
+## The data lives in three layers
+
+```
+data/{country}/{disease}/{data_source}/{data_type}/
+   raw/        as-received from the source
+   staged/     DQ-checked, awaiting sign-off
+   processed/  analyst-approved — the data the whole team trusts
+```
+
+Data flows **one way**: `raw → staged → processed`.
+
+::: notes
+Raw is untouched. Staged is cleaned but provisional. Processed is canonical and trusted. The direction
+never reverses.
+:::
+
+## The golden rule
+
+> **Nothing reaches `processed/` without `eri_approve()` — the human gate.**
+
+`eri_approve()` moves staged → processed, writes an approval log, and registers the file in the catalog.
+
+- You are the gate. Nothing is "official" until you sign off.
+- Never hand-edit or delete `processed/` data.
+
+::: notes
+This is the single most important concept. The approve step is a deliberate human checkpoint, with an
+audit trail attached to your `ERI_ANALYST_ID`.
+:::
+
+## A path has five axes
+
+```
+data / country / disease / data_source / data_type / layer
+        uga      oncho     programmatic  treatment   staged
+```
+
+- **`data_source`** = the **channel** (how it arrives): surveillance · programmatic · research
+- **`data_type`** = the **measure** (what it counts): case · aggregate · treatment · mmdp · survey · …
+
+Run **`eri_data_model()`** to print the live vocabulary.
+
+::: notes
+Channel and measure are independent. This is the concept new DAs find hardest — spend time here. Use the
+data-model card.
+:::
+
+## Channel ≠ measure
+
+The same channel carries different measures; the same (channel, disease) differs by country:
+
+- One **CMR** (programmatic) → **7 measures across 3 diseases**.
+- DR malaria surveillance = **case** (line-list); Haiti malaria surveillance = **aggregate** (counts).
+
+A missing combination is **normal** — it warns, it doesn't error.
+
+::: notes
+Hammer the DR-vs-HT example: same source, same disease, different measure. That's why measure can't be
+inferred and must be an explicit axis.
+:::
+
+## Which pipeline for which data?
+
+| You received… | Pipeline |
+|---------------|----------|
+| Monthly CMR Excel | `eri_stage_cmr` → `eri_split_cmr` → `eri_approve` |
+| Surveillance extract | `eri_ingest` (or the primitives) → `eri_approve` |
+| ODK submissions | `eri_odk_register` → `eri_odk_sync` → clean → `eri_approve` |
+| A brand-new space | `eri_onboard_*` first, then one of the above |
+
+Everything ends at **`eri_approve()`**.
+
+::: notes
+This table is the daily decision. It's also on the cheat sheet. The four on-ramps differ, but they all
+converge on the same gate and the same catalog.
+:::
+
+## Your 11 tasks → where they live
+
+- **Load CMR / surveillance** → `da-cmr-guide` · `da-ingest-guide`
+- **Process OEPA** → general pipeline (oncho treatment + prevalence)
+- **QC + analytic products + country feedback** → `run_dq_checks` · `dq_report` · `eri_notify_dq`
+- **Figures / routine reports** → `eri_table` · `eri_map_*` · `eri_pptx_*` · `eri_report_*`
+- **ODK: monitor + pull + backfill + final reports** → `da-odk-guide` · `eri_survey_status` · `eri_odk_upload`
+- **Ad-hoc requests** → read processed parquet (a query layer is coming)
+- **Errors & logs** → `eri_logs` · `eri_logs_resolve`
+
+::: notes
+Walk the list against the cheat sheet. Note honestly what's a guide today vs. primitives-only vs.
+coming. Set expectations.
+:::
+
+## A boundary worth stating
+
+**Creating ODK forms is *not* an erifunctions task.**
+
+- Survey **forms are authored in the ODK Central UI** (XLSForm).
+- erifunctions picks up at **sync** — it pulls submissions, monitors deployment, and backfills records.
+
+::: notes
+This avoids a common new-DA confusion ("how do I make a form in R?"). You don't — you make it in ODK,
+then the package takes over.
+:::
+
+## Three golden rules to leave with
+
+1. **The gate is sacred.** Nothing is real until `eri_approve()`; never touch `processed/` by hand.
+2. **Secrets live only in `.Renviron`** — never in a script, never in git. Set `ERI_ANALYST_ID` first.
+3. **Real country data never leaves the system.** Practice on the sandbox; protect the real thing.
+
+::: notes
+End on the three non-negotiables. These are the things that, if violated, cause real harm — everything
+else is recoverable.
+:::
+
+## Where to learn
+
+- **Cheat sheets** (`docs/training/`): the DA cheat sheet + the data-model, connections, and
+  troubleshooting cards — your desk reference.
+- **Run-it-live guides** (the Articles menu): copy-paste walkthroughs on safe data.
+- **Onboarding path** (`docs/onboarding.md`): the paced Week-0 → Week-2 track.
+- **`eri_data_model()`** and the [guide index](../guides.md): your "how do I…?" lookups.
+
+::: notes
+Point them at the cheat sheet for daily work, the guides for learning a new task, and onboarding.md for
+the order to do it in.
+:::

--- a/docs/training/troubleshooting-card.md
+++ b/docs/training/troubleshooting-card.md
@@ -43,6 +43,8 @@ eri_logs(include_handled = TRUE)           # confirm it's closed
 ```
 
 - `eri_logs()` hides handled items by default — the open list shrinks as you resolve.
-- Persist a DQ result's flags yourself with `eri_dq_log(result, country, disease, data_type)`.
+- Persist a DQ result's flags yourself with
+  `eri_dq_log(result, country, disease, data_source, data_type = )` (note: `data_source` is the 4th
+  argument, the measure `data_type` the 5th — mind the source/measure order).
 - Full walkthrough: the
   [log-triage guide](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html).

--- a/docs/training/troubleshooting-card.md
+++ b/docs/training/troubleshooting-card.md
@@ -1,0 +1,48 @@
+# Troubleshooting card
+
+*The errors a DA actually hits, what they mean, and the fix. Then: how to work the shared error/DQ log
+backlog with `eri_logs()`.*
+
+---
+
+## Common messages → fix
+
+| Message (or symptom) | What it means | Fix |
+|----------------------|---------------|-----|
+| `403 Forbidden` (Azure) | Your account isn't granted access to that storage (RBAC). **Not** a code bug. | Ask an ERI admin to add you. |
+| `ODK username is required` / `password is required` | `ODK_USER` / `ODK_PASS` not set | Add to `.Renviron`; **restart R**. |
+| `… is not a known ERI country` | `eri_odk_register()` checks a fixed list — `dr/ht/eth/nga/sdn/ssd/uga/mad/tcd` (disease is free text). Note: the general pipeline (`eri_ingest`/`eri_approve`) takes free-text country, so `oepa` etc. work there but not for ODK registration. | Use a listed code; sandbox practice uses a real code + a fake disease (e.g. `uga`/`demo`). |
+| `Form … is not in the ODK registry` | You called `eri_odk_sync()` for an unregistered form | `eri_odk_register()` it first. |
+| `No schema found` / `load_dq_schema()` can't resolve | The `{country}_{disease}_{source}_{measure}.yaml` schema doesn't exist | Check the four axes match a bundled schema; if it's a new space, author one (`da-onboard-guide`). |
+| `File not found: …` | A local path (CMR Excel, upload CSV) is wrong | Check the path; use an absolute path. |
+| Warning: *unknown `data_source`/`data_type`* | The axis value isn't in the registry | Expected for a new space — it **warns, not errors**. Confirm the spelling, or onboard the new value. |
+| `data_type will be "NA"` on approve | You approved without the measure (5th arg) | Pass `data_type = "case"` (etc.) to record the measure in the catalog. |
+| Output looks stale after editing `.Renviron` | `.Renviron` is read once at startup | **Restart R** after every `.Renviron` edit. |
+| A change to exports/docs isn't reflected | `NAMESPACE`/`man/` out of date | (Maintainers) re-run `devtools::document()`. |
+
+> **First move on any Azure/ODK error:** confirm you're connected (`eri_list(...)`,
+> `list_odk_projects(con)`) and that `.Renviron` is loaded (`Sys.getenv("ERI_ANALYST_ID")`). Most
+> "errors" are an expired session or an unset variable.
+
+---
+
+## Working the log backlog (task: review errors & logs)
+
+Every operation leaves a structured log in Azure. `eri_logs()` is the **shared backlog** — any analyst
+can see what failed or needs review and close it out.
+
+```r
+eri_logs(status = "error")                 # the open error backlog (across the tree)
+eri_logs(status = "needs_review")          # DQ flags awaiting a human
+eri_logs(country = "uga", disease = "lf")  # scope to one dataset (faster)
+
+# Inspect one, fix the underlying issue, then mark it handled:
+eri_logs_resolve(log_path, note = "re-ran ingest after fixing the date column")
+
+eri_logs(include_handled = TRUE)           # confirm it's closed
+```
+
+- `eri_logs()` hides handled items by default — the open list shrinks as you resolve.
+- Persist a DQ result's flags yourself with `eri_dq_log(result, country, disease, data_type)`.
+- Full walkthrough: the
+  [log-triage guide](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html).

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -74,6 +74,12 @@ The guides are short, copy-paste, run-it-live walkthroughs on safe sandbox data.
 
 ### New Data Analyst
 
+For the paced version of this with checkpoints, follow the
+[**onboarding path**](https://github.com/thecartercenter/erifunctions/blob/main/docs/onboarding.md), and
+keep the [**DA cheat sheet**](https://github.com/thecartercenter/erifunctions/blob/main/docs/training/da-cheatsheet.md)
+and the [data-model card](https://github.com/thecartercenter/erifunctions/blob/main/docs/training/data-model-card.md)
+open as you work.
+
 1. [Connecting to the services](connections-guide.html)
 2. [Onboarding a new country / disease / data type](da-onboard-guide.html) — stand up the space
 3. [Ingesting a surveillance dataset](da-ingest-guide.html) — raw → DQ → staged → **approved**


### PR DESCRIPTION
Closes #219. Pure docs — the reference/training bundle from the DA-task evaluation.

Aimed at a **"still learning R"** Data Analyst, attacking the biggest comprehension taxes (the channel-vs-measure data model, the "which pipeline?" decision, the overwhelming reference) with low-maintenance reference material.

## What's in it

- **`docs/training/da-cheatsheet.md`** — the flagship: the 5-axis path, a **"which pipeline?" decision tree**, the ~15 functions a DA actually uses (with canonical calls), and the approve gate.
- **`docs/training/data-model-card.md`** — channel (`data_source`) vs. measure (`data_type`), the four questions, worked examples, the two things that trip people up.
- **`docs/training/connections-card.md`** — the four services, the `.Renviron` template, verify-it-works one-liners, the 403/auth fixes.
- **`docs/training/troubleshooting-card.md`** — common errors → fixes + the `eri_logs()` triage loop.
- **`docs/onboarding.md`** — a paced **Week-0 → Week-2** path with checkpoints and a **competency checklist**, on the existing sandbox namespaces (`atlantis`, `uga/demo`, `eri_test_*`).
- **`docs/training/orientation-deck.qmd`** — a revealjs orientation deck for a first training session.
- Linked from README, `docs/guides.md`, and the getting-started article.

## Notes

- **No code change.** Function signatures and country lists were verified against source — e.g. `oepa` is valid for the general pipeline (free-text country) but **not** for `eri_odk_register`'s `.KNOWN_COUNTRY_CODES`, which the troubleshooting card now states precisely.
- The cheat sheets/deck live in `docs/` (GitHub-rendered, printable), so pkgdown doesn't build them; the getting-started article links to them via GitHub URLs. getting-started.Rmd still knits.
- **Pinned for later** (await specifics): the OEPA guide and SIL/BoT/EoE report templates.
- **Out of scope** (decided): ODK form-creation material — the deck states the package begins at *sync*.

## Follow-on

Separate run-it-live codelab PRs: `da-qc-feedback`, `da-reporting`, `da-survey-report`, `da-adhoc`.