### PR TITLE
da-survey-report-guide: final summaries and reports from an ODK survey

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # erifunctions (development version)
 
+## Docs: `da-survey-report-guide` — final summaries and reports from an ODK survey (#231)
+
+- **New `da-survey-report-guide` article** (DA task: create/assist final summaries/tables/reports after
+  ODK surveys) takes an approved LF TAS extract to a summary with `eri_lf_tas_summary()` and packages it
+  with the reporting toolkit (`eri_table()`, `eri_pptx_*`), pointing to the disease helpers and the
+  spatial map wrapper. Offline; real summary output captured. **Completes the Data-Analyst guide set.**
+
 ## Docs: `da-qc-feedback-guide` — quality-check an extract and give a country feedback (#229)
 
 - **New `da-qc-feedback-guide` article** (DA tasks: QC data + provide feedback to countries) walks a

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The full set:
 | [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer |
 | [Branded tables, figures & decks](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | Data analysts turning approved data into on-brand tables, plots, Excel workbooks, and PowerPoint decks |
 | [QC an extract & give a country feedback](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | Data analysts running DQ checks on a submission and turning the flags into clear country feedback |
+| [Final summaries & reports from an ODK survey](https://thecartercenter.github.io/erifunctions/articles/da-survey-report-guide.html) | Data analysts summarising an approved survey (e.g. LF TAS) with the disease helpers and packaging the result |
 | [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract |
 | [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers |
 | [Reconciling localities to admin units](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | Epidemiologists mapping messy free-text place names to canonical admin units (match → geocode → review) |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -83,6 +83,7 @@ articles:
   - da-adhoc-guide
   - da-reporting-guide
   - da-qc-feedback-guide
+  - da-survey-report-guide
 
 - title: For epidemiologists
   navbar: Epidemiologists

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -71,6 +71,7 @@ Grouped the same way as the [documentation site's Articles menu](https://thecart
 | Answer ad-hoc data requests with SQL (`eri_query`) | [`da-adhoc-guide`](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | ✅ Shipped |
 | Branded tables, figures, and decks for outputs | [`da-reporting-guide`](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | ✅ Shipped |
 | QC an extract and give a country feedback | [`da-qc-feedback-guide`](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | ✅ Shipped |
+| Final summaries and reports from an ODK survey | [`da-survey-report-guide`](https://thecartercenter.github.io/erifunctions/articles/da-survey-report-guide.html) | ✅ Shipped |
 
 ### For epidemiologists
 

--- a/vignettes/da-survey-report-guide.Rmd
+++ b/vignettes/da-survey-report-guide.Rmd
@@ -61,7 +61,8 @@ summary
 #> 6 Saut-d'Eau Positive   Positive       1  16.7
 ```
 
-Read it per commune: Saut-d'Eau has **2 of 6** FTS-positive children, Mirebalais **3 of 6**. In a real
+Read it per commune by summing the `Positive` FTS rows: Saut-d'Eau has **2 of 6** FTS-positive children,
+Mirebalais **3 of 6**. In a real
 TAS you compare that antigen-positive count against the survey's **critical cutoff** to decide
 pass/fail — the helper gives you the counts the decision rests on.
 

--- a/vignettes/da-survey-report-guide.Rmd
+++ b/vignettes/da-survey-report-guide.Rmd
@@ -1,0 +1,105 @@
+---
+title: "Final summaries and reports from an ODK survey"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Final summaries and reports from an ODK survey}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
+```
+
+Once a survey has been pulled from ODK, cleaned, and **approved**, the last step is the deliverable: a
+summary, a results table, a short report. This guide takes an approved survey dataset to a final
+summary using the disease helpers, then packages it for sharing.
+
+It picks up where the [ODK guide](da-odk-guide.html) (sync) and the [ingest guide](da-ingest-guide.html)
+(stage → approve) leave off, and uses the [reporting toolkit](da-reporting-guide.html) to package the
+result. The summary itself is offline.
+
+## The golden rule
+
+> **Report from the approved (`processed/`) dataset, not a working copy.** The number in your report
+> should trace to a specific approved file in the catalog. Pull it with `eri_read()` / `eri_query()`,
+> summarise, then package — don't re-summarise an ad-hoc export that never went through the gate.
+
+## The survey data {#data}
+
+In practice you'd read the approved survey: `eri_read("ht/lf/research/processed/…")` or an
+`eri_query()` roll-up. Here is a small individual-level **LF TAS** (Transmission Assessment Survey)
+extract — one row per child tested, with FTS and RDT antigen results:
+
+```{r data}
+tas <- data.frame(
+  commune    = c(rep("Saut-d'Eau", 6), rep("Mirebalais", 6)),
+  fts_result = c("Negative","Negative","Negative","Negative","Positive","Positive",
+                 "Negative","Negative","Negative","Positive","Positive","Positive"),
+  rdt_result = c("Negative","Negative","Negative","Negative","Negative","Positive",
+                 "Negative","Negative","Negative","Negative","Positive","Positive")
+)
+```
+
+## Summarise with the disease helper {#summary}
+
+[`eri_lf_tas_summary()`](../reference/eri_lf_tas_summary.html) cross-tabulates the FTS and RDT results
+into a tidy per-combination summary, optionally per survey unit:
+
+```{r summary}
+summary <- eri_lf_tas_summary(tas, fts_col = "fts_result", rdt_col = "rdt_result",
+                              group_col = "commune")
+summary
+#> # A tibble: 6 × 5
+#>   commune    fts_result rdt_result     n   pct
+#>   <chr>      <chr>      <chr>      <int> <dbl>
+#> 1 Mirebalais Negative   Negative       3  50
+#> 2 Mirebalais Positive   Negative       1  16.7
+#> 3 Mirebalais Positive   Positive       2  33.3
+#> 4 Saut-d'Eau Negative   Negative       4  66.7
+#> 5 Saut-d'Eau Positive   Negative       1  16.7
+#> 6 Saut-d'Eau Positive   Positive       1  16.7
+```
+
+Read it per commune: Saut-d'Eau has **2 of 6** FTS-positive children, Mirebalais **3 of 6**. In a real
+TAS you compare that antigen-positive count against the survey's **critical cutoff** to decide
+pass/fail — the helper gives you the counts the decision rests on.
+
+Other survey measures have their own helpers: `eri_lf_pooled_prev()` for entomology/xenomonitoring
+pooled prevalence, and `eri_oncho_program_levels()` / `eri_oncho_status_map()` for oncho — see
+[epi analytics](epi-analytics.html).
+
+## Package it for sharing {#package}
+
+The summary is an ordinary tibble, so the [reporting toolkit](da-reporting-guide.html) takes it the rest
+of the way — a branded table for the report:
+
+```{r table}
+eri_table(
+  summary,
+  title    = "LF TAS antigen results by commune",
+  footnote = "FTS = filariasis test strip; RDT = rapid diagnostic test."
+)
+```
+
+…a slide for a results meeting:
+
+```{r pptx}
+deck <- eri_pptx_create()
+deck <- eri_pptx_add_title(deck, "LF TAS Results", subtitle = "Centre Department, 2026")
+deck <- eri_pptx_add_table(deck, summary, title = "Antigen results by commune")
+eri_pptx_save(deck, "lf_tas_results.pptx")
+#> ✔ Presentation saved to 'lf_tas_results.pptx'
+```
+
+…or a self-contained HTML write-up with `eri_report_html()`, or an Excel workbook with
+`eri_report_excel()`. For a programme-status **map** by evaluation unit, `eri_lf_status_map()` wraps the
+spatial helpers (see the [spatial workflow](spatial-workflow.html)).
+
+## What's next
+
+- The [reporting guide](da-reporting-guide.html) — the full table/figure/deck/Excel toolkit.
+- [Epi analytics](epi-analytics.html) — the disease helpers (LF/oncho) and indicators.
+- [Working with ODK Central](da-odk-guide.html) — pulling the survey in the first place.
+- The [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md).
+```


### PR DESCRIPTION
Closes #231. Wave-2 codelab guide (DA task 8: final summaries/tables/reports after ODK surveys). **Completes the Data-Analyst guide set.**

Picks up where the ODK guide (sync) and ingest guide (approve) leave off: an approved **LF TAS** extract →
- `eri_lf_tas_summary(tas, fts_col, rdt_col, group_col = "commune")` → a tidy FTS/RDT cross-tab per commune (real captured output).
- Interpretation (antigen-positive counts vs the survey's critical cutoff), with pointers to the other disease helpers (`eri_lf_pooled_prev` for entomology, `eri_oncho_*`).
- Package with the reporting toolkit: `eri_table()` for the report table, `eri_pptx_*` for a results deck (`✔ Presentation saved…`), and a note on `eri_report_html`/`eri_report_excel`/`eri_lf_status_map`.

The golden rule it teaches: **report from the approved (`processed/`) dataset**, traceable to a catalog entry.

## Verification

`eri_lf_tas_summary` run locally on a small deterministic TAS frame — the `#>` is the real 6×5 output. The `eri_pptx_save` message is from source (verified in the reporting guide). Vignette knits. No code change.

## Wave 2 complete

`da-adhoc` · `da-reporting` · `da-qc-feedback` · `da-survey-report` — all shipped. Pinned (await specifics): OEPA guide + SIL/BoT/EoE templates.