### PR TITLE
da-reporting-guide: branded tables, figures, and decks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # erifunctions (development version)
 
+## Docs: `da-reporting-guide` — branded tables, figures, and decks (#227)
+
+- **New `da-reporting-guide` article** walks the reporting toolkit on safe data: `eri_table()` (branded
+  flextable), `eri_brand_ggplot_theme()`, `eri_report_excel()` (styled workbook), and the `eri_pptx_*`
+  deck builder, with pointers to the spatial/epi-analytics guides for maps and curves. Every chunk runs
+  on a plain data frame (verified end-to-end).
+
 ## Feature: `eri_query()` — serverless SQL across processed data (ADR-0004, roadmap Phase 2)
 
 - **New `eri_query(sql, …)`** runs SQL across **processed** parquet without a database server, by

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The full set:
 | [Onboarding a new country / disease / data type](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | Data analysts standing up the schema + folders for a new program before any data flows |
 | [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) |
 | [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer |
+| [Branded tables, figures & decks](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | Data analysts turning approved data into on-brand tables, plots, Excel workbooks, and PowerPoint decks |
 | [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract |
 | [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers |
 | [Reconciling localities to admin units](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | Epidemiologists mapping messy free-text place names to canonical admin units (match → geocode → review) |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -81,6 +81,7 @@ articles:
   - da-odk-guide
   - da-logs-guide
   - da-adhoc-guide
+  - da-reporting-guide
 
 - title: For epidemiologists
   navbar: Epidemiologists

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -69,6 +69,7 @@ Grouped the same way as the [documentation site's Articles menu](https://thecart
 | Work with ODK Central (connect → monitor → manage → pull) | [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | ✅ Shipped |
 | Triage the error / DQ log backlog | [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | ✅ Shipped |
 | Answer ad-hoc data requests with SQL (`eri_query`) | [`da-adhoc-guide`](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | ✅ Shipped |
+| Branded tables, figures, and decks for outputs | [`da-reporting-guide`](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | ✅ Shipped |
 
 ### For epidemiologists
 

--- a/vignettes/da-reporting-guide.Rmd
+++ b/vignettes/da-reporting-guide.Rmd
@@ -49,12 +49,13 @@ eri_table(
   dat,
   title          = "Malaria cases by province, 2026",
   footnote       = "Source: sandbox data",
-  highlight_cols = "positivity"
+  highlight_cols = list(positivity = "#FFC000")
 )
 ```
 
 It returns a `flextable` object; print it in a report, or hand it to the Word/PowerPoint/HTML helpers.
-`highlight_cols` shades the columns you want the eye to land on.
+`highlight_cols` is a **named list** mapping a column to a fill colour (`list(col = "#hex")`) — use it to
+shade the column you want the eye to land on.
 
 ## An on-brand figure {#figure}
 

--- a/vignettes/da-reporting-guide.Rmd
+++ b/vignettes/da-reporting-guide.Rmd
@@ -1,0 +1,125 @@
+---
+title: "Branded tables, figures, and decks for outputs"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Branded tables, figures, and decks for outputs}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
+```
+
+Once data is approved, a lot of the job is turning it into **outputs** — a table for a memo, a figure
+for proceedings, a workbook for a partner, a slide deck for a meeting. `erifunctions` ships a small,
+consistent **reporting toolkit** so those come out on-brand without fiddling with styling each time.
+
+This guide is the general toolkit (it runs on any data frame). Specific recurring reports get their own
+templates as they're defined; the domain figures — **maps** and **epidemic curves** — live in the
+[spatial workflow](spatial-workflow.html) and [epi analytics](epi-analytics.html) guides.
+
+## Before you start {#before-you-start}
+
+```{r library}
+library(erifunctions)
+```
+
+In practice you'd pull approved data first — `eri_query()` for a roll-up (see the
+[ad-hoc guide](da-adhoc-guide.html)) or `eri_read()` for one dataset. Here we use a small frame so every
+chunk runs as-is:
+
+```{r data}
+dat <- data.frame(
+  province   = c("North", "South", "East", "West"),
+  cases      = c(420, 180, 260, 95),
+  tested     = c(1200, 600, 900, 400)
+)
+dat$positivity <- round(dat$cases / dat$tested * 100, 1)
+```
+
+## A branded table {#table}
+
+[`eri_table()`](../reference/eri_table.html) turns a data frame into a styled
+[`flextable`](https://davidgohel.github.io/flextable/) — ERI navy header, banded rows, an optional
+title and footnote — ready to drop into an HTML/Word/PowerPoint output:
+
+```{r table}
+eri_table(
+  dat,
+  title          = "Malaria cases by province, 2026",
+  footnote       = "Source: sandbox data",
+  highlight_cols = "positivity"
+)
+```
+
+It returns a `flextable` object; print it in a report, or hand it to the Word/PowerPoint/HTML helpers.
+`highlight_cols` shades the columns you want the eye to land on.
+
+## An on-brand figure {#figure}
+
+Any `ggplot` becomes on-brand by adding [`eri_brand_ggplot_theme()`](../reference/eri_brand_ggplot_theme.html):
+
+```{r plot}
+library(ggplot2)
+p <- ggplot(dat, aes(x = province, y = cases)) +
+  geom_col() +
+  labs(title = "Cases by province", x = NULL, y = "Cases") +
+  eri_brand_ggplot_theme()
+p
+```
+
+For domain figures there are purpose-built helpers — `eri_plot_theme("map" | "epicurve")` and
+`eri_color_scheme()` (e.g. the standard `"malaria.incidence"` bins), and the `eri_map_*` family for
+choropleths and point maps. Those need boundary data; the [spatial workflow](spatial-workflow.html)
+guide covers them end-to-end, and [epi analytics](epi-analytics.html) covers `eri_epidemic_curve()`.
+
+## An Excel workbook {#excel}
+
+For a partner who wants the numbers, [`eri_report_excel()`](../reference/eri_report_excel.html) writes a
+styled multi-sheet workbook in one call — each named element of `sheets` becomes a tab:
+
+```{r excel}
+eri_report_excel(
+  sheets = list(Cases = dat),
+  path   = "malaria_summary_2026.xlsx",
+  title  = "Malaria summary 2026"
+)
+#> ✔ Workbook saved to 'malaria_summary_2026.xlsx'
+```
+
+Need finer control (multiple sheets, added titles)? Build it up with `eri_wb_create()` →
+`eri_wb_add_sheet()` → `eri_wb_save()`.
+
+## A slide deck for proceedings {#pptx}
+
+The `eri_pptx_*` family builds a PowerPoint slide by slide — title, sections, tables, and plots — so a
+meeting deck is reproducible code, not manual copy-paste:
+
+```{r pptx}
+deck <- eri_pptx_create()
+deck <- eri_pptx_add_title(deck, "Malaria Summary 2026", subtitle = "ERI")
+deck <- eri_pptx_add_table(deck, dat, title = "Cases by province")
+deck <- eri_pptx_add_plot(deck, p, title = "Cases by province")
+eri_pptx_save(deck, "malaria_summary_2026.pptx")
+#> ✔ Presentation saved to 'malaria_summary_2026.pptx'
+```
+
+Each `eri_pptx_add_*` call returns the updated deck, so you pipe or reassign as you go. `eri_pptx_create()`
+accepts a `template =` to start from a branded master.
+
+## An HTML report {#html}
+
+[`eri_report_html()`](../reference/eri_report_html.html) assembles a self-contained HTML page from
+`sections` (text, tables, and plots), for a quick shareable write-up. For a full parameterised report,
+`eri_report_qmd_template()` scaffolds a Quarto document you fill in.
+
+## What's next
+
+- **Maps:** the [spatial workflow](spatial-workflow.html) — choropleths, incidence maps, insets.
+- **Curves & indicators:** [epi analytics](epi-analytics.html) — `eri_epidemic_curve()`, incidence,
+  disease helpers.
+- **Where the data comes from:** the [ad-hoc guide](da-adhoc-guide.html) (`eri_query`) and the
+  [ingest guide](da-ingest-guide.html).
+- The [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md).
+```


### PR DESCRIPTION
Closes #227. Wave-2 codelab guide (DA task 5: figures for proceedings/outputs).

A run-it-live walkthrough of the **general reporting toolkit** on a plain data frame, so every chunk runs as-is:
- `eri_table()` → a branded `flextable` (navy header, banded rows, title/footnote, `highlight_cols`).
- `eri_brand_ggplot_theme()` → any `ggplot` on-brand.
- `eri_report_excel()` → a styled multi-sheet workbook (`✔ Workbook saved…`); `eri_wb_*` for finer control.
- `eri_pptx_*` → a PowerPoint built slide-by-slide (`✔ Presentation saved…`).
- `eri_report_html()` / `eri_report_qmd_template()` noted.

Domain figures cross-link out: **maps** → [spatial-workflow](https://thecartercenter.github.io/erifunctions/articles/spatial-workflow.html), **epidemic curves** → [epi-analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html). Where the data comes from → the ad-hoc/ingest guides.

## Verification

Ran the whole suite locally on synthetic data: `eri_table` → flextable, `eri_brand_ggplot_theme` → ggplot, `eri_report_excel` writes the xlsx, `eri_pptx_*` writes the pptx — all succeed. The `#>` are the real `✔ … saved` messages. Vignette knits. No code change.

(Note: `eri_report_excel` emits a pre-existing upstream `openxlsx2` warning about `outer_border`/`outer_color` — already visible in the test-suite warnings; a separate fix, not in this docs PR.)

## Wave-2 status

`da-reporting` done; remaining: `da-qc-feedback`, `da-survey-report`. Pinned: OEPA + SIL/BoT/EoE templates.