### PR TITLE
ADR-0015: hsp-mal cutover criteria

### DIFF
--- a/docs/adr/0015-hsp-mal-cutover-criteria.md
+++ b/docs/adr/0015-hsp-mal-cutover-criteria.md
@@ -32,22 +32,41 @@ the measure splits the stream) combination — and gated on all of:
    - The `by` keys and any non-zero `tolerance` are **fixed per stream and recorded**, so the bar cannot
      be quietly moved between periods.
 2. **Consecutiveness.** The stream must be equivalent for **N = 3 consecutive periods** (configurable per
-   stream, never below 2). One match can be luck; a streak is evidence the pipelines agree structurally.
+   stream, never below 2). A **period** is one reporting cycle of the stream — the data `period` of the
+   ingest (e.g. a monthly CMR period, a surveillance epiweek), which is also the ledger's indexing unit —
+   *not* a wall-clock interval or an individual ingest event. One match can be luck; a streak is evidence
+   the pipelines agree structurally.
 3. **No unexplained deltas.** Any delta seen during the parallel run must be explained and either fixed
-   or explicitly accepted (and documented) — not merely absent from the latest run. A delta that
-   appears, disappears, then reappears **resets the streak**.
+   or explicitly accepted (and documented) — not merely absent from the latest run. The **streak** is the
+   number of consecutive most-recent periods that are both `equivalent = TRUE` *and* carry no open
+   (unexplained) delta; **any** non-equivalent period, or a reappearing/unresolved delta, resets it to
+   zero. Eligibility needs streak ≥ N.
 4. **Human gate.** Meeting 1–3 makes a stream *eligible*; the cutover itself is a deliberate human
    action, consistent with [`eri_approve()`](../../R/dal.R) — the system records the evidence, a person
    decides.
 
+**Streams with no legacy mirror.** A stream the legacy hsp-mal pipeline never produced (e.g. a new
+`research` measure under [ADR-0012](0012-source-measure-data-model.md), or a country/disease the
+contractor never covered) has nothing to compare against and is **authoritative from the start** — no
+cutover gate applies. This gate is only for streams the contractor pipeline currently owns and the
+`mirror_pipeline` dual-write mirrors.
+
 **Recording.** Each period's comparison outcome is appended to a **cutover ledger**,
-`_cutover/cutover_log.yaml` in the `data/` blob — one entry per stream × period: who ran it, when,
-`equivalent`, the delta counts (added/dropped rows, value mismatches, schema diffs), and the exact
-`eri_compare()` parameters used. The ledger is the auditable record of the streak. The operational
-helpers that write and read it (record a period, report a stream's current streak vs `N`) are built
-**alongside the Phase-3 simulation harness** — the simulation is what first generates these comparison
-runs. The ledger reuses the concurrency-safe metadata write path (ADR-0002) and the verified actor
-identity (ADR-0003), exactly like the catalog and the feedback log.
+`_cutover/cutover_log.yaml` in the `data/` blob — one entry per stream × period, carrying:
+- the **stream identity** — `country`, `disease`, `data_source`, and `data_type` (where the measure
+  splits the stream);
+- the **`period`** identifier (the indexing unit above);
+- `equivalent`, and the delta counts (added/dropped rows, value mismatches, schema diffs);
+- the exact `eri_compare()` parameters used — the `by` keys and `tolerance` — so the bar is auditable
+  and a later period can't silently use a different standard;
+- who recorded it and when (the verified actor).
+
+The ledger is the auditable record from which a stream's streak is computed (count back from the most
+recent period per the rule above). The operational helpers that write and read it (record a period,
+report a stream's current streak vs `N`) are built **alongside the Phase-3 simulation harness** — the
+simulation is what first generates these comparison runs. The ledger reuses the concurrency-safe metadata
+write path (ADR-0002) and the verified actor identity (ADR-0003), exactly like the catalog and the
+feedback log.
 
 **At cutover.** Once a stream meets the criteria and a maintainer triggers the cutover, its
 `mirror_pipeline` dual-write is turned off. When **every** stream in a legacy pipeline is cut over, the

--- a/docs/adr/0015-hsp-mal-cutover-criteria.md
+++ b/docs/adr/0015-hsp-mal-cutover-criteria.md
@@ -1,0 +1,66 @@
+# ADR-0015 — hsp-mal cutover criteria
+
+- **Status:** Accepted
+- **Date:** 2026-06-29
+
+## Context
+
+Phase 3 runs the new pipeline **in parallel** with the legacy hsp-mal contractor pipeline: the opt-in
+`mirror_pipeline` dual-write keeps feeding the legacy `projects/intermediate` output that Power BI reads,
+while `eri_ingest()` writes the same data to `data/staged`. [`eri_compare()`](../../R/compare.R) (#244)
+reconciles the two for a given period.
+
+Before we make the `data/` blob authoritative and retire the contractor pipeline, we need a **written,
+objective gate** — not a judgement call. The risk is asymmetric: a premature cutover breaks live
+dashboards; an over-cautious one wastes effort. So this ADR defines exactly what "equivalent enough to
+cut over" means, and requires it to hold **repeatedly**, not once. It also pins the `equivalent`
+semantics that `eri_compare()` implements, so the policy and the code can't drift apart.
+
+## Decision
+
+Cutover is decided **per data stream** — a `country` / `disease` / `data_source` (and `data_type` where
+the measure splits the stream) combination — and gated on all of:
+
+1. **Equivalence standard.** A `period` is *equivalent* when
+   `eri_compare(new_staged, legacy_mirror, by = <stream keys>, strict_schema = FALSE, tolerance = <stream tolerance>)`
+   reports `equivalent = TRUE`. Concretely:
+   - **Value and row parity are mandatory** — no added or dropped rows, and no per-cell value mismatches
+     (within the stream's documented numeric `tolerance`, default `0`).
+   - **Schema *additions* are tolerated** (`strict_schema = FALSE`): the new five-axis pipeline may carry
+     extra provenance columns the legacy mirror never had. **Dropped columns and type mismatches are
+     not** — a column the legacy output had but the new one lost is a regression.
+   - The `by` keys and any non-zero `tolerance` are **fixed per stream and recorded**, so the bar cannot
+     be quietly moved between periods.
+2. **Consecutiveness.** The stream must be equivalent for **N = 3 consecutive periods** (configurable per
+   stream, never below 2). One match can be luck; a streak is evidence the pipelines agree structurally.
+3. **No unexplained deltas.** Any delta seen during the parallel run must be explained and either fixed
+   or explicitly accepted (and documented) — not merely absent from the latest run. A delta that
+   appears, disappears, then reappears **resets the streak**.
+4. **Human gate.** Meeting 1–3 makes a stream *eligible*; the cutover itself is a deliberate human
+   action, consistent with [`eri_approve()`](../../R/dal.R) — the system records the evidence, a person
+   decides.
+
+**Recording.** Each period's comparison outcome is appended to a **cutover ledger**,
+`_cutover/cutover_log.yaml` in the `data/` blob — one entry per stream × period: who ran it, when,
+`equivalent`, the delta counts (added/dropped rows, value mismatches, schema diffs), and the exact
+`eri_compare()` parameters used. The ledger is the auditable record of the streak. The operational
+helpers that write and read it (record a period, report a stream's current streak vs `N`) are built
+**alongside the Phase-3 simulation harness** — the simulation is what first generates these comparison
+runs. The ledger reuses the concurrency-safe metadata write path (ADR-0002) and the verified actor
+identity (ADR-0003), exactly like the catalog and the feedback log.
+
+**At cutover.** Once a stream meets the criteria and a maintainer triggers the cutover, its
+`mirror_pipeline` dual-write is turned off. When **every** stream in a legacy pipeline is cut over, the
+legacy adapters that [ADR-0012](0012-source-measure-data-model.md) isolates — `mirror_pipeline`,
+`.eri_pipeline_registry`, `.eri_schema_country_map`, and the `rblf` combined code — are removed (Phase
+3), leaving `eri_ingest()` purely general over the five-axis model.
+
+## Consequences
+
+- **Easier:** an objective, auditable, repeatable gate replaces a judgement call; the equivalence
+  semantics live in exactly one place (this ADR + `eri_compare()`), so policy and code can't drift.
+- **Harder:** requires N periods of parallel running before any cutover, and an up-front per-stream
+  decision on keys and tolerance.
+- **Not doing:** an *automatic* cutover (the criteria gate it; a person pulls the trigger), or a per-row
+  sign-off (the period-level comparison is the unit of evidence). The blob remains the system of record
+  (ADR-0004); we are not adding a separate database to track the streak.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,5 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0011](0011-unified-schema-naming.md) | One vocabulary for addressing data and schemas (unified schema naming) | Superseded by ADR-0012 |
 | [0012](0012-source-measure-data-model.md) | Data is addressed by source *and* measure (the 5-axis path model) | Accepted |
 | [0013](0013-odk-submission-backfill.md) | Submission backfill: erifunctions writes records *into* ODK Central | Accepted |
+| [0014](0014-feedback-ticket-log.md) | In-package feedback / ticket log in the `data/` blob | Accepted |
+| [0015](0015-hsp-mal-cutover-criteria.md) | hsp-mal cutover criteria: N consecutive periods of equivalence | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,6 +69,7 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 | [0012](adr/0012-source-measure-data-model.md) | Address data by 5 axes splitting data_source (channel) from data_type (measure); general ingest core + legacy adapters | Coherent data-addressing model (#175); supersedes ADR-0011 |
 | [0013](adr/0013-odk-submission-backfill.md) | Write records *into* ODK Central (submission backfill): deterministic instanceID idempotency, columns map by field name, repeats reuse ADR-0010 | `eri_odk_upload()` (Phase 4, #211) |
 | [0014](adr/0014-feedback-ticket-log.md) | In-package feedback / ticket log in the `data/` blob (capture now via `eri_feedback()`, reusing ADR-0002/0003); triage is a later feature | Tight adoption feedback loop (#237) |
+| [0015](adr/0015-hsp-mal-cutover-criteria.md) | hsp-mal cutover gate: per-stream value/row parity (`strict_schema = FALSE`) for N=3 consecutive periods, recorded in a cutover ledger; human-triggered | Objective Phase-3 cutover criteria (#245) |
 
 ---
 
@@ -172,10 +173,15 @@ against existing Azure data as a simulation; validated against real uploads when
 - **Simulation harness**: pull existing `staged/`/`raw/` files to stand in for "new data."
   Because that data is largely already clean, add an anomaly-injection helper so the DQ and
   cleaning paths are genuinely exercised.
-- **`eri_compare()`**: diff `eri_ingest()`'s `data/staged` output against the
+- ~~**`eri_compare()`**: diff `eri_ingest()`'s `data/staged` output against the
   `projects/intermediate` (hsp-mal) output the dual-write already produces — row/column/value
-  reconciliation. No such tool exists today.
-- Define written **cutover criteria** (N consecutive periods of equivalence) as an ADR.
+  reconciliation.~~ **Shipped** (#244): keyed row+value reconciliation, schema diff, numeric/NA-aware,
+  `strict_schema` flag; returns an `eri_comparison` object.
+- ~~Define written **cutover criteria** (N consecutive periods of equivalence) as an ADR.~~ **Done** —
+  [ADR-0015](adr/0015-hsp-mal-cutover-criteria.md): per-stream value/row parity (`strict_schema = FALSE`)
+  for N=3 consecutive periods, recorded in a cutover ledger, human-triggered. Pins the `equivalent`
+  semantics so policy and `eri_compare()` don't drift. The ledger's read/write helpers land with the
+  simulation harness (next).
 - Harden `eri_ingest_cmr()` / `eri_stage()`; fold DQ failures into the log-triage surface
   (Phase 5).
 - **Retire the legacy adapters** that [ADR-0012](adr/0012-source-measure-data-model.md) isolates from


### PR DESCRIPTION
Closes #245. Defines the Phase-3 cutover gate as an ADR (docs-only).

## What
[ADR-0015](docs/adr/0015-hsp-mal-cutover-criteria.md) pins, per data stream:
- **Equivalence standard** — `eri_compare(..., strict_schema = FALSE, by = <stream keys>, tolerance = <stream tolerance>)` returning `equivalent = TRUE`: value/row parity mandatory; schema *additions* tolerated (the new pipeline's extra provenance columns); dropped columns + type mismatches not tolerated.
- **N = 3 consecutive periods** (configurable per stream, never below 2).
- **No unexplained deltas** — a delta that comes and goes resets the streak.
- **Human gate** — the criteria make a stream eligible; a person triggers the cutover (like `eri_approve()`).
- A **cutover ledger** (`_cutover/cutover_log.yaml`) records each period's outcome; its read/write helpers land with the simulation harness (next item), reusing ADR-0002/0003.

## Why
The review on #244 flagged that the cutover-criteria ADR should own `eri_compare()`'s `equivalent` semantics so code and policy don't drift. This ADR does exactly that — and explains *why* `strict_schema = FALSE` is the cutover default.

## Also
Roadmap: ADR-0015 index row added; the `eri_compare()` and cutover-criteria Phase-3 bullets struck through (both done). Docs-only — no code change.