### PR TITLE
Harden the CMR ingest/stage path (Phase 3)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # erifunctions (development version)
 
+## Fixes: CMR ingest/stage hardening (Phase 3)
+
+- **`eri_stage_cmr(period = NULL)`** now correctly auto-selects the most recent period. It used
+  `which.max()` on the character period labels, which for the real underscore format (`"2024_06"`)
+  coerced to `NA` and selected *nothing*; it now uses `max()` (robust for zero-padded / ISO labels).
+- **`eri_ingest_cmr()`** fails with a helpful, named error listing the available sheets when the
+  (alias-resolved) `sheet` isn't in the workbook, instead of an opaque `readxl` error.
+
 ## Feature: cutover ledger — `eri_cutover_check()` / `eri_cutover_status()` (ADR-0015)
 
 - **New `eri_cutover_check(new, old, country, disease, data_source, period, by, …)`** runs the

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,10 @@
 
 ## Fixes: CMR ingest/stage hardening (Phase 3)
 
-- **`eri_stage_cmr(period = NULL)`** now correctly auto-selects the most recent period. It used
-  `which.max()` on the character period labels, which for the real underscore format (`"2024_06"`)
-  coerced to `NA` and selected *nothing*; it now uses `max()` (robust for zero-padded / ISO labels).
+- **`eri_stage_cmr(period = NULL)`** now auto-selects the most recent period with a robust lexical
+  `max()` over the `YYYYMM` directory labels, instead of `which.max()` on those character labels —
+  which coerced them to numeric (a warning, and `integer(0)` for any non-numeric label, so a future
+  ISO/underscore period format would have silently selected nothing).
 - **`eri_ingest_cmr()`** fails with a helpful, named error listing the available sheets when the
   (alias-resolved) `sheet` isn't in the workbook, instead of an opaque `readxl` error.
 

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -381,9 +381,12 @@ eri_stage_cmr <- function(country,
       )
     }
 
-    # Most recent = lexically greatest period label (zero-padded / ISO formats
-    # like "2024_06" or "2024-W01" sort correctly). `max()` not `which.max()` —
-    # which.max() coerces these strings to NA and returns nothing.
+    # Most recent = lexically greatest period label. Directories are zero-padded
+    # `YYYYMM` (and the lexical order also holds for ISO labels like "2024-W01"),
+    # so a string `max()` is correct and robust. Use `max()` not `which.max()`:
+    # which.max() coerces the labels to numeric, which is fragile (a warning, and
+    # an `integer(0)` result for any non-numeric label). Assumes fixed-width,
+    # zero-padded components.
     period <- max(period_dirs$period_name)
     cli::cli_alert_info("No period specified; staging most recent: {.val {period}}")
   }

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -90,6 +90,18 @@ eri_ingest_cmr <- function(path, sheet, country = NULL) {
     }
   }
 
+  # Fail with a helpful, named error rather than readxl's opaque one when the
+  # sheet (after alias resolution) isn't in the workbook.
+  if (is.character(actual_sheet)) {
+    available <- readxl::excel_sheets(path)
+    if (!actual_sheet %in% available) {
+      cli::cli_abort(c(
+        "Sheet {.val {actual_sheet}} not found in {.path {basename(path)}}.",
+        "i" = "Available sheets: {.val {available}}."
+      ))
+    }
+  }
+
   raw <- readxl::read_excel(path, sheet = actual_sheet, skip = 4,
                              col_names = TRUE, .name_repair = "minimal")
 
@@ -369,7 +381,10 @@ eri_stage_cmr <- function(country,
       )
     }
 
-    period <- period_dirs$period_name[which.max(period_dirs$period_name)]
+    # Most recent = lexically greatest period label (zero-padded / ISO formats
+    # like "2024_06" or "2024-W01" sort correctly). `max()` not `which.max()` —
+    # which.max() coerces these strings to NA and returns nothing.
+    period <- max(period_dirs$period_name)
     cli::cli_alert_info("No period specified; staging most recent: {.val {period}}")
   }
 

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -56,6 +56,13 @@ test_that("eri_ingest_cmr reads correct data values", {
   expect_equal(out[["#rbtrt_adm1"]], c("North", "South"))
 })
 
+test_that("eri_ingest_cmr errors helpfully when the sheet is missing", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_cmr_xlsx(tmp, sheet_name = "RB Treatment")
+  expect_error(eri_ingest_cmr(tmp, sheet = "No Such Sheet"),
+               "Sheet .* not found")
+})
+
 test_that("eri_ingest_cmr drops all-NA spacer rows", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   make_cmr_xlsx(tmp,
@@ -389,6 +396,42 @@ test_that("eri_split_cmr aborts when the workbook has none of the routable sheet
     suppressWarnings(eri_split_cmr(tmp, "uga", dry_run = TRUE)),
     "None of the .* routable sheets were found"
   )
+})
+
+test_that("eri_stage_cmr(period = NULL) auto-selects the most recent period", {
+  calls    <- 0L
+  read_src <- NULL
+  mock_con <- structure(list(), class = "mock")
+
+  local_mocked_bindings(
+    storage_dir_exists  = function(...) TRUE,
+    storage_file_exists = function(...) FALSE,
+    list_storage_files  = function(container, dir, ...) {
+      calls <<- calls + 1L
+      if (calls == 1L) {
+        # period directories under the country's raw/filled_templates
+        tibble::tibble(name = paste0(dir, c("/2024_05", "/2024_06")), isdir = TRUE)
+      } else {
+        tibble::tibble(name = paste0(dir, "/uga_", basename(dir), ".xlsx"), isdir = FALSE)
+      }
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    .eri_blob_read   = function(con, src, dest, ...) { read_src <<- src; file.create(dest); invisible(dest) },
+    .eri_blob_write  = function(...) invisible(NULL),
+    .eri_write_log   = function(...) invisible(NULL),
+    .eri_log_session = function(...) invisible(NULL),
+    .eri_analyst_id  = function(...) "tester",
+    get_azure_storage_connection = function(...) mock_con,
+    .package = "erifunctions"
+  )
+
+  expect_message(
+    eri_stage_cmr("uga", data_con = mock_con),
+    "2024_06"   # most recent, not character(0)
+  )
+  expect_match(read_src, "2024_06")   # staged from the 2024_06 source dir
 })
 
 test_that("eri_split_cmr writes one parquet per routed sheet to the data blob", {

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -409,10 +409,10 @@ test_that("eri_stage_cmr(period = NULL) auto-selects the most recent period", {
     list_storage_files  = function(container, dir, ...) {
       calls <<- calls + 1L
       if (calls == 1L) {
-        # period directories under the country's raw/filled_templates
-        tibble::tibble(name = paste0(dir, c("/2024_05", "/2024_06")), isdir = TRUE)
+        # period directories under raw/filled_templates/{country}/ are YYYYMM
+        tibble::tibble(name = paste0(dir, c("/202405", "/202406")), isdir = TRUE)
       } else {
-        tibble::tibble(name = paste0(dir, "/uga_", basename(dir), ".xlsx"), isdir = FALSE)
+        tibble::tibble(name = paste0(dir, "/uga_cmr_", basename(dir), ".xlsx"), isdir = FALSE)
       }
     },
     .package = "AzureStor"
@@ -429,9 +429,9 @@ test_that("eri_stage_cmr(period = NULL) auto-selects the most recent period", {
 
   expect_message(
     eri_stage_cmr("uga", data_con = mock_con),
-    "2024_06"   # most recent, not character(0)
+    "202406"   # most recent period, picked robustly via max()
   )
-  expect_match(read_src, "2024_06")   # staged from the 2024_06 source dir
+  expect_match(read_src, "202406")   # staged from the 202406 source dir
 })
 
 test_that("eri_split_cmr writes one parquet per routed sheet to the data blob", {


### PR DESCRIPTION
Closes #251. Two robustness improvements in the CMR path (roadmap Phase 3: "harden `eri_ingest_cmr()` / `eri_stage()`").

## 1. `eri_stage_cmr(period = NULL)` period auto-select — defensive hardening
Selecting the most recent period used `which.max()` on the **character** vector of period directory names. The real directory format is `YYYYMM` (e.g. `202406`, per the docstring + `da-cmr-guide`), for which `which.max()`'s numeric coercion happens to work — but it's fragile: it emits a coercion warning, and would return `integer(0)` (selecting *nothing*) for any non-numeric label (a future ISO/underscore period format). Switched to a lexical `max()`, which is correct for the zero-padded `YYYYMM` labels and robust across formats. No existing test exercised the `period = NULL` path — added a mocked one using the documented `YYYYMM` directories.

## 2. `eri_ingest_cmr()` sheet validation
A wrong `sheet` name (after alias resolution) fell through to an opaque `readxl` error. Now it checks the sheet exists in the workbook first and aborts with a named cli error **listing the available sheets**. Correctly skips the numeric-sheet-index case (only checks when `actual_sheet` is character).

## Tests
+2 (missing-sheet error; `period = NULL` picking `202406` over `202405` via mocked Azure listing). Full suite green (2022, 0 failures).

This is the buildable half of the Phase-3 hardening item — the DQ→triage fold is already done (`eri_ingest()` persists DQ flags via `eri_dq_log()` into the `eri_logs()` backlog), and `eri_stage()`/`eri_ingest()`/`eri_stage_cmr()` already wrap work in tryCatch with op-log capture.