### PR TITLE
da-adhoc-guide: answering ad-hoc requests with eri_query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
   population). Returns a tibble. `duckdb` + `DBI` are **Suggests** (install once;
   `install.packages(c("duckdb", "DBI"))`) — analysts who never query don't pay for them. Closes the
   ad-hoc-data-request gap (DA task 10).
+- **New `da-adhoc-guide` article** — a run-it-live walkthrough of `eri_query()` (catalog roll-ups,
+  joins, window functions) for answering ad-hoc requests; the in-memory examples run with no Azure.
 
 ## Docs: Data Analyst training bundle — cheat sheets, onboarding path, orientation deck (#219)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The full set:
 | [Working with ODK Central](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | Data analysts connecting to ODK Central to monitor a form, manage collectors, and pull submissions into the pipeline |
 | [Onboarding a new country / disease / data type](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | Data analysts standing up the schema + folders for a new program before any data flows |
 | [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) |
+| [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer |
 | [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract |
 | [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers |
 | [Reconciling localities to admin units](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | Epidemiologists mapping messy free-text place names to canonical admin units (match → geocode → review) |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -67,6 +67,7 @@ articles:
   - da-cmr-guide
   - da-odk-guide
   - da-logs-guide
+  - da-adhoc-guide
 
 - title: For epidemiologists
   navbar: Epidemiologists

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -58,6 +58,7 @@ Grouped the same way as the [documentation site's Articles menu](https://thecart
 | Upload, split & approve a monthly country report (CMR) | [`da-cmr-guide`](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | ✅ Shipped |
 | Work with ODK Central (connect → monitor → manage → pull) | [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | ✅ Shipped |
 | Triage the error / DQ log backlog | [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | ✅ Shipped |
+| Answer ad-hoc data requests with SQL (`eri_query`) | [`da-adhoc-guide`](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | ✅ Shipped |
 
 ### For epidemiologists
 

--- a/vignettes/da-adhoc-guide.Rmd
+++ b/vignettes/da-adhoc-guide.Rmd
@@ -35,8 +35,11 @@ flowchart LR
 ## Before you start {#before-you-start}
 
 ```{r install}
-# eri_query needs two optional packages, installed once:
+# eri_query needs two optional packages — install them once:
 install.packages(c("duckdb", "DBI"))
+```
+
+```{r library}
 library(erifunctions)
 ```
 
@@ -78,6 +81,9 @@ eri_query(
 #> 1 ht      12345
 #> 2 dr       9876
 ```
+
+*(Illustrative numbers — your catalog will differ. The in-memory examples below are real output you can
+reproduce.)*
 
 Because every row is stamped with its provenance, you can `GROUP BY country`, `period`, `data_type`,
 etc. without joining anything. (Those five names are reserved in this mode — see
@@ -166,8 +172,8 @@ a population table you supply.
 
 `eri_query()` returns an ordinary tibble, so the result flows straight into the rest of the toolkit —
 [`eri_table()`](../reference/eri_table.html) for a branded table, `ggplot2` / the `eri_map_*` helpers
-for a figure, or `eri_case_summary()` / `eri_incidence_rate()` for standard epi summaries. The
-[reporting helpers](da-ingest-guide.html) take it from there.
+for a figure, or `eri_case_summary()` / `eri_incidence_rate()` for standard epi summaries — see the
+[function reference](../reference/index.html) for the full reporting toolkit.
 
 ## Tips
 

--- a/vignettes/da-adhoc-guide.Rmd
+++ b/vignettes/da-adhoc-guide.Rmd
@@ -1,0 +1,187 @@
+---
+title: "Answering ad-hoc data requests with SQL (eri_query)"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Answering ad-hoc data requests with SQL (eri_query)}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
+```
+
+"How many malaria cases by province this year?" "Pull treatment coverage for these three countries."
+Ad-hoc requests are a daily part of the job, and they usually mean the same thing: **combine a few
+approved datasets and compute a number.** [`eri_query()`](../reference/eri_query.html) does that with
+**SQL**, so you don't hand-read and merge parquet files one at a time.
+
+## The golden rule
+
+> **`eri_query()` runs SQL across *processed* data — the approved, trustworthy layer — without moving it
+> out of Azure or standing up a database.** It attaches the relevant parquet into an in-process
+> [DuckDB](https://duckdb.org) session, runs your query, and hands back a tibble.
+
+```{=html}
+<div class="mermaid">
+flowchart LR
+    C["Approved data (processed/)"] --> Q["eri_query(sql, ...)"]
+    Cat["Data catalog (which files to attach)"] --> Q
+    Q --> R["a tibble"]
+    R --> O["table / figure / answer"]
+</div>
+```
+
+## Before you start {#before-you-start}
+
+```{r install}
+# eri_query needs two optional packages, installed once:
+install.packages(c("duckdb", "DBI"))
+library(erifunctions)
+```
+
+Querying approved data in Azure also needs a connection (the browser opens on first use); pure
+in-memory queries — the examples in [Joins and aggregations](#explicit) below — need nothing.
+
+```{r connect}
+data_con <- get_azure_storage_connection(storage_name = "data")
+```
+
+## Two ways to put data in scope
+
+`eri_query()` gives you two ways to choose what your SQL can see, and they combine:
+
+1. **Catalog-driven** — name the data by its axes (`country`, `disease`, `data_type`, …) and
+   `eri_query()` finds the matching **processed** files, stamps each row with its
+   `country`/`disease`/`data_source`/`data_type`/`period`, and unions them into one table called
+   `data`. This is how you roll up across countries or periods.
+2. **Explicit tables** — hand it named tables directly (`tables = list(name = …)`), where each is a
+   data.frame, a local `.parquet`, or a `data/` blob path. This is how you join your own inputs (a
+   population table, a lookup) to approved data.
+
+## Roll up across the catalog {#catalog}
+
+The catalog is the index of approved data; `eri_query()` reads it for you. To total malaria cases by
+country from every approved aggregate dataset:
+
+```{r catalog-rollup}
+eri_query(
+  "SELECT country, SUM(total_cases) AS cases
+     FROM data GROUP BY country ORDER BY cases DESC",
+  disease = "malaria", data_type = "aggregate", data_con = data_con
+)
+#> ℹ Querying 1 table: "data".
+#> ✔ Returned 2 rows.
+#> # A tibble: 2 × 2
+#>   country  cases
+#>   <chr>    <dbl>
+#> 1 ht      12345
+#> 2 dr       9876
+```
+
+Because every row is stamped with its provenance, you can `GROUP BY country`, `period`, `data_type`,
+etc. without joining anything. (Those five names are reserved in this mode — see
+`?eri_query`.) Not sure what's available? [`eri_catalog_query()`](../reference/eri_catalog_query.html)
+with the same filters lists the files that would be attached.
+
+## Joins and aggregations {#explicit}
+
+The explicit mode runs entirely in memory, so these you can run right now. Say a request lands as two
+small tables — weekly case counts and a population denominator:
+
+```{r data}
+cases <- data.frame(
+  province = c("North", "North", "South", "South", "East"),
+  epiweek  = c(1, 2, 1, 2, 1),
+  cases    = c(40, 55, 12, 9, 30)
+)
+pop <- data.frame(
+  province = c("North", "South", "East"),
+  pop      = c(120000, 45000, 80000)
+)
+```
+
+**Aggregate** — total cases by province:
+
+```{r agg}
+eri_query(
+  "SELECT province, SUM(cases) AS cases
+     FROM cases GROUP BY province ORDER BY cases DESC",
+  tables = list(cases = cases)
+)
+#> ℹ Querying 1 table: "cases".
+#> ✔ Returned 3 rows.
+#> # A tibble: 3 × 2
+#>   province cases
+#>   <chr>    <dbl>
+#> 1 North       95
+#> 2 East        30
+#> 3 South       21
+```
+
+**Join** — incidence per 1,000, combining the two tables:
+
+```{r join}
+eri_query(
+  "SELECT c.province, SUM(c.cases) * 1000.0 / p.pop AS incidence_per_1000
+     FROM cases c JOIN pop p USING (province)
+     GROUP BY c.province, p.pop ORDER BY incidence_per_1000 DESC",
+  tables = list(cases = cases, pop = pop)
+)
+#> ℹ Querying 2 tables: "cases" and "pop".
+#> ✔ Returned 3 rows.
+#> # A tibble: 3 × 2
+#>   province incidence_per_1000
+#>   <chr>                 <dbl>
+#> 1 North                 0.792
+#> 2 South                 0.467
+#> 3 East                  0.375
+```
+
+**Window functions** — week-over-week change, which is awkward in base R but one line of SQL:
+
+```{r window}
+eri_query(
+  "SELECT province, epiweek, cases,
+          cases - LAG(cases) OVER (PARTITION BY province ORDER BY epiweek) AS wow_change
+     FROM cases ORDER BY province, epiweek",
+  tables = list(cases = cases)
+)
+#> ℹ Querying 1 table: "cases".
+#> ✔ Returned 5 rows.
+#> # A tibble: 5 × 4
+#>   province epiweek cases wow_change
+#>   <chr>      <dbl> <dbl>      <dbl>
+#> 1 East           1    30         NA
+#> 2 North          1    40         NA
+#> 3 North          2    55         15
+#> 4 South          1    12         NA
+#> 5 South          2     9         -3
+```
+
+You can mix the modes — pass catalog filters **and** `tables = list(pop = …)` to join approved cases to
+a population table you supply.
+
+## Turn the answer into an output
+
+`eri_query()` returns an ordinary tibble, so the result flows straight into the rest of the toolkit —
+[`eri_table()`](../reference/eri_table.html) for a branded table, `ggplot2` / the `eri_map_*` helpers
+for a figure, or `eri_case_summary()` / `eri_incidence_rate()` for standard epi summaries. The
+[reporting helpers](da-ingest-guide.html) take it from there.
+
+## Tips
+
+- **It queries *approved* data.** `eri_query()` reads the `processed/` layer through the catalog — the
+  data the team trusts — not `raw/` or `staged/`.
+- **Big scans are bounded by memory/download** (ADR-0004): filter tight (`country`/`disease`/`period`)
+  so you attach only what you need.
+- **It's DuckDB SQL** — joins, `GROUP BY`, window functions, CTEs, date functions all work; see the
+  [DuckDB docs](https://duckdb.org/docs/sql/introduction).
+
+## What's next
+
+- The [data catalog reference](../reference/eri_catalog_query.html) — see what approved data exists
+  before you query it.
+- The [surveillance ingest guide](da-ingest-guide.html) — how data *gets* approved in the first place.
+- The [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md).
+```


### PR DESCRIPTION
Closes #223. Wave-2 codelab guide on top of `eri_query()` (#222).

A run-it-live walkthrough for the DA **ad-hoc data request** task:
- **Catalog-driven roll-up** — `SELECT country, SUM(...) FROM data GROUP BY country` with `disease`/`data_type` filters (representative; needs Azure + the catalog).
- **Explicit-table** join (incidence per 1,000), aggregation, and a **window function** (week-over-week change) — all run **in memory with no Azure**, so the reader can run them as-is. The `#>` output is real captured output.
- Closes with how the tibble flows into `eri_table()` / figures / the reporting helpers, plus tips (queries approved data, memory-bounded, DuckDB SQL).

Wired into `_pkgdown.yml` (Data analysts articles), `docs/guides.md`, README, NEWS. Mermaid label kept single-line; vignette knits.

Follow-on wave-2 guides: `da-reporting`, `da-qc-feedback`, `da-survey-report`.