### PR TITLE
da-qc-feedback-guide: QC an extract and give a country feedback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # erifunctions (development version)
 
+## Docs: `da-qc-feedback-guide` — quality-check an extract and give a country feedback (#229)
+
+- **New `da-qc-feedback-guide` article** (DA tasks: QC data + provide feedback to countries) walks a
+  real `run_dq_checks()` → `dq_report()` run on a seeded DR malaria extract: the auto-corrections
+  (`res$log`) vs the review flags (`res$flags`), turning the flags into a country-feedback table with
+  `eri_table()` and posting a summary with `eri_notify_dq()`. Runs offline on a plain data frame.
+
 ## Docs: `da-reporting-guide` — branded tables, figures, and decks (#227)
 
 - **New `da-reporting-guide` article** walks the reporting toolkit on safe data: `eri_table()` (branded

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The full set:
 | [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) |
 | [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer |
 | [Branded tables, figures & decks](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | Data analysts turning approved data into on-brand tables, plots, Excel workbooks, and PowerPoint decks |
+| [QC an extract & give a country feedback](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | Data analysts running DQ checks on a submission and turning the flags into clear country feedback |
 | [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract |
 | [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers |
 | [Reconciling localities to admin units](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | Epidemiologists mapping messy free-text place names to canonical admin units (match → geocode → review) |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -82,6 +82,7 @@ articles:
   - da-logs-guide
   - da-adhoc-guide
   - da-reporting-guide
+  - da-qc-feedback-guide
 
 - title: For epidemiologists
   navbar: Epidemiologists

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -70,6 +70,7 @@ Grouped the same way as the [documentation site's Articles menu](https://thecart
 | Triage the error / DQ log backlog | [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | ✅ Shipped |
 | Answer ad-hoc data requests with SQL (`eri_query`) | [`da-adhoc-guide`](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | ✅ Shipped |
 | Branded tables, figures, and decks for outputs | [`da-reporting-guide`](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | ✅ Shipped |
+| QC an extract and give a country feedback | [`da-qc-feedback-guide`](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | ✅ Shipped |
 
 ### For epidemiologists
 

--- a/vignettes/da-qc-feedback-guide.Rmd
+++ b/vignettes/da-qc-feedback-guide.Rmd
@@ -123,19 +123,22 @@ flags, the most-flagged columns) to Teams — handy for a shared channel that tr
 submissions:
 
 ```{r notify}
-eri_notify_dq(res, country = "dr", disease = "malaria", team = "ERI", channel = "DQ")
+eri_notify_dq(res, country = "dr", disease = "malaria")
 #> ℹ Sending Teams message via incoming webhook.
 ```
 
-It posts a compact, at-a-glance summary to the channel:
+It posts a compact, at-a-glance summary to the channel your webhook points at:
 
 ```
 [DQ Report] DR - MALARIA
 Rows processed : 5
 Corrections    : 3
 Flags          : 5
-Top flagged    : <the most-flagged columns>
+Top flagged    : Age, EpiWeek, Province_Residence, SampleDate, Sex
 ```
+
+To target a specific Teams channel instead of the default webhook, pass `team =` / `channel =` with a
+token (the Graph-API path) — see the [connections guide](connections-guide.html#teams).
 
 ## What's next
 

--- a/vignettes/da-qc-feedback-guide.Rmd
+++ b/vignettes/da-qc-feedback-guide.Rmd
@@ -1,0 +1,149 @@
+---
+title: "Quality-check an extract and give a country feedback"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Quality-check an extract and give a country feedback}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
+```
+
+When a country sends a data extract, quality-checking it is only half the job — the other half is
+telling them, **specifically and clearly, what needs fixing**. `run_dq_checks()` does both: it
+**auto-corrects** the safe, unambiguous things (and records what it changed) and **flags** the rest for
+a human. The flags are your feedback to the country.
+
+## The golden rule
+
+> **Auto-corrections are applied and logged; flags are handed back.** A correction is something the
+> schema can fix unambiguously (a known spelling, a translation). A flag is something only the country
+> can resolve (an impossible age, an unknown locality). Never "fix" a flag by guessing — send it back.
+
+This is offline — the DQ engine runs on a plain data frame. For where DQ sits in the full pipeline see
+the [ingest guide](da-ingest-guide.html); for the engine internals and custom checks, the
+[DQ pipeline](dq-pipeline.html).
+
+## The extract {#extract}
+
+In practice you'd read the submitted file (`eri_read()` / the raw layer). Here is a small DR malaria
+surveillance extract with a few deliberate problems — two values that the schema can normalise, and a
+few that it cannot:
+
+```{r data}
+extract <- data.frame(
+  Year                   = c(2026, 2026, 2026, 2026, 2026),
+  EpiWeek                = c(10, 11, 12, 13, 60),          # 60 is out of range
+  Age                    = c(34, 5, 200, 41, 28),          # 200 is impossible
+  Sex                    = c("Masculino", "Femenino", "Male", "X", "F"),  # X is invalid
+  Province_Residence     = c("SANTIAGO", "Santo Domingo", "Azua", "Distrito Nacional", "Nowhere"),
+  Municipality_Residence = c("Santiago", "SD", "Azua", "DN", "X"),
+  SampleDate             = c("2026-03-01", "2026-03-08", "2026-03-15", "2026-03-22", "2026-03-29"),
+  EpiWeekYear            = c(2026, 2026, 2025, 2026, 2026)  # row 3 mismatches Year
+)
+```
+
+## Run the checks {#run}
+
+Load the schema for this dataset's four axes (`azcontainer = NULL` uses the bundled schema, no Azure),
+then run the checks and print the report:
+
+```{r run}
+schema <- load_dq_schema("dr", "malaria", "surveillance", "aggregate", azcontainer = NULL)
+res    <- run_dq_checks(extract, schema)
+#> ✔ DQ checks complete: 3 corrections, 5 flags for review.
+
+dq_report(res)
+#> ── Data Quality Report ─────────────────────────────────────────────
+#> Shape: 5 rows x 8 columns
+#>
+#> ── Automated Corrections (3 total) ──
+#> • "Sex": 2 corrections (translation)
+#> • "Province_Residence": 1 correction (correction)
+#>
+#> ── Flags Requiring Review (5 total) ──
+#> ! Value not in allowed_values list: 2 rows [Sex, Province_Residence] (e.g. X (row 4); Nowhere (row 5))
+#> ! Value outside expected range [0, 120]: 1 row [Age] (e.g. 200 (row 3))
+#> ! Value outside expected range [1, 53]: 1 row [EpiWeek] (e.g. 60 (row 5))
+#> ! Year extracted from SampleDate does not match EpiWeekYear: 1 row [SampleDate] (e.g. 2026-03-15 (row 3))
+#>
+#> ℹ See `result$flags` for the full row-level detail.
+```
+
+## What was fixed automatically {#corrections}
+
+`res$log` is the audit trail of every auto-correction — what changed, in which row, and why. Share it
+so the country knows what was normalised on their behalf (it is not an error on their part, but they
+should see it):
+
+```{r log}
+res$log
+#> # A tibble: 3 × 6
+#>     row column             original_value corrected_value rule        action
+#>   <int> <chr>              <chr>          <chr>           <chr>       <chr>
+#> 1     1 Sex                Masculino      Male            translation corrected
+#> 2     2 Sex                Femenino       Female          translation corrected
+#> 3     1 Province_Residence SANTIAGO       Santiago        correction  corrected
+```
+
+## What the country must fix {#flags}
+
+`res$flags` is the feedback list — the rows the schema could **not** resolve. This is what you send
+back:
+
+```{r flags}
+res$flags
+#> # A tibble: 5 × 4
+#>     row column             value      issue
+#>   <int> <chr>              <chr>      <chr>
+#> 1     5 EpiWeek            60         Value outside expected range [1, 53]
+#> 2     3 Age                200        Value outside expected range [0, 120]
+#> 3     4 Sex                X          Value not in allowed_values list
+#> 4     5 Province_Residence Nowhere    Value not in allowed_values list
+#> 5     3 SampleDate         2026-03-15 Year extracted from SampleDate does not match EpiWeekYear
+```
+
+Turn it into a clean artifact to attach to your message with
+[`eri_table()`](../reference/eri_table.html):
+
+```{r feedback-table}
+eri_table(
+  res$flags,
+  title    = "DR malaria — items to correct and resubmit",
+  footnote = "Auto-corrected values are not listed; only rows needing your review."
+)
+```
+
+## Notify the team / country {#notify}
+
+[`eri_notify_dq()`](../reference/eri_notify_dq.html) posts a one-glance summary (rows, corrections,
+flags, the most-flagged columns) to Teams — handy for a shared channel that tracks each country's
+submissions:
+
+```{r notify}
+eri_notify_dq(res, country = "dr", disease = "malaria", team = "ERI", channel = "DQ")
+#> ℹ Sending Teams message via incoming webhook.
+```
+
+It posts a compact, at-a-glance summary to the channel:
+
+```
+[DQ Report] DR - MALARIA
+Rows processed : 5
+Corrections    : 3
+Flags          : 5
+Top flagged    : <the most-flagged columns>
+```
+
+## What's next
+
+- The cleaned data (`res$data`) continues through the pipeline — see the
+  [ingest guide](da-ingest-guide.html) for stage → **approve**.
+- The [DQ pipeline](dq-pipeline.html) — the check engine, schema rules, and adding `custom_checks`.
+- The [epi anomaly guide](epi-dq-guide.html) — spikes, gaps, and cross-field/spatial anomalies beyond
+  cell-level validity.
+- Persist the flags to the shared backlog with `eri_dq_log()` — the
+  [log-triage guide](da-logs-guide.html).
+```


### PR DESCRIPTION
Closes #229. Wave-2 codelab guide (DA tasks 4 + 9: QC data + provide feedback to countries).

A run-it-live (offline) walkthrough of the QC → feedback loop:
- `load_dq_schema("dr","malaria","surveillance","aggregate", azcontainer = NULL)` + `run_dq_checks()` + `dq_report()` on a small DR malaria extract with **seeded issues** (out-of-range Age/EpiWeek, an invalid Sex/Province, a year-mismatch).
- The framing that matters: **auto-corrections are applied + logged (`res$log`)**; **flags are handed back (`res$flags`)** — never guess-fix a flag.
- Turn `res$flags` into a clean country-feedback table with `eri_table()`, and post a summary with `eri_notify_dq()` (Teams, representative).

## Verification

Captured the **real** `run_dq_checks` / `dq_report` output (3 corrections, 5 flags) and the `res$log` / `res$flags` tibbles by running it locally on the seeded data — those are pasted into the `#>`. The `eri_notify_dq` message template is taken from source (`R/teams.R`), shown as the posted Teams message (not console). Vignette knits. No code change.

## Wave-2 status

`da-adhoc`, `da-reporting`, `da-qc-feedback` done; **`da-survey-report` remaining**. Pinned: OEPA + SIL/BoT/EoE templates.