### PR TITLE
docs: revoice pkgdown docs to the writing style guide (em-dash sweep + Azure-setup accuracy)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,26 @@ Schemas live in `inst/schemas/` (surveillance) and `inst/schemas/cmr/` (CMR).
 - All exported functions are named `eri_*()` — verb-first, tab-completable.
 - Internal helpers are prefixed with `.` and documented with `#' @keywords internal`.
 - Use `cli::cli_abort()` / `cli::cli_inform()` / `cli::cli_alert_success()` for all user-facing messages — no `message()`, `warning()`, or `stop()`.
-- No non-ASCII characters in R source files (no em dashes, smart quotes, tab literals).
+- No non-ASCII characters in R source files (no em dashes, smart quotes, tab literals). Prose files have their own rule; see Documentation prose below.
 - No `withr::local_mocked_bindings` — use `testthat::local_mocked_bindings()`.
 - Temp files cleaned up with `withr::defer(unlink(tmp))`.
+
+## Documentation prose
+
+Vignettes (`vignettes/*.Rmd`), `README.md`, and the files under `docs/` are the public
+pkgdown site. Keep the prose in a consistent voice:
+
+- **No em dashes as connectors.** Use a comma, semicolon, colon, parentheses, or a period
+  instead. This is the one hard rule; em dashes are the most common drift.
+- **Oxford commas** in lists; specific hedging over vague ("may reflect X rather than Y", not
+  "might possibly").
+- **No end-of-paragraph recaps** of what the reader just read, and no triadic lists used as a
+  reflex rather than because three items are actually true.
+- **Register by file.** The how-to guides address the reader directly ("you", imperatives); keep
+  that. The narrative docs (`README.md`, `docs/vision.md`, `docs/roadmap.md`) carry the
+  declarative, caveat-forward voice ("This does X", "We caution that Y").
+- **Bolding** is fine for UI terms, role names, and layer names; it is a navigational cue, not
+  emphasis for its own sake.
 
 ## Phase releases
 

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ them **Get started → your role → topic deep-dives → contributing**. The
 [**Getting started**](https://thecartercenter.github.io/erifunctions/articles/getting-started.html)
 article is the front door.
 
-**New Data Analyst?** Start with the **[onboarding path](https://thecartercenter.github.io/erifunctions/articles/onboarding.html)**
-— a paced Week-0 → Week-2 track through the guides below — and keep the quick-reference articles open as
+**New Data Analyst?** Start with the **[onboarding path](https://thecartercenter.github.io/erifunctions/articles/onboarding.html)**,
+a paced Week-0 → Week-2 track through the guides below, and keep the quick-reference articles open as
 you work:
 
-- [Orientation](https://thecartercenter.github.io/erifunctions/articles/orientation.html) — the big
+- [Orientation](https://thecartercenter.github.io/erifunctions/articles/orientation.html): the big
   picture: the data system, the pipeline, and where your tasks live
-- [DA cheat sheet](https://thecartercenter.github.io/erifunctions/articles/da-cheatsheet.html) — the
+- [DA cheat sheet](https://thecartercenter.github.io/erifunctions/articles/da-cheatsheet.html): the
   ~15 functions you use, the path model, and the "which pipeline?" decision tree
-- [Data-model card](https://thecartercenter.github.io/erifunctions/articles/data-model-card.html) —
+- [Data-model card](https://thecartercenter.github.io/erifunctions/articles/data-model-card.html):
   channel (`data_source`) vs. measure (`data_type`)
-- [Troubleshooting card](https://thecartercenter.github.io/erifunctions/articles/troubleshooting.html)
-  — common errors → fixes + the log-triage loop
+- [Troubleshooting card](https://thecartercenter.github.io/erifunctions/articles/troubleshooting.html):
+  common errors → fixes + the log-triage loop
 
 **New here? Do these in order** (then dip into the rest as your work needs them). First, run
-`eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure) every guide
+`eri_data_model()` once, it prints the data-addressing vocabulary (channel vs. measure) every guide
 assumes.
 
 - **New Data Analyst:**
@@ -63,8 +63,8 @@ The full set:
 
 | Guide | For |
 |---|---|
-| [Connecting to Azure, ODK, SharePoint & Teams](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) | Everyone — how to authenticate to each service and confirm it works (start here) |
-| [A complete research workflow for epidemiologists](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | Epidemiologists running a study end-to-end — from a fresh project to a citable, reproducible result |
+| [Connecting to Azure, ODK, SharePoint & Teams](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) | Everyone, how to authenticate to each service and confirm it works (start here) |
+| [A complete research workflow for epidemiologists](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | Epidemiologists running a study end-to-end, from a fresh project to a citable, reproducible result |
 | [Ingesting a surveillance dataset (raw → approved)](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | Data analysts taking a dataset through the raw → staged → approved pipeline, with a human approval gate |
 | [Uploading a monthly country report (CMR)](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | Data analysts uploading, staging, parsing, and approving the monthly CMR Excel reports countries file |
 | [Working with ODK Central](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | Data analysts connecting to ODK Central to monitor a form, manage collectors, and pull submissions into the pipeline |
@@ -162,21 +162,21 @@ data/{country}/{disease}/{data_source}/{data_type}/{layer}/
                                                    processed/  <- analyst-approved, canonical
 ```
 
-The `data_type` (measure) level is optional — channel-only data lands one level shallower. The two
+The `data_type` (measure) level is optional, channel-only data lands one level shallower. The two
 addressing axes are explained just below. `eri_approve()` is the explicit human gate. Nothing reaches
 `processed/` without it.
 
 ### How data is addressed (vocabulary)
 
-A path has **five independent axes** ([ADR-0012](docs/adr/0012-source-measure-data-model.md)) — the key
+A path has **five independent axes** ([ADR-0012](docs/adr/0012-source-measure-data-model.md)), the key
 is that **how the data arrives (`data_source`) is separate from what it measures (`data_type`)**:
 
 | Axis | What it is | Examples |
 |---|---|---|
 | `country` | the country | `dr`, `ht`, `uga` |
 | `disease` | the disease | `malaria`, `lf`, `oncho` |
-| `data_source` | **the channel — how it arrives** | `surveillance`, `programmatic`, `research` |
-| `data_type` | **the measure — what it captures** | `case`, `aggregate`, `treatment`, `tas` |
+| `data_source` | **the channel, how it arrives** | `surveillance`, `programmatic`, `research` |
+| `data_type` | **the measure, what it captures** | `case`, `aggregate`, `treatment`, `tas` |
 | `layer` | pipeline stage | `raw`, `staged`, `processed` |
 
 ```r
@@ -186,7 +186,7 @@ path <- eri_data_path("dr", "malaria", "surveillance", "case", "processed")
 
 One source can carry many measures (a CMR yields `treatment` + `mmdp` + `survey`; the same source +
 disease is `case` in one country, `aggregate` in another). `data_source` and `data_type` are
-**extensible** — `eri_data_model()` lists the known values, and an unregistered one *warns* rather than
+**extensible**: `eri_data_model()` lists the known values, and an unregistered one *warns* rather than
 errors so new data is never blocked. (The schema set is keyed by `country` / `disease` / `data_source` /
 `data_type`; the legacy four-axis path form and schema names are being migrated under #175.)
 
@@ -299,7 +299,7 @@ eri_catalog_verify()
 
 | Function | What it does |
 |---|---|
-| `eri_research_scaffold(name, country, disease, description)` | Create a **standalone research-project repository** (ADR-0006) at `dest/name/` — a full repo skeleton that depends on erifunctions |
+| `eri_research_scaffold(name, country, disease, description)` | Create a **standalone research-project repository** (ADR-0006) at `dest/name/`, a full repo skeleton that depends on erifunctions |
 | `eri_research_init(project_name, country, disease, description)` | Initialise a research project **in the current directory** (local `data/`/`figs/`/`outputs/` + `research.yaml`, registered in Azure) |
 | `eri_research_resume()` | Re-read `research.yaml` and print session summary |
 | `eri_research_status(check_remote)` | Report what data the project depends on and whether any of it is stale |
@@ -312,7 +312,7 @@ eri_catalog_verify()
 | `eri_research_tag(label, description)` | Freeze a reproducible, citable version of the project (tag + optional snapshot) |
 
 `eri_research_scaffold()` vs `eri_research_init()`: **scaffold** stands up a new, separate project
-*repository* (the ADR-0006 way — its own git repo); **init** initialises a project in a directory you
+*repository* (the ADR-0006 way, its own git repo); **init** initialises a project in a directory you
 are already in. Most new studies start with `eri_research_scaffold()`.
 
 ### Template management

--- a/README.md
+++ b/README.md
@@ -102,30 +102,33 @@ renv::snapshot()
 
 ## Setup
 
-Add the following to your project `.Renviron` (`usethis::edit_r_environ(scope = "project")`):
+Azure needs no configuration. The first command that touches Azure opens your browser to sign in with your Carter Center account, and access is validated against your own identity. The tenant, app registration, and storage endpoint are built into the package.
+
+Only a couple of entries go in your project `.Renviron` (`usethis::edit_r_environ(scope = "project")`), and only if you need them:
 
 ```
-# Azure storage
-ERIFUNCTIONS_TENANT_ID=<Azure tenant ID>
-ERIFUNCTIONS_APP_ID=<Azure app registration ID>
-ERIFUNCTIONS_RESOURCE_ENDPOINT=<storage account endpoint URL>
-ERIFUNCTIONS_STORAGE_NAME=projects
-ERIFUNCTIONS_DATA_STORAGE_NAME=data
-
-# Service principal — for scripted/automated use only
-ERIFUNCTIONS_SP_CLIENT_ID=<SP client ID>
-ERIFUNCTIONS_SP_CLIENT_SECRET=<SP client secret>
-
-# Your analyst identity (appears in approval and access logs)
+# Your analyst identity, recorded in approval and access logs (recommended)
 ERI_ANALYST_ID=firstname.lastname
 
-# ODK Central
-ODK_URL=https://rblf.tccodk.org/
+# ODK Central credentials (only if you sync ODK data)
 ODK_USER=your.email@cartercenter.org
 ODK_PASS=<ODK password>
 ```
 
 Restart R after editing `.Renviron`.
+
+Advanced settings, rarely needed:
+
+```
+ERIFUNCTIONS_STORAGE_NAME=projects           # only for data-analyst pipeline work against the projects blob
+ODK_URL=https://rblf.tccodk.org/             # only if your ODK server is not the default
+ERIFUNCTIONS_SP_CLIENT_ID=<SP client ID>     # unattended service-principal auth (automation only)
+ERIFUNCTIONS_SP_CLIENT_SECRET=<SP client secret>
+# ERIFUNCTIONS_TENANT_ID / ERIFUNCTIONS_APP_ID / ERIFUNCTIONS_RESOURCE_ENDPOINT override the built-in defaults
+```
+
+The full connection walkthrough, including the service-principal and Teams paths, is in the
+[Connections guide](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html).
 
 ---
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,12 +1,12 @@
-# Task guides — who does what, and where the guide is
+# Task guides, who does what, and where the guide is
 
 > **Status:** living index. Add a row whenever a new task guide ships; flip its status when it lands.
 
 The [grouped function reference](https://thecartercenter.github.io/erifunctions/reference/)
 answers *"what does this function do?"*. These **task guides** answer the more useful question for
-a domain expert: *"I need to do X — show me the steps for my exact job."*
+a domain expert: *"I need to do X, show me the steps for my exact job."*
 
-The framework is one short, worked guide **per user role × task** — a Data Analyst running a
+The framework is one short, worked guide **per user role × task**, a Data Analyst running a
 monthly country report, an Epidemiologist running a study, someone onboarding a new country, and
 so on. Each guide is a copy-pasteable walkthrough on safe example data that a user can run
 end-to-end on their own laptop. They complement (do not replace) the reference and the role
@@ -17,13 +17,13 @@ This page is the **menu and the backlog**: what exists today, and what is still 
 ## New here? Do these in order
 
 **New Data Analysts:** follow the paced **[onboarding path](https://thecartercenter.github.io/erifunctions/articles/onboarding.html)**
-(Week 0 → Week 2), and keep the quick-reference articles open — the
+(Week 0 → Week 2), and keep the quick-reference articles open, the
 [orientation](https://thecartercenter.github.io/erifunctions/articles/orientation.html),
 [DA cheat sheet](https://thecartercenter.github.io/erifunctions/articles/da-cheatsheet.html),
 [data-model card](https://thecartercenter.github.io/erifunctions/articles/data-model-card.html), and
 [troubleshooting card](https://thecartercenter.github.io/erifunctions/articles/troubleshooting.html).
 
-First run `eri_data_model()` once — it prints the data-addressing vocabulary (channel vs. measure)
+First run `eri_data_model()` once, it prints the data-addressing vocabulary (channel vs. measure)
 the guides assume. Then follow your role's path; dip into the rest as your work needs them.
 
 - **Data Analyst:** [`connections-guide`](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html)
@@ -103,7 +103,7 @@ A new guide is a pkgdown article in `vignettes/`, following the pattern set by
 
 1. A **worked example on safe data** (public sample data, or Azure data the user already has) so
    it runs on any laptop.
-2. **Copy-paste chunks read and run in order** — not a single sourced script — so the reader
+2. **Copy-paste chunks read and run in order**: not a single sourced script, so the reader
    learns the steps, not just the outcome.
 3. A **clean-up section** that removes anything the walkthrough created.
 4. Add the article to `_pkgdown.yml` under the right `articles:` group (**Get started / Data analysts

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-# erifunctions V2 — Development Phases Roadmap
+# erifunctions V2: Development Phases Roadmap
 
 > **Status:** living document. This is the shared, version-controlled north star for V2.
 > Update it as phases land or decisions change, and record any architectural decision as an
@@ -7,7 +7,7 @@
 > founding brief this plan derives from.
 >
 > **Where we are (2026-06-30):** Phases 0–2 complete. **Phase 3 cutover/simulation tooling is
-> complete and offline-tested — the next step is a real-data *pilot* (parallel run), not more
+> complete and offline-tested, the next step is a real-data *pilot* (parallel run), not more
 > building**; the actual cutover and legacy-adapter retirement wait on real CMR/malaria uploads.
 > Phase 4 (ODK live pilot + the "Mimic" dashboard) is the next build, pending a direction call.
 
@@ -26,7 +26,7 @@ deferred, (2) harden V1 for real non-developer users, (3) fill the functional ga
 vision implies, and (4) keep design intent under version control so it survives across
 sessions and teammates.
 
-**All three pilots — `dr_irs`, CMR/surveillance, and ODK — are first-class V2 work.**
+**All three pilots (`dr_irs`, CMR/surveillance, and ODK) are first-class V2 work.**
 `dr_irs` leads simply because its data is already available; the real CMR and ODK uploads
 are ~a week out. Critically, the CMR/surveillance and ODK phases are **not blocked on those
 uploads**: they can be developed against the data already in Azure (`staged/`, `raw/`) as a
@@ -37,12 +37,12 @@ than assume dirty input.
 
 ```mermaid
 flowchart TD
-    P0["Phase 0 — Governance scaffolding<br/>roadmap.md, ADRs, CLAUDE.md, pkgdown"]
-    P1["Phase 1 — dr_irs vertical slice<br/>Epi research workflow end-to-end"]
-    P2["Phase 2 — Architecture hardening<br/>concurrency, identity, query layer"]
-    P3["Phase 3 — hsp-mal cutover + CMR<br/>eri_compare, authoritative data/ blob"]
-    P4["Phase 4 — ODK live pilot (Uganda)<br/>cleaning rules, edit tracking, dashboard"]
-    P5["Phase 5 — DA breadth helpers<br/>ad-hoc, log triage, new-dataset onboarding"]
+    P0["Phase 0: Governance scaffolding<br/>roadmap.md, ADRs, CLAUDE.md, pkgdown"]
+    P1["Phase 1: dr_irs vertical slice<br/>Epi research workflow end-to-end"]
+    P2["Phase 2: Architecture hardening<br/>concurrency, identity, query layer"]
+    P3["Phase 3: hsp-mal cutover + CMR<br/>eri_compare, authoritative data/ blob"]
+    P4["Phase 4: ODK live pilot (Uganda)<br/>cleaning rules, edit tracking, dashboard"]
+    P5["Phase 5: DA breadth helpers<br/>ad-hoc, log triage, new-dataset onboarding"]
     P0 --> P1 --> P2 --> P3 --> P4 --> P5
     P2 -. "needed before multi-user<br/>surveillance pilots" .-> P3
 ```
@@ -78,34 +78,34 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 
 ---
 
-## Phase 0 — Governance & shared memory scaffolding  *(landed)*
+## Phase 0: Governance & shared memory scaffolding  *(landed)*
 
 Moves design intent out of the gitignored `sandbox/` and into the repo so teammates and
 fresh sessions inherit it.
 
-- **`docs/roadmap.md`** — this document.
-- **`docs/adr/`** — the six ADRs above plus a README explaining the format.
-- **`CLAUDE.md`** (repo root) — concise project memory: purpose, the 3-layer model +
+- **`docs/roadmap.md`**: this document.
+- **`docs/adr/`**: the six ADRs above plus a README explaining the format.
+- **`CLAUDE.md`** (repo root), concise project memory: purpose, the 3-layer model +
   approval gate, naming conventions, where ADRs/roadmap live, the "global vs local solution"
   guardrail, and the pre-PR check routine.
-- **`_pkgdown.yml`** — grouped function reference (ADR-0001) + articles from existing vignettes.
-- **`.github/workflows/pkgdown.yaml`** — build/deploy the documentation site.
+- **`_pkgdown.yml`**: grouped function reference (ADR-0001) + articles from existing vignettes.
+- **`.github/workflows/pkgdown.yaml`**: build/deploy the documentation site.
 - README version banner fix + roadmap link.
 
 **Verification:** `R CMD check` clean; `pkgdown::build_site()` renders with the grouped
-reference; ADRs and roadmap render; links resolve. (Built in CI — this repo's dev container
+reference; ADRs and roadmap render; links resolve. (Built in CI; this repo's dev container
 has no local R.)
 
 ---
 
-## Phase 1 — `dr_irs` vertical slice (Epi research, end-to-end)  *(first pilot)*
+## Phase 1: `dr_irs` vertical slice (Epi research, end-to-end)  *(first pilot)*
 
 Drive the real DR IRS interrupted-time-series study end-to-end with the package. **The
-package's role here is to *source data reproducibly* and *maintain study-data discipline* —
+package's role here is to *source data reproducibly* and *maintain study-data discipline*,
 not to do the analysis.** Epidemiologists run the ITS themselves (matching, windowing,
 modelling, counterfactuals) in the research repo (ADR-0006); the package removes the friction
 around getting data in, keeping it reproducible, and producing standard figures. The
-scaffolding already fits — `eri_research_init("dr_irs_2024", "dr", "malaria", …)` is the
+scaffolding already fits, `eri_research_init("dr_irs_2024", "dr", "malaria", …)` is the
 documented example.
 
 **Required input:** `dr_irs.R` and the structure of its IRS / incidence / spatial inputs
@@ -115,7 +115,7 @@ documented example.
    enters via `eri_artifact_upload()` → `eri_artifact_pull()`; malaria incidence comes from
    the surveillance `processed/` layer via `eri_research_pull()`; spatial (admin boundaries,
    LandScan) is sourced from the Azure `spatial/` blob via `eri_spatial_load()` /
-   `eri_spatial_pop()`. **Gap:** spatial reads from Azure without caching — cache every input
+   `eri_spatial_pop()`. **Gap:** spatial reads from Azure without caching. Cache every input
    into the project and record it in `research.yaml` for reproducibility. Exercise the
    surveillance pipeline (`eri_ingest` → `eri_stage` → `eri_approve`) by updating incidence
    with a newer country dataset, then re-pulling.
@@ -125,7 +125,7 @@ documented example.
 3. **Version-tag-linked-to-publication** (genuine gap): `eri_research_snapshot()` freezes
    `data/` but gives no named tag binding *data + code commit + outputs* to a publication.
    Add `eri_research_tag(label, …)` recording snapshot ref + analysis git SHA + output
-   manifest, so an analysis is reproducible from a citation — including across data updates.
+   manifest, so an analysis is reproducible from a citation, including across data updates.
 4. **Research-repo template** (ADR-0006): port `dr_irs` into a standalone repo from the new
    template as the reference example (this is where the ITS analysis lives).
 5. **(Stretch) figures:** thin helpers on top of `eri_map_*` / `eri_brand_ggplot_theme()` for
@@ -133,7 +133,7 @@ documented example.
 6. **Epidemiologist documentation** *(done)*: a role-oriented, copy-paste **worked example** of the
    full research lifecycle on safe public data (`vignettes/epi-research-guide.Rmd`, using
    `mtcars`), superseding the older `research-workflow` vignette. This also seeds the **task-guide
-   framework** (one guide per user role × task), tracked in [`guides.md`](guides.md) — the live
+   framework** (one guide per user role × task), tracked in [`guides.md`](guides.md), the live
    index of which guides exist and which are still missing.
 
 **Verification:** a `test-smoke.R`-style live test (`ERI_SMOKE_TESTS=true`): init → pull IRS
@@ -143,24 +143,24 @@ and re-tag; re-pull the original tag on a clean checkout and reproduce its figur
 
 ---
 
-## Phase 2 — Architecture hardening
+## Phase 2: Architecture hardening
 
 Implements ADR-0002/0003/0004 before multi-user surveillance pilots make concurrency and
 identity load-bearing.
 
-> **Update (2026-06-16):** the *interactive-auth enablement* half of ADR-0003 landed early —
-> zero-config browser auth via baked non-secret defaults ([ADR-0008](adr/0008-baked-azure-auth-defaults.md)) —
+> **Update (2026-06-16):** the *interactive-auth enablement* half of ADR-0003 landed early,
+> zero-config browser auth via baked non-secret defaults ([ADR-0008](adr/0008-baked-azure-auth-defaults.md)),
 > because epidemiologists couldn't use the package without it. Token-derived approver identity
 > (`.eri_token_identity()`, below) remains the Phase 2 work.
 - ~~Concurrency-safe + rebuildable catalog/registries (`R/catalog.R`, `R/odk_registry.R`,
-  `R/artifacts.R`); add `eri_catalog_rebuild()`.~~ **Shipped** — catalog/registry/artifact writes go
+  `R/artifacts.R`); add `eri_catalog_rebuild()`.~~ **Shipped**: catalog/registry/artifact writes go
   through `.eri_yaml_update()` (read-with-ETag, conditional `If-Match`/`If-None-Match` write, re-read +
   retry on 412); `eri_catalog_rebuild()` reconstructs the catalog from the processed-layer parquet
   listing (ADR-0002). **Closes Phase 2.**
-- ~~`.eri_token_identity()`; `eri_approve()` uses verified identity.~~ **Shipped** — governed actions
+- ~~`.eri_token_identity()`; `eri_approve()` uses verified identity.~~ **Shipped**: governed actions
   (approve `approved_by`, catalog `registered_by`, op-logs) record the verified Azure AD token identity;
   `ERI_ANALYST_ID` is the service-principal fallback (ADR-0003).
-- ~~`eri_query()` DuckDB-over-parquet read layer.~~ **Shipped** — catalog-driven roll-ups + explicit-table
+- ~~`eri_query()` DuckDB-over-parquet read layer.~~ **Shipped**: catalog-driven roll-ups + explicit-table
   joins over processed parquet via an in-process DuckDB session (`duckdb`/`DBI` as Suggests). Brought
   forward to close the DA ad-hoc-request task ahead of the rest of Phase 2 (concurrency-safe metadata
   and token identity), which has since shipped.
@@ -171,12 +171,12 @@ datasets returns a correct join.
 
 ---
 
-## Phase 3 — hsp-mal cutover tooling + CMR/surveillance pilot
+## Phase 3: hsp-mal cutover tooling + CMR/surveillance pilot
 
 Make the `data/` blob authoritative and retire the contractor pipeline on evidence. Built
 against existing Azure data as a simulation; validated against real uploads when they land.
 
-> **Status (2026-06-30): the cutover *tooling* is COMPLETE — the next step is a real-data
+> **Status (2026-06-30): the cutover *tooling* is COMPLETE. The next step is a real-data
 > pilot, not more building.** Everything below the line is shipped and offline-tested; what
 > remains (the parallel run, the equivalence streak, the adapter retirement) is operational
 > work that needs real CMR/malaria uploads and a maintainer at the trigger.
@@ -199,7 +199,7 @@ against existing Azure data as a simulation; validated against real uploads when
   CMR period/sheet hardening (#252); the DQ→triage fold was already in place (`eri_ingest()` persists
   flags via `eri_dq_log()` into the `eri_logs()` backlog), and stage/ingest already have full op-log +
   tryCatch capture.
-- **Retire the legacy adapters** that [ADR-0012](adr/0012-source-measure-data-model.md) isolates — the
+- **Retire the legacy adapters** that [ADR-0012](adr/0012-source-measure-data-model.md) isolates: the
   `projects`-blob dual-write (`mirror_pipeline`), `.eri_pipeline_registry`, `.eri_schema_country_map`,
   and the `rblf` combined code. **Deferred to the cutover itself** (irreversible; only once a stream's
   streak is met and a maintainer triggers it).
@@ -207,11 +207,11 @@ against existing Azure data as a simulation; validated against real uploads when
 **Pilot (the next operational step):** run `eri_ingest(..., mirror_pipeline = "hsp-mal")` on the real
 periods as they arrive; `eri_cutover_check()` each one; watch `eri_cutover_status()` reach the N-period
 streak; only then retire the adapters for that stream. The toolchain is ready and end-to-end tested
-offline — it needs real uploads, not more code.
+offline. It needs real uploads, not more code.
 
 ---
 
-## Phase 4 — ODK live pilot (Uganda survey)
+## Phase 4: ODK live pilot (Uganda survey)
 
 Developed against existing synced ODK submissions (simulation); validated against the live
 Uganda form once it launches. Exercises register/sync/status and fills two named gaps.
@@ -219,21 +219,21 @@ Forms with **repeat groups** now sync as a relational set of tables in `raw/`
 ([ADR-0010](adr/0010-odk-repeat-group-tables.md)), which the cleaning-rules layer, edit
 tracking, and dashboard below all build on:
 - **Live cleaning-rules layer**: versioned, declarative cleaning applied *on read* for
-  dashboards while `raw/` stays pristine — distinct from the slow `approve` gate. New
+  dashboards while `raw/` stays pristine, distinct from the slow `approve` gate. New
   `cleaning_rules` concept layered on the DQ schema engine (`R/dq.R`).
 - **Manual-edit tracking**: capture ODK Central submission edit history during
   `eri_odk_sync()` so direct edits are auditable.
-- **Submission backfill** (`eri_odk_upload()`) — the inverse of `download_odk_form()` /
+- **Submission backfill** (`eri_odk_upload()`), the inverse of `download_odk_form()` /
   `eri_odk_sync()`: bulk-create submissions on an existing **published** form from a CSV/Excel table,
   for migrating paper or legacy records into ODK Central. Maps columns → form fields via the form's
   `/fields` schema,
   builds one instance XML per row, and POSTs each to `.../forms/{id}/submissions` with a
   **deterministic `instanceID`** so re-runs are idempotent (HTTP 409 = already loaded → skip).
-  A `dry_run`/validation pass (required-field, choice-list, and type/format checks — dates and
+  A `dry_run`/validation pass (required-field, choice-list, and type/format checks, dates and
   geopoints especially) runs before anything is sent, and the call returns a per-row outcome
   tibble (`created` / `skipped` / `failed`) rather than aborting the batch on one bad row. Flat
   forms first; **repeat groups** reuse the ADR-0010 relational-table convention (parent + child
-  CSVs joined on `PARENT_KEY`) as a fast-follow. Attachments are out of scope — the REST
+  CSVs joined on `PARENT_KEY`) as a fast-follow. Attachments are out of scope, the REST
   submission endpoint excludes them. Independent of the live-pilot timing.
 - Quarto **survey dashboard** template (replacing PowerBI) built on `R/reports_html.R`.
 
@@ -243,14 +243,14 @@ range, map, positives, open-text, DQ flags).
 
 ---
 
-## Phase 5 — DA breadth helpers
+## Phase 5: DA breadth helpers
 
 The remaining DA tasks, once the spine is solid.
 - **Ad-hoc request** helpers on top of `eri_query()` (lookups/figures for presentations).
 - **Error/log triage** surface: the structured op-logs already written to Azure `…/logs/`
-  need a reader — `eri_logs()` to list/filter/triage a backlog and mark items handled.
+  need a reader, `eri_logs()` to list/filter/triage a backlog and mark items handled.
 - **New-dataset onboarding** generalised (IRS as the worked example) so adding a
-  country/disease/data-type doesn't require core edits — extends `R/onboarding.R`.
+  country/disease/data-type doesn't require core edits; extends `R/onboarding.R`.
 
 **Verification:** `eri_logs()` surfaces a seeded error backlog; an ad-hoc cross-country query
 returns expected numbers; onboarding a new data type round-trips ingest→approve→catalog.
@@ -261,6 +261,6 @@ returns expected numbers; onboarding a new data type round-trips ingest→approv
 - **Phase 1:** `dr_irs.R` and example IRS + incidence data shapes.
 - **Phase 2:** confirmation of the Azure AD app registration / RBAC so all DAs/Epis can use
   interactive browser auth (ADR-0003 assumes token identity is available to every user).
-- **Phases 3–4:** not blocked on the real uploads — built against existing Azure
+- **Phases 3–4:** not blocked on the real uploads, built against existing Azure
   `staged/raw` + synced ODK data as a simulation, then re-validated when the real CMR/ODK
   uploads arrive. Phase 4 also needs ODK Central audit-log/permissions for edit tracking.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,4 +1,4 @@
-# erifunctions — Founding Vision
+# erifunctions, Founding Vision
 
 > This is the original founding brief for the erifunctions data system, written by an
 > epidemiologist on the ERI team. It is the source-of-truth for *user intent* behind the package and the V2

--- a/vignettes/connections-guide.Rmd
+++ b/vignettes/connections-guide.Rmd
@@ -15,34 +15,34 @@ knitr::opts_chunk$set(
 )
 ```
 
-`erifunctions` talks to four outside services on your behalf — **Azure** (where the data lives),
+`erifunctions` talks to four outside services on your behalf, **Azure** (where the data lives),
 **ODK Central** (where field submissions come from), **SharePoint** (shared files), and **Teams**
 (notifications). This is the one place that shows how to connect to each and **confirm it works**.
 
-The good news: most need little or no setup. Azure and SharePoint are **zero-config** — you just sign
+The good news: most need little or no setup. Azure and SharePoint are **zero-config**, you just sign
 in through your browser. ODK needs three lines in a settings file. Teams is optional. Work through the
 service(s) you need; skip the rest.
 
-> **A note on secrets.** Where a service needs a credential, it lives in your **`.Renviron`** file —
+> **A note on secrets.** Where a service needs a credential, it lives in your **`.Renviron`** file,
 > never typed into a script and never committed to git. We point that out at each step.
 
 > **Do this first: set your analyst identity.** Before your **first governed action** (approving data,
-> registering a catalog entry, syncing a form), set `ERI_ANALYST_ID` in your `.Renviron` —
+> registering a catalog entry, syncing a form), set `ERI_ANALYST_ID` in your `.Renviron`,
 > `usethis::edit_r_environ()`, add `ERI_ANALYST_ID=firstname.lastname`, save, and **restart R**. Every
 > approval log, catalog entry, and operation log is stamped with it. If it is unset, `erifunctions`
 > warns once and records the approver as **`jsmith (unverified)`** (your OS username, marked so the
 > audit trail shows the attribution is provisional). Set it once and the attribution is correct
-> everywhere. A team or automated run can **require** it — set `ERI_REQUIRE_ANALYST_ID=true` and
+> everywhere. A team or automated run can **require** it, set `ERI_REQUIRE_ANALYST_ID=true` and
 > governed actions refuse to run until `ERI_ANALYST_ID` is configured.
 
 ```{=html}
 <div class="mermaid">
 flowchart TD
     You["Your R session"] --> P["erifunctions"]
-    P --> AZ["Azure Storage — where the data lives"]
-    P --> ODK["ODK Central — field submissions"]
-    P --> SP["SharePoint — shared files"]
-    P --> TM["Teams — notifications"]
+    P --> AZ["Azure Storage, where the data lives"]
+    P --> ODK["ODK Central, field submissions"]
+    P --> SP["SharePoint, shared files"]
+    P --> TM["Teams, notifications"]
 </div>
 ```
 
@@ -59,7 +59,7 @@ flowchart TD
 library(erifunctions)
 ```
 
-## Azure — nothing to configure {#azure}
+## Azure, nothing to configure {#azure}
 
 This is the big one: **the data system itself**. And there is nothing to set up. Thanks to baked-in
 defaults (see `?get_azure_storage_connection` and ADR-0008), the **first time** a command needs Azure
@@ -68,14 +68,14 @@ rest of the session.
 
 ```{r azure-connect}
 # The first call this session opens your browser to sign in.
-# Nothing prints on success — you get a connection object back.
+# Nothing prints on success, you get a connection object back.
 data_con <- get_azure_storage_connection(storage_name = "data")
 ```
 
 The `storage_name` picks **which blob you connect to**: `"data"` (the governed three-layer data
 system) or `"projects"` (the legacy contractor space). Most analyst work is in `"data"`.
 
-**Confirm it works** by listing the top of the container — if you get a tibble back, you are in:
+**Confirm it works** by listing the top of the container, if you get a tibble back, you are in:
 
 ```{r azure-verify}
 eri_list("", azcontainer = data_con)
@@ -92,16 +92,16 @@ The `name` column holds the **full path** from the container root (so a deeper l
 `eri_list("uga/demo/research/raw", …)` returns `uga/demo/research/raw/<file>` names); pass
 `full_names = FALSE` for just the leaf filenames.
 
-> **For automation / CI (headless).** A scheduled job has no browser. Set a **service principal** —
+> **For automation / CI (headless).** A scheduled job has no browser. Set a **service principal**,
 > `ERIFUNCTIONS_SP_CLIENT_ID` and `ERIFUNCTIONS_SP_CLIENT_SECRET` in the environment (or pass
-> `creds_yaml_path=`) — and `get_azure_storage_connection()` signs in non-interactively instead. The
+> `creds_yaml_path=`), and `get_azure_storage_connection()` signs in non-interactively instead. The
 > secret is the *only* true secret here; the tenant, app, and endpoint are non-sensitive defaults.
 
-> **`403 Forbidden`?** That is not a bug — it is Azure telling you your account does not have access to
+> **`403 Forbidden`?** That is not a bug, it is Azure telling you your account does not have access to
 > that storage. Access is granted by an administrator (Azure RBAC), not by the package. Ask your ERI
 > admin to add you.
 
-## ODK Central — three lines in your settings file {#odk}
+## ODK Central, three lines in your settings file {#odk}
 
 ODK Central signs in with your **email and password**, so those go in your `.Renviron` once. Open it
 with:
@@ -118,7 +118,7 @@ ODK_USER=you@example.org
 ODK_PASS=your-password
 ```
 
-Now connect — `init_odk_connection()` reads those automatically, so your password never appears in a
+Now connect, `init_odk_connection()` reads those automatically, so your password never appears in a
 script:
 
 ```{r odk-connect}
@@ -138,15 +138,15 @@ list_odk_projects(con = con)
 #> 3         11 testing   NA
 ```
 
-Pass that `con` to the other ODK functions as `con = con`. For the full ODK workflow — registering a
-form, monitoring it, and pulling submissions — see the
+Pass that `con` to the other ODK functions as `con = con`. For the full ODK workflow, registering a
+form, monitoring it, and pulling submissions, see the
 [ODK Central guide](da-odk-guide.html).
 
 > **For automation / CI.** Instead of email+password, you can reuse a **bearer token**: set `ODK_TOKEN`
-> in the environment and call the ODK functions with `con = NULL` — they fall back to `ODK_URL` +
+> in the environment and call the ODK functions with `con = NULL`, they fall back to `ODK_URL` +
 > `ODK_TOKEN`.
 
-## SharePoint — just the site URL {#sharepoint}
+## SharePoint, just the site URL {#sharepoint}
 
 SharePoint uses the same browser sign-in as Azure (via `Microsoft365R`), so all you supply is the
 **site URL**:
@@ -171,12 +171,12 @@ eri_sharepoint_list(site, "Shared Documents/Malaria/2024")
 For reading and uploading files, see `eri_sharepoint_read()` / `eri_sharepoint_upload()` and the
 [SharePoint workflow](sharepoint-workflow.html) vignette.
 
-> **No service-principal path.** SharePoint is browser-sign-in only in `erifunctions` — there is no
+> **No service-principal path.** SharePoint is browser-sign-in only in `erifunctions`, there is no
 > headless/CI path for it. Use it interactively.
 
-## Teams — for posting notifications {#teams}
+## Teams, for posting notifications {#teams}
 
-Teams is **optional** — you only need it if you want `erifunctions` to post messages (for example,
+Teams is **optional**, you only need it if you want `erifunctions` to post messages (for example,
 [`eri_notify_dq()`](../reference/eri_notify_dq.html) posts a data-quality summary to a channel). There
 are three ways in, easiest first:
 
@@ -192,7 +192,7 @@ eri_teams_send(message = "Hello from erifunctions.")
 #> ℹ Sending Teams message via incoming webhook.
 ```
 
-**For direct messages, use the Graph API.** `get_teams_connection()` returns a token — from
+**For direct messages, use the Graph API.** `get_teams_connection()` returns a token, from
 `ERIFUNCTIONS_TEAMS_TOKEN` if you have one, otherwise via an interactive device-code sign-in. Unlike
 Azure, this path is **not** zero-config: the device-code flow needs `ERIFUNCTIONS_APP_ID` set in your
 `.Renviron` (without it you'll get a "No Teams token or app ID found" warning). Most people only need
@@ -210,7 +210,7 @@ eri_teams_send(message = "Test message to myself.", to = "self", token = token)
 ```
 
 > **For automation / CI.** A webhook (`ERIFUNCTIONS_TEAMS_WEBHOOK`) is the most robust for scheduled
-> jobs — it needs no interactive sign-in. Where conditional-access policies block the device-code flow,
+> jobs, it needs no interactive sign-in. Where conditional-access policies block the device-code flow,
 > the webhook is the way through. For DMs in automation, set a pre-obtained `ERIFUNCTIONS_TEAMS_TOKEN`.
 
 ## One `.Renviron` for everything {#renviron}
@@ -245,16 +245,16 @@ ODK_PASS=your-password
 # ERIFUNCTIONS_SP_CLIENT_SECRET=<service principal client secret>
 ```
 
-**Always restart R after editing `.Renviron`.** Everything in this file is read once at startup — and
+**Always restart R after editing `.Renviron`.** Everything in this file is read once at startup, and
 none of it is ever written into your scripts or committed to git.
 
 ## Troubleshooting {#troubleshooting}
 
 | Symptom | What it means | Fix |
 |---|---|---|
-| Azure `403 Forbidden` | Your account lacks access to that storage (RBAC) | Ask an ERI admin to grant access — it is not a code problem |
+| Azure `403 Forbidden` | Your account lacks access to that storage (RBAC) | Ask an ERI admin to grant access, it is not a code problem |
 | ODK: *"ODK username is required"* | `ODK_USER` / `ODK_PASS` aren't set | Add them to `.Renviron`; restart R |
-| A call re-opens the browser unexpectedly | Your cached session expired | Just sign in again — connections are session-scoped |
+| A call re-opens the browser unexpectedly | Your cached session expired | Just sign in again, connections are session-scoped |
 | Teams device-code sign-in is blocked | Conditional-access policy | Use an incoming webhook (`ERIFUNCTIONS_TEAMS_WEBHOOK`) instead |
 | SharePoint "package Microsoft365R is required" | Optional dependency missing | `install.packages("Microsoft365R")` |
 
@@ -262,9 +262,9 @@ none of it is ever written into your scripts or committed to git.
 
 Now that you can connect, the role guides put these connections to work:
 
-- [Ingesting a surveillance dataset](da-ingest-guide.html) — the `raw → staged → approved` pipeline.
-- [Working with ODK Central](da-odk-guide.html) — register, monitor, and pull form data.
-- [A complete research workflow for epidemiologists](epi-research-guide.html) — running a study.
+- [Ingesting a surveillance dataset](da-ingest-guide.html): the `raw → staged → approved` pipeline.
+- [Working with ODK Central](da-odk-guide.html): register, monitor, and pull form data.
+- [A complete research workflow for epidemiologists](epi-research-guide.html): running a study.
 
 For every connection function grouped together, see the **Connections & authentication** section of
 the [reference](../reference/index.html).

--- a/vignettes/da-adhoc-guide.Rmd
+++ b/vignettes/da-adhoc-guide.Rmd
@@ -18,7 +18,7 @@ approved datasets and compute a number.** [`eri_query()`](../reference/eri_query
 
 ## The golden rule
 
-> **`eri_query()` runs SQL across *processed* data — the approved, trustworthy layer — without moving it
+> **`eri_query()` runs SQL across *processed* data, the approved, trustworthy layer, without moving it
 > out of Azure or standing up a database.** It attaches the relevant parquet into an in-process
 > [DuckDB](https://duckdb.org) session, runs your query, and hands back a tibble.
 
@@ -35,7 +35,7 @@ flowchart LR
 ## Before you start {#before-you-start}
 
 ```{r install}
-# eri_query needs two optional packages — install them once:
+# eri_query needs two optional packages, install them once:
 install.packages(c("duckdb", "DBI"))
 ```
 
@@ -44,7 +44,7 @@ library(erifunctions)
 ```
 
 Querying approved data in Azure also needs a connection (the browser opens on first use); pure
-in-memory queries — the examples in [Joins and aggregations](#explicit) below — need nothing.
+in-memory queries, the examples in [Joins and aggregations](#explicit) below, need nothing.
 
 ```{r connect}
 data_con <- get_azure_storage_connection(storage_name = "data")
@@ -54,11 +54,11 @@ data_con <- get_azure_storage_connection(storage_name = "data")
 
 `eri_query()` gives you two ways to choose what your SQL can see, and they combine:
 
-1. **Catalog-driven** — name the data by its axes (`country`, `disease`, `data_type`, …) and
+1. **Catalog-driven**: name the data by its axes (`country`, `disease`, `data_type`, …) and
    `eri_query()` finds the matching **processed** files, stamps each row with its
    `country`/`disease`/`data_source`/`data_type`/`period`, and unions them into one table called
    `data`. This is how you roll up across countries or periods.
-2. **Explicit tables** — hand it named tables directly (`tables = list(name = …)`), where each is a
+2. **Explicit tables**: hand it named tables directly (`tables = list(name = …)`), where each is a
    data.frame, a local `.parquet`, or a `data/` blob path. This is how you join your own inputs (a
    population table, a lookup) to approved data.
 
@@ -82,18 +82,18 @@ eri_query(
 #> 2 dr       9876
 ```
 
-*(Illustrative numbers — your catalog will differ. The in-memory examples below are real output you can
+*(Illustrative numbers, your catalog will differ. The in-memory examples below are real output you can
 reproduce.)*
 
 Because every row is stamped with its provenance, you can `GROUP BY country`, `period`, `data_type`,
-etc. without joining anything. (Those five names are reserved in this mode — see
+etc. without joining anything. (Those five names are reserved in this mode, see
 `?eri_query`.) Not sure what's available? [`eri_catalog_query()`](../reference/eri_catalog_query.html)
 with the same filters lists the files that would be attached.
 
 ## Joins and aggregations {#explicit}
 
 The explicit mode runs entirely in memory, so these you can run right now. Say a request lands as two
-small tables — weekly case counts and a population denominator:
+small tables, weekly case counts and a population denominator:
 
 ```{r data}
 cases <- data.frame(
@@ -107,7 +107,7 @@ pop <- data.frame(
 )
 ```
 
-**Aggregate** — total cases by province:
+**Aggregate**: total cases by province:
 
 ```{r agg}
 eri_query(
@@ -125,7 +125,7 @@ eri_query(
 #> 3 South       21
 ```
 
-**Join** — incidence per 1,000, combining the two tables:
+**Join**: incidence per 1,000, combining the two tables:
 
 ```{r join}
 eri_query(
@@ -144,7 +144,7 @@ eri_query(
 #> 3 East                  0.375
 ```
 
-**Window functions** — week-over-week change, which is awkward in base R but one line of SQL:
+**Window functions**: week-over-week change, which is awkward in base R but one line of SQL:
 
 ```{r window}
 eri_query(
@@ -165,29 +165,29 @@ eri_query(
 #> 5 South          2     9         -3
 ```
 
-You can mix the modes — pass catalog filters **and** `tables = list(pop = …)` to join approved cases to
+You can mix the modes, pass catalog filters **and** `tables = list(pop = …)` to join approved cases to
 a population table you supply.
 
 ## Turn the answer into an output
 
-`eri_query()` returns an ordinary tibble, so the result flows straight into the rest of the toolkit —
+`eri_query()` returns an ordinary tibble, so the result flows straight into the rest of the toolkit,
 [`eri_table()`](../reference/eri_table.html) for a branded table, `ggplot2` / the `eri_map_*` helpers
-for a figure, or `eri_case_summary()` / `eri_incidence_rate()` for standard epi summaries — see the
+for a figure, or `eri_case_summary()` / `eri_incidence_rate()` for standard epi summaries, see the
 [function reference](../reference/index.html) for the full reporting toolkit.
 
 ## Tips
 
-- **It queries *approved* data.** `eri_query()` reads the `processed/` layer through the catalog — the
-  data the team trusts — not `raw/` or `staged/`.
+- **It queries *approved* data.** `eri_query()` reads the `processed/` layer through the catalog, the
+  data the team trusts, not `raw/` or `staged/`.
 - **Big scans are bounded by memory/download** (ADR-0004): filter tight (`country`/`disease`/`period`)
   so you attach only what you need.
-- **It's DuckDB SQL** — joins, `GROUP BY`, window functions, CTEs, date functions all work; see the
+- **It's DuckDB SQL**: joins, `GROUP BY`, window functions, CTEs, date functions all work; see the
   [DuckDB docs](https://duckdb.org/docs/sql/introduction).
 
 ## What's next
 
-- The [data catalog reference](../reference/eri_catalog_query.html) — see what approved data exists
+- The [data catalog reference](../reference/eri_catalog_query.html), see what approved data exists
   before you query it.
-- The [surveillance ingest guide](da-ingest-guide.html) — how data *gets* approved in the first place.
+- The [surveillance ingest guide](da-ingest-guide.html), how data *gets* approved in the first place.
 - The [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md).
 ```

--- a/vignettes/da-cheatsheet.Rmd
+++ b/vignettes/da-cheatsheet.Rmd
@@ -14,22 +14,22 @@ when you want the full walkthrough.*
 ## The data system in one picture
 
 Everything lives in the Azure **`data/`** blob under a canonical 5-axis path. Build it with
-`eri_data_path()` — never hand-type it.
+`eri_data_path()`: never hand-type it.
 
 ```
 data/ {country} / {disease} / {data_source} / {data_type} / {layer} / file
         dr         malaria     surveillance    case          raw        as-received
         uga        oncho       programmatic    treatment     staged     DQ-checked, awaiting sign-off
-        ht         lf          research        prevalence    processed  approved — the team trusts this
+        ht         lf          research        prevalence    processed  approved, the team trusts this
 ```
 
 - **`data_source` = the channel** (how the data arrives): `surveillance` · `programmatic` · `research`.
 - **`data_type` = the measure** (what it counts): `case` · `aggregate` · `treatment` · `mmdp` ·
   `training` · `survey` · `tas` · `prevalence` · `entomology`.
 - Run **`eri_data_model()`** once to print the full, current vocabulary. Unknown values *warn, not
-  error* — a new country/disease/source/measure is a normal gap, not a bug.
+  error*, a new country/disease/source/measure is a normal gap, not a bug.
 
-> **The golden rule:** nothing reaches **`processed/`** without **`eri_approve()`** — the human gate.
+> **The golden rule:** nothing reaches **`processed/`** without **`eri_approve()`**, the human gate.
 > It moves staged → processed, writes an approval log, and registers the file in the catalog. Never
 > hand-edit or delete `processed/` data.
 
@@ -85,7 +85,7 @@ eri_approve(c, d, src, period, data_type = mea, azcontainer = data_con)   # the 
 | Triage errors / DQ backlog | `eri_logs` · `eri_logs_resolve` | `eri_logs(status = "error")` → `eri_logs_resolve(log_path, note =)` |
 
 *Signatures to mind:* `eri_onboard_disease(disease, country, …)` takes **disease first** (unlike the
-others); `eri_approve()`'s **5th arg is `data_type`** (the measure) — omit it and the catalog records
+others); `eri_approve()`'s **5th arg is `data_type`** (the measure), omit it and the catalog records
 the measure as `NA`.
 
 ## Quick analytics (for initial epi QC products)
@@ -97,7 +97,7 @@ eri_epidemic_curve(data, date_col, count_col =, period = "week")
 # disease helpers: eri_lf_tas_summary(), eri_oncho_program_levels(), eri_lf_pooled_prev() …
 ```
 
-## Don't reinvent — search first
+## Don't reinvent, search first
 
 Before writing new code, reuse `azure_io()` / `eri_read()` / `eri_write()` / `eri_data_path()` and the
 DQ / catalog / logs machinery. If a problem is general, it probably already has a helper (and if it

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-Every month, country programmes file a **Case Management Report (CMR)** — a filled Excel template of
+Every month, country programmes file a **Case Management Report (CMR)**, a filled Excel template of
 treatment, training, and survey numbers. This guide, for a **Data Analyst**, walks the monthly job:
 take that incoming Excel, **upload** it to Azure, **stage** it, **parse** each sheet, and **approve** it
 into the governed data system.
@@ -44,8 +44,8 @@ flowchart TD
 ## Before you start {#before-you-start}
 
 - `remotes::install_github("thecartercenter/erifunctions")`.
-- **Azure access** for the upload / stage / approve steps (zero-config browser sign-in — see the
-  [connections guide](connections-guide.html)). The **parsing** step (`eri_ingest_cmr()`) is offline —
+- **Azure access** for the upload / stage / approve steps (zero-config browser sign-in, see the
+  [connections guide](connections-guide.html)). The **parsing** step (`eri_ingest_cmr()`) is offline,
   it just reads a local Excel file.
 
 ```{r library}
@@ -53,7 +53,7 @@ library(erifunctions)
 ```
 
 > **A note on the examples below.** The upload, stage, and approve steps run against the live Azure
-> `projects`/`data` blobs and real, registered countries — so the outputs for those are shown as
+> `projects`/`data` blobs and real, registered countries, so the outputs for those are shown as
 > illustrations rather than run here. Unlike the surveillance and ODK guides, there is **no
 > throwaway-sandbox path** for stage/approve: `eri_stage_cmr()` only accepts a registered RB-expansion
 > country (it rejects a made-up one). The **parsing** step *is* run for real on a small **synthetic**
@@ -69,7 +69,7 @@ projects: health-rb-country-expansion-dev/raw/filled_templates/{country}/{period
 e.g.      …/raw/filled_templates/uga/202406/uga_cmr_2024_06.xlsx
 ```
 
-Do this from R with `eri_upload()` — it keeps the whole monthly run in one place and one tool. (If a
+Do this from R with `eri_upload()`, it keeps the whole monthly run in one place and one tool. (If a
 file already arrived via Azure Storage Explorer or SharePoint, that's fine too; you can skip ahead to
 staging.) Connect to the `projects` blob and upload the file to that path:
 
@@ -87,13 +87,13 @@ eri_upload(
 
 ### What the template looks like
 
-Every CMR sheet has the same shape — a few rows of human-readable headers, then the **field-code row**,
+Every CMR sheet has the same shape, a few rows of human-readable headers, then the **field-code row**,
 then the data:
 
 | Excel row | Contents |
 |---|---|
 | 1–4 | Title, group headers, human-readable column names |
-| **5** | **`#field codes`** (e.g. `#rbtrt_year`, `#rbtrt_adm1`, `#rbtrt_treated`) — the parsing anchor |
+| **5** | **`#field codes`** (e.g. `#rbtrt_year`, `#rbtrt_adm1`, `#rbtrt_treated`), the parsing anchor |
 | 6+ | The monthly numbers |
 
 That row 5 is what makes the whole thing work, as you'll see in §3.
@@ -121,19 +121,19 @@ eri_stage_cmr("uga")
 #> …
 ```
 
-(CMR data lives under the `rblf` disease folder — RB for onchocerciasis, LF for lymphatic filariasis,
-the two programmes these reports cover. Only the registered RB-expansion countries —
-`eth`, `nga`, `sdn`, `ssd`, `uga`, `mad`, `tcd` — can be staged.)
+(CMR data lives under the `rblf` disease folder, RB for onchocerciasis, LF for lymphatic filariasis,
+the two programmes these reports cover. Only the registered RB-expansion countries,
+`eth`, `nga`, `sdn`, `ssd`, `uga`, `mad`, `tcd`, can be staged.)
 
-> **Heads-up on the `rblf` coordinate.** CMR always uses `disease = "rblf"` — the combined RB + LF
-> programme code — so the paths are `{country}/rblf/cmr/…` and you approve with
+> **Heads-up on the `rblf` coordinate.** CMR always uses `disease = "rblf"`, the combined RB + LF
+> programme code, so the paths are `{country}/rblf/cmr/…` and you approve with
 > `eri_approve(country, "rblf", "cmr", period)`. Scaffolding a new country's CMR with
 > `eri_onboard_cmr(create_dirs = TRUE)` creates those same `{country}/rblf/cmr/` folders.
 >
 > **From `rblf`/`cmr` to per-disease.** `rblf`/`cmr` were interim coordinates: under the
 > [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
 > CMR is a *format* of the `programmatic` channel, and [`eri_split_cmr()`](#split) (below) routes each
-> sheet to its own disease and measure — e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`.
+> sheet to its own disease and measure, e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`.
 > You then approve **each disease/measure**, not one combined `rblf`/`cmr` bucket.
 
 ## 3. Parse each sheet {#parse}
@@ -152,13 +152,13 @@ names(schema$sheets)
 #> [13] "RB Epi Surveys"                "RB Ento Surveys"
 ```
 
-(A real monthly file has many sheets — treatments, MMDP, the various trainings, and surveys. The
+(A real monthly file has many sheets, treatments, MMDP, the various trainings, and surveys. The
 bundled `cmr-example.xlsx` below is a small **two-sheet** subset, `RB Treatment` + `SCH Treatment`, so
 you can run the parse and split offline.)
 
 Then read a sheet with [`eri_ingest_cmr()`](../reference/eri_ingest_cmr.html). It reads from **row 5**
-(the field codes), keeps only the `#`-coded columns, drops the template's blank spacer rows, and — when
-you pass `country` — tags each row with it. (We use the package's bundled synthetic example here;
+(the field codes), keeps only the `#`-coded columns, drops the template's blank spacer rows, and, when
+you pass `country`, tags each row with it. (We use the package's bundled synthetic example here;
 in real work you'd point at your staged file.)
 
 ```{r ingest-rb}
@@ -183,12 +183,12 @@ sch <- eri_ingest_cmr(report, sheet = "SCH Treatment", country = "uga")
 #> ✔ CMR sheet "SCH Treatment": 2 data rows, 6 field codes.
 ```
 
-The column names *are* the field codes — stable identifiers you can rely on across every monthly file.
+The column names *are* the field codes, stable identifiers you can rely on across every monthly file.
 This is the moment to eyeball the numbers (treated vs target, missing districts) before you sign off.
 
 > **Same codes, any language.** The field codes (`#rbtrt_…`) are language-neutral, so the *same*
 > `eri_ingest_cmr()` parses a French template too. For a French file, the sheet is named in French
-> (e.g. `"Oncho Traitement"`) — pass the **canonical slug** and the country, and the schema's
+> (e.g. `"Oncho Traitement"`), pass the **canonical slug** and the country, and the schema's
 > `sheet_aliases` resolves it:
 >
 > ```r
@@ -200,10 +200,10 @@ This is the moment to eyeball the numbers (treated vs target, missing districts)
 
 The sheets are per-programme, but the canonical store is **per-disease**.
 [`eri_split_cmr()`](../reference/eri_split_cmr.html) reads every routable sheet and routes its rows to
-`{country}/{disease}/programmatic/{measure}/staged/` — the **disease from the sheet** (RB Treatment →
+`{country}/{disease}/programmatic/{measure}/staged/`: the **disease from the sheet** (RB Treatment →
 `oncho`, SCH Treatment → `sch`, LF MMDP → `lf`), the **measure from its category**. It reads the Excel
 **directly** (here the bundled example; in real work the file you uploaded), independently of the
-`rblf/cmr/staged/` copy `eri_stage_cmr()` made — that copy is the raw archive; this is the parse + route.
+`rblf/cmr/staged/` copy `eri_stage_cmr()` made, that copy is the raw archive; this is the parse + route.
 Preview the routing first with `dry_run`:
 
 ```{r split-dry}
@@ -218,17 +218,17 @@ eri_split_cmr(report, "uga", dry_run = TRUE)
 #> # ... (the example has only the two treatment sheets; a real file routes them all)
 ```
 
-A sheet the schema routes but the workbook doesn't contain is **skipped with a warning** — expected
+A sheet the schema routes but the workbook doesn't contain is **skipped with a warning**, expected
 here, since the example is a two-sheet subset. (If *none* of the routable sheets are present,
 `eri_split_cmr()` errors instead of silently doing nothing.)
 
 > **Why the sheet, not the row?** Each sheet carries a per-row `#…_disease` field whose values are
-> *programme-coverage* codes (`RB` / `RBLF` / `RBLFSCH` — which programmes run at that location), **not**
+> *programme-coverage* codes (`RB` / `RBLF` / `RBLFSCH`, which programmes run at that location), **not**
 > a single disease. `eri_split_cmr()` keeps that field as a data column and takes the routing disease
 > from the sheet, so the same treatment numbers are **never duplicated** across diseases. Cross-programme
 > **Training** sheets, which serve all programmes at once, route together under the combined `rblf` disease.
 
-Then stage for real — one parquet per sheet, in its disease/measure folder:
+Then stage for real, one parquet per sheet, in its disease/measure folder:
 
 ```{r split-real}
 eri_split_cmr(report, "uga")
@@ -241,7 +241,7 @@ eri_split_cmr(report, "uga")
 
 ## 5. Approve each disease/measure {#approve}
 
-Each split dataset passes through the same human gate — once per disease/measure:
+Each split dataset passes through the same human gate, once per disease/measure:
 
 ```{r approve}
 eri_approve("uga", "oncho", "programmatic", "202406", data_type = "treatment")
@@ -271,16 +271,16 @@ That's the monthly loop: **upload → stage → split → approve.**
 ## What's next
 
 - **A new country files its first report?** Its CMR schema (which sheets, which field codes) has to
-  exist first — see the CMR section of the [onboarding guide](da-onboard-guide.html)
+  exist first, see the CMR section of the [onboarding guide](da-onboard-guide.html)
   (`eri_onboard_cmr()`).
 - **`eri_split_cmr()` says "No routable sheets"?** A sheet only routes when its schema entry declares a
   `disease` and a `data_type`. `uga` is the worked example; other countries' routing keys are being
-  filled in — add them to the country's `inst/schemas/cmr/{code}.yaml` (one `disease` + `data_type` per
+  filled in, add them to the country's `inst/schemas/cmr/{code}.yaml` (one `disease` + `data_type` per
   sheet) to enable the split there.
 - The [surveillance ingest guide](da-ingest-guide.html) covers the same `raw → staged → approved` gate
   for line-list data, and the data-catalog mechanics in more depth.
 
-> **Real reports are not practice data.** The monthly CMR files are protected country data — staged and
+> **Real reports are not practice data.** The monthly CMR files are protected country data, staged and
 > approved through this pipeline, never deleted or moved casually. (The example here is synthetic, which
 > is the only reason we could pass it around freely.)
 

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -16,26 +16,26 @@ knitr::opts_chunk$set(
 ```
 
 This is a hands-on, **start-to-finish walkthrough** of getting a surveillance dataset into the
-Carter Center data system — the daily work of a **Data Analyst (DA)**. It is written for domain
+Carter Center data system, the daily work of a **Data Analyst (DA)**. It is written for domain
 experts who are *not* software developers. Work through it once, in order, and you will have done
 every step a real dataset needs: store the raw file, quality-check it, stage it, and **approve** it
 so the rest of the team can trust it.
 
-So you can practise the whole thing safely, we will invent a **make-believe country** — *Atlantis* —
+So you can practise the whole thing safely, we will invent a **make-believe country**, *Atlantis*,
 and make up some malaria surveillance data for it. Nothing here touches real country data, and the
-very last section — [**Clean up**](#clean-up) — deletes everything you created, so you can run the
+very last section, [**Clean up**](#clean-up), deletes everything you created, so you can run the
 full loop end-to-end and leave no trace.
 
 > **You can run this for real.** Every command below works against the live Azure system. Because
 > *Atlantis* is a sandbox of your own, you can ingest, break, fix, and approve data without
-> affecting anyone — then wipe it.
+> affecting anyone, then wipe it.
 
 ## The golden rule
 
 > **Data moves through three layers, and nothing becomes official without your sign-off.** Every
 > dataset travels `raw/` &rarr; `staged/` &rarr; `processed/`. `raw/` is the file exactly as it
 > arrived. `staged/` is the cleaned, quality-checked version awaiting review. `processed/` is the
-> **canonical data the whole team builds on** — and a file only gets there when *you* call
+> **canonical data the whole team builds on**, and a file only gets there when *you* call
 > [`eri_approve()`](../reference/eri_approve.html). That approval is the human gate.
 
 ```{=html}
@@ -64,10 +64,10 @@ You need two things, once:
 
 **Azure access** needs no configuration. The first time a command needs Azure, your browser opens
 and you sign in with your Carter Center account; the sign-in is remembered for the rest of the
-session. (No keys, no environment variables — see `?get_azure_storage_connection`.)
+session. (No keys, no environment variables, see `?get_azure_storage_connection`.)
 
 `erifunctions` narrates what it is doing. Load it and leave the verbosity at its default `"full"`
-for this walkthrough — that is the step-by-step output shown in the blocks below:
+for this walkthrough, that is the step-by-step output shown in the blocks below:
 
 ```{r verbosity}
 library(erifunctions)
@@ -81,7 +81,7 @@ library(erifunctions)
 
 The surveillance pipeline lives in the **`data` blob**. The reading and writing functions
 (`eri_read()`, `eri_write()`, `eri_upload()`) talk to your *default* connection, so we make one
-pointed at `data` and pass it explicitly everywhere below — that way every step targets the right
+pointed at `data` and pass it explicitly everywhere below, that way every step targets the right
 place:
 
 ```{r connect}
@@ -89,11 +89,11 @@ data_con <- get_azure_storage_connection(storage_name = "data")
 ```
 
 Every dataset is identified by five coordinates ([ADR-0012](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md)):
-**country**, **disease**, **data_source** (the *channel* — how the data arrives), **data_type** (the
-*measure* — what it captures), and **layer**. The key idea is that the channel is **separate** from the
+**country**, **disease**, **data_source** (the *channel*, how the data arrives), **data_type** (the
+*measure*, what it captures), and **layer**. The key idea is that the channel is **separate** from the
 measure: `surveillance` data can be a `case` line-list in one country and an `aggregate` weekly count in
-another. Our extract is a line-list — one row per case — so its measure is `case`. Never hand-type the
-folder paths — let [`eri_data_path()`](../reference/eri_data_path.html) build the canonical path for
+another. Our extract is a line-list, one row per case, so its measure is `case`. Never hand-type the
+folder paths, let [`eri_data_path()`](../reference/eri_data_path.html) build the canonical path for
 you, so every step agrees on where things go:
 
 ```{r data-path}
@@ -110,8 +110,8 @@ eri_data_path(country, disease, data_source, data_type, "staged")
 #> [1] "atlantis/malaria/surveillance/case/staged"
 ```
 
-`data_source` and `data_type` are **extensible** — `eri_data_model()` lists the known values, and an
-unregistered one *warns* rather than blocks — while `layer` is one of `"raw"`, `"staged"`,
+`data_source` and `data_type` are **extensible**, `eri_data_model()` lists the known values, and an
+unregistered one *warns* rather than blocks, while `layer` is one of `"raw"`, `"staged"`,
 `"processed"`. **Country and disease are free text**, which is exactly why we can stand up an *atlantis*
 sandbox next to the real countries without disturbing them.
 
@@ -125,7 +125,7 @@ eri_dir_create(eri_data_path(country, disease, data_source, data_type, "staged")
 
 ## 2. Simulate an as-received extract and store it in `raw/` {#raw}
 
-In real life a surveillance officer emails you a spreadsheet. Here we *make one up* — a tiny
+In real life a surveillance officer emails you a spreadsheet. Here we *make one up*, a tiny
 line-list of malaria cases, one row per case. Notice it is deliberately a little messy, the way real
 data always is: some sex values are in Spanish (`Masculino`/`Femenino`/`M`), and a couple of
 district names are mis-cased or use an old spelling (`coralia`, `Nerei City`):
@@ -153,24 +153,24 @@ raw_path1 <- eri_data_path(country, disease, data_source, data_type, "raw",
 eri_write(extract1, raw_path1, azcontainer = data_con)
 ```
 
-`raw/` is your archive of the source. From here on we work toward `staged/` — but the original is
+`raw/` is your archive of the source. From here on we work toward `staged/`, but the original is
 safe if you ever need to start over.
 
 ## 3. Author a data-quality schema {#schema}
 
 How does `erifunctions` know that `Masculino` should become `Male`, or that `Age` cannot be 250? You
-tell it, once, in a **DQ schema** — a small YAML file describing each column: its type, its allowed
+tell it, once, in a **DQ schema**, a small YAML file describing each column: its type, its allowed
 range or allowed values, known fixes, and translations. The schema is the contract every future
 extract for this dataset is checked against.
 
 Open a text editor and save the following as **`atlantis_malaria_surveillance_case.yaml`** in your
-working directory — the filename is the four-part identity `{country}_{disease}_{data_source}_{data_type}`,
-which is how `load_dq_schema()` finds it. (It is intentionally short — a real schema like
+working directory, the filename is the four-part identity `{country}_{disease}_{data_source}_{data_type}`,
+which is how `load_dq_schema()` finds it. (It is intentionally short, a real schema like
 `dr_malaria_surveillance_case.yaml` has more columns, but the *shape* is exactly this.)
 
 > **One source, many measures.** If you stood up this space with the
 > [onboarding guide](da-onboard-guide.html), its scaffold defaults to the **`aggregate`** measure
-> (weekly counts) — `atlantis_malaria_surveillance_aggregate.yaml`. Our extract here is a line-list, so
+> (weekly counts), `atlantis_malaria_surveillance_aggregate.yaml`. Our extract here is a line-list, so
 > we author the **`case`** measure alongside it. That is the whole point of separating the channel from
 > the measure: the same `surveillance` source can hold both `case` and `aggregate` data. Run
 > `eri_data_model()` any time to see the known measures.
@@ -232,7 +232,7 @@ columns:
     range: [0, 120]
 ```
 
-Read it slowly — each block is a rule:
+Read it slowly, each block is a rule:
 
 | Block | What it does | DQ result |
 |---|---|---|
@@ -256,7 +256,7 @@ eri_upload("atlantis_malaria_surveillance_case.yaml",
 ## 4. Run the data-quality checks {#dq}
 
 Load your raw file back from `raw/`, load the schema, and run the checks. `run_dq_checks()` applies
-every rule in the schema and hands back the cleaned data plus two ledgers — what it *fixed*, and
+every rule in the schema and hands back the cleaned data plus two ledgers, what it *fixed*, and
 what it wants *you* to look at:
 
 ```{r dq1}
@@ -282,7 +282,7 @@ result1
 #> ✔ No flags.
 ```
 
-Six things were fixed automatically and **nothing needs your review** — a clean extract. You can
+Six things were fixed automatically and **nothing needs your review**, a clean extract. You can
 always see exactly *what* was changed in the `$log` ledger:
 
 ```{r dq1-log}
@@ -298,13 +298,13 @@ result1$log
 #> 6     6 District Nerei City     Nerei           correction  corrected
 ```
 
-The cleaned data lives in `result1$data` — Spanish sexes mapped to `Male`/`Female`, district names
+The cleaned data lives in `result1$data`, Spanish sexes mapped to `Male`/`Female`, district names
 canonicalised. **That** is what we stage.
 
 ## 5. Write the cleaned data to `staged/` {#stage}
 
 `staged/` holds DQ-checked data that is awaiting your approval. We store it as **parquet** (compact,
-typed, fast). Give the file a name that contains the reporting period — you will use that period to
+typed, fast). Give the file a name that contains the reporting period, you will use that period to
 approve it in the next step:
 
 ```{r stage1}
@@ -337,7 +337,7 @@ eri_approve(country, disease, data_source, "2024-01", data_type = data_type, azc
 ```
 
 Passing `data_type` records the **measure** on the catalog entry. (Omit it and `eri_approve()` files the
-data at the channel level with `data_type = NA`, and says so once — fine for channel-only data, but here
+data at the channel level with `data_type = NA`, and says so once, fine for channel-only data, but here
 our line-list is `case`.)
 
 The catalog is the team's index of canonical data. Confirm your dataset is now in it:
@@ -361,7 +361,7 @@ nrow(official)   # 10 approved cases
 
 That is the whole loop: **raw &rarr; DQ &rarr; staged &rarr; approved.**
 
-## 7. A second extract arrives — this time with errors {#second-extract}
+## 7. A second extract arrives, this time with errors {#second-extract}
 
 The next reporting file lands, and real data is rarely clean. This one has two genuine problems an
 analyst must judge: an `Age` of **250** (impossible), and a district **`Atlantica`** that is not one
@@ -407,7 +407,7 @@ result2
 ```
 
 This time there are **two flags**. The schema fixed what it safely could, but it will not guess about
-an age of 250 or an unknown district — those are *your* call. Look at exactly which rows:
+an age of 250 or an unknown district, those are *your* call. Look at exactly which rows:
 
 ```{r dq2-flags}
 result2$flags
@@ -432,7 +432,7 @@ result2b <- run_dq_checks(fixed, schema)
 ```
 
 > **Why not just edit the schema?** If `Atlantica` were a *real* new district, the right fix is to
-> add it to `allowed_values` and re-upload the schema — then every future extract accepts it. Use a
+> add it to `allowed_values` and re-upload the schema, then every future extract accepts it. Use a
 > correction/translation for genuine fixes; use a flag-then-edit only for one-off data errors like
 > the impossible age.
 
@@ -457,7 +457,7 @@ You now have **two approved periods** in the catalog for *atlantis*, each with i
 recording that you signed off and when.
 
 > **Going further: cross-period anomalies.** Range and allowed-value checks catch bad *cells*. To
-> catch a suspicious *trend* — a district whose case count suddenly triples — see
+> catch a suspicious *trend*, a district whose case count suddenly triples, see
 > [`add_anomaly_pct_change()`](../reference/add_anomaly_pct_change.html), which you can chain onto a
 > `run_dq_checks()` result once you have several periods stacked together.
 
@@ -494,25 +494,25 @@ unlink("atlantis_malaria_surveillance_case.yaml")   # the local schema file
 ```
 
 > **Why we could delete freely here:** *Atlantis* is invented and its data is fake. **Real Carter
-> Center surveillance data is different** — approved country data must never be deleted casually,
-> copied off Azure, or committed to git. The discipline this guide builds — raw kept untouched, DQ
-> before staging, and a human approval gate before anything becomes canonical — is exactly what keeps
+> Center surveillance data is different**, approved country data must never be deleted casually,
+> copied off Azure, or committed to git. The discipline this guide builds, raw kept untouched, DQ
+> before staging, and a human approval gate before anything becomes canonical, is exactly what keeps
 > protected data trustworthy. When in doubt, ask before you delete.
 
 ## What's next
 
 You have now done the full DA ingest loop: store raw, quality-check against a schema, fix what only a
-human can, stage, and **approve** into the canonical layer — twice, including a messy extract.
+human can, stage, and **approve** into the canonical layer, twice, including a messy extract.
 
-One call — [`eri_ingest()`](../reference/eri_ingest.html) — does the read-and-DQ-and-stage steps
+One call, [`eri_ingest()`](../reference/eri_ingest.html), does the read-and-DQ-and-stage steps
 (§2, §4, §5) in a single shot, on **any** data including the sandbox you just built (it takes the same
 `country` / `disease` / `data_source` / `data_type` you have been using). We did each step by hand here
 so you could *see* every layer; once you are comfortable, `eri_ingest()` is the fast path, and
-`eri_approve()` — your sign-off — is always the same human gate at the end. *(For the legacy `hsp-mal`
-cutover, passing `mirror_pipeline = "hsp-mal"` also mirrors the output to the old `projects` blob — off
+`eri_approve()`: your sign-off, is always the same human gate at the end. *(For the legacy `hsp-mal`
+cutover, passing `mirror_pipeline = "hsp-mal"` also mirrors the output to the old `projects` blob, off
 by default.)*
 
-This is one of a planned set of short, task-oriented guides — **one for each common job** an analyst
+This is one of a planned set of short, task-oriented guides, **one for each common job** an analyst
 or epidemiologist does. See [the guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md)
 for what exists today and what is coming, and the [reference](../reference/index.html) for the full
 menu of functions grouped by purpose.

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -15,13 +15,13 @@ knitr::opts_chunk$set(
 )
 ```
 
-Every operation `erifunctions` runs — an ingest, an approval, an ODK sync — **leaves a log** in
+Every operation `erifunctions` runs, an ingest, an approval, an ODK sync, **leaves a log** in
 Azure. When something fails, or a data-quality check raises issues, that log is the record. This guide
 is for a **Data Analyst** working the **backlog**: finding what failed or needs review with
 [`eri_logs()`](../reference/eri_logs.html), and closing items out with
 [`eri_logs_resolve()`](../reference/eri_logs_resolve.html).
 
-Because the logs live in Azure, the backlog is **shared** — if a teammate is out, you can run
+Because the logs live in Azure, the backlog is **shared**, if a teammate is out, you can run
 `eri_logs()`, see exactly what broke, and pick up where they left off. We will practise on the
 **`atlantis`** sandbox from the [ingest](da-ingest-guide.html) and [onboarding](da-onboard-guide.html)
 guides.
@@ -31,7 +31,7 @@ guides.
 > **Nothing fails silently, and nothing stays open by accident.** Operations write structured logs as
 > they go; data-quality flags are persisted with [`eri_dq_log()`](../reference/eri_dq_log.html) (and
 > `eri_ingest()` does it for you). `eri_logs()` turns that pile into a triage list, and
-> `eri_logs_resolve()` marks an item handled — with *who* handled it and *when* — so it drops off the
+> `eri_logs_resolve()` marks an item handled, with *who* handled it and *when*, so it drops off the
 > open backlog without ever erasing the record.
 
 ```{=html}
@@ -39,9 +39,9 @@ guides.
 flowchart TD
     A["An operation runs (ingest / approve / sync)"] --> B["Writes a log to …/logs/"]
     C["run_dq_checks() flags issues"] --> D["eri_dq_log() persists them"]
-    B --> E["eri_logs() — the backlog"]
+    B --> E["eri_logs(), the backlog"]
     D --> E
-    E --> F["eri_logs_resolve() — mark handled"]
+    E --> F["eri_logs_resolve(), mark handled"]
     F --> G["Drops off the open backlog (record kept)"]
 </div>
 ```
@@ -58,12 +58,12 @@ library(erifunctions)
 ## 1. Where logs come from {#sources}
 
 Two kinds of log end up in `{country}/{disease}/{data_source}/[{data_type}/]logs/` (the measure level
-is present when the data was approved with one — `eri_logs()` reads both layouts):
+is present when the data was approved with one, `eri_logs()` reads both layouts):
 
-- **Operation logs** — written automatically by `eri_ingest()`, `eri_approve()`, `eri_stage()`,
-  `eri_odk_sync()`, and friends. Each records the operation, who ran it, its parameters, and — if it
-  failed — the **error**.
-- **Data-quality logs** — the `$flags` from [`run_dq_checks()`](../reference/run_dq_checks.html) are
+- **Operation logs**: written automatically by `eri_ingest()`, `eri_approve()`, `eri_stage()`,
+  `eri_odk_sync()`, and friends. Each records the operation, who ran it, its parameters, and, if it
+  failed, the **error**.
+- **Data-quality logs**: the `$flags` from [`run_dq_checks()`](../reference/run_dq_checks.html) are
   only in your R session until you persist them. `eri_dq_log()` writes them to the same place (and
   `eri_ingest()` calls it automatically), so a data-quality issue someone hit last month is still
   discoverable today.
@@ -86,7 +86,7 @@ eri_dq_log(result, "atlantis", "malaria", "surveillance", data_type = "case", pe
 
 ### Cause a failure
 
-Now a common slip: you try to approve a period before the file is staged. It errors — **and leaves an
+Now a common slip: you try to approve a period before the file is staged. It errors, **and leaves an
 error log** behind:
 
 ```{r approve-fail}
@@ -110,7 +110,7 @@ eri_logs("atlantis", "malaria", "surveillance")
 #> 2 2026-06-26T09:30:00Z dq_flags    needs_review 2024-01 2 flags           da.one
 ```
 
-(The tibble also carries `log_path`, `n_issues`, and the `handled*` columns — shown trimmed here.)
+(The tibble also carries `log_path`, `n_issues`, and the `handled*` columns, shown trimmed here.)
 Filter to just the failures:
 
 ```{r logs-error}
@@ -130,7 +130,7 @@ out scans the whole data blob for a **system-wide backlog** (scoping is faster).
 ## 3. Resolve an item {#resolve}
 
 You investigate the failure, stage the file, and re-approve it successfully. Now close out the original
-error so it leaves the open backlog — with a note for whoever reads it next:
+error so it leaves the open backlog, with a note for whoever reads it next:
 
 ```{r resolve}
 backlog <- eri_logs("atlantis", "malaria", "surveillance", status = "error")
@@ -142,7 +142,7 @@ eri_logs_resolve(
 #> ✔ Marked 20260626_100000_eri_approve_2024-02.yaml handled.
 ```
 
-Re-list, and the error is gone from the open backlog — only the data-quality item remains:
+Re-list, and the error is gone from the open backlog, only the data-quality item remains:
 
 ```{r relist}
 eri_logs("atlantis", "malaria", "surveillance")
@@ -153,7 +153,7 @@ eri_logs("atlantis", "malaria", "surveillance")
 #> 1 dq_flags  needs_review 2024-01 2 flags
 ```
 
-Resolving never deletes the log — it adds a `triage` record. Pass `include_handled = TRUE` to see the
+Resolving never deletes the log, it adds a `triage` record. Pass `include_handled = TRUE` to see the
 closed item, with who handled it and your note:
 
 ```{r include-handled}
@@ -167,7 +167,7 @@ eri_logs("atlantis", "malaria", "surveillance",
 
 ## 4. When a teammate steps in {#teammate}
 
-This is the point of a *shared* backlog. The logs live in Azure, not on anyone's laptop — so when an
+This is the point of a *shared* backlog. The logs live in Azure, not on anyone's laptop, so when an
 analyst is away and something needs attention, a colleague can run one command to see the whole
 picture:
 
@@ -176,7 +176,7 @@ picture:
 eri_logs(status = "error")
 ```
 
-They see the same failures, the same error messages, and — for anything already handled — *who* dealt
+They see the same failures, the same error messages, and, for anything already handled, *who* dealt
 with it and the note they left. No "what was going on with the DR upload last week?" guesswork.
 
 ## 5. Clean up {#clean-up}
@@ -195,11 +195,11 @@ eri_dir_delete("atlantis", azcontainer = con)
 
 ## What's next
 
-You can now find, filter, and close out the error/data-quality backlog — solo or covering for a
+You can now find, filter, and close out the error/data-quality backlog, solo or covering for a
 teammate. The logs you are reading are written by the workflows in the other guides:
 
-- [Ingesting a surveillance dataset](da-ingest-guide.html) — where DQ flags and approval logs come from.
-- [Working with ODK Central](da-odk-guide.html) — sync logs.
+- [Ingesting a surveillance dataset](da-ingest-guide.html): where DQ flags and approval logs come from.
+- [Working with ODK Central](da-odk-guide.html): sync logs.
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) and the
 **Logs & triage** group in the [reference](../reference/index.html).

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -15,32 +15,32 @@ knitr::opts_chunk$set(
 )
 ```
 
-**ODK Central** is where field data is born — survey teams collect submissions on phones, and they
+**ODK Central** is where field data is born, survey teams collect submissions on phones, and they
 land on an ODK Central server. This is a hands-on walkthrough for a **Data Analyst (DA)** of the whole
 loop: connect to ODK Central, stand up a form, **monitor** it, **manage** who collects on it, and
 **pull** its submissions into the governed Carter Center data system.
 
 So you can practise safely, you will create a **make-believe form** in a sandbox **`test` project** on
-your ODK Central server, submit a few fake records, and work the loop end-to-end — then the final
+your ODK Central server, submit a few fake records, and work the loop end-to-end, then the final
 [**Clean up**](#clean-up) section removes everything you created.
 
 > **What you need to follow along.** Unlike the other guides, this one talks to a live **ODK Central**
 > server, so you need an ODK Central account and access to a project you can experiment in. If you do
-> not, read along — the steps are the same against any server.
+> not, read along; the steps are the same against any server.
 
 ## The golden rule
 
 > **ODK Central is the front door; `erifunctions` brings the data through it into one governed
 > pipeline.** You **register** a form (the registry is the team's record of which forms are tracked),
 > **sync** its submissions into `{country}/{disease}/research/raw/`, and from there it flows through the
-> same `raw → staged → processed` lifecycle — with [`eri_approve()`](../reference/eri_approve.html) as
-> the human gate — as every other dataset.
+> same `raw → staged → processed` lifecycle, with [`eri_approve()`](../reference/eri_approve.html) as
+> the human gate, as every other dataset.
 >
 > **Where ODK lands.** Under the
 > [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
 > ODK is the **`research`** channel's collection *format* (`format: odk`), so `eri_odk_sync()` writes to
 > the `research` source. Its measure (`tas`, `prevalence`, …) is **optional** and assigned later, when
-> you clean the form into a final dataset — which is why these paths carry no measure level yet.
+> you clean the form into a final dataset, which is why these paths carry no measure level yet.
 
 ```{=html}
 <div class="mermaid">
@@ -71,11 +71,11 @@ flowchart TD
    ODK_USER=you@example.org
    ODK_PASS=your-password
    ```
-   Everything below reads these automatically — you never type your password into a script.
+   Everything below reads these automatically, you never type your password into a script.
 4. **Azure access** is zero-config: the first command that needs it opens your browser to sign in
    (see `?get_azure_storage_connection`).
 
-One comfort setting — leave verbosity at its default `"full"` for this walkthrough (that is the
+One comfort setting, leave verbosity at its default `"full"` for this walkthrough (that is the
 step-by-step output shown below):
 
 ```{r verbosity}
@@ -83,15 +83,15 @@ library(erifunctions)
 # eri_verbosity("quiet")   # later, to trim to headlines + warnings only
 ```
 
-## 1. Begin — create your practice form {#begin}
+## 1. Begin, create your practice form {#begin}
 
-> **Heads up — this first step happens in your browser, not in R.** Creating the `test` project,
+> **Heads up, this first step happens in your browser, not in R.** Creating the `test` project,
 > uploading the form, and submitting practice entries are all done in the ODK Central **web
 > interface**. `erifunctions` takes over from *Connect* (below) once there is data on the server.
 
 ### Put a form on the server
 
-The package ships a tiny practice form — a mock vector-surveillance "river prospection" survey. Find
+The package ships a tiny practice form, a mock vector-surveillance "river prospection" survey. Find
 it on your machine and upload it to a **`test`** project in ODK Central:
 
 ```{r form-path}
@@ -132,7 +132,7 @@ list_odk_forms(con = con, project_id = 11)
 #> # A tibble: 1 × 2
 #>   xmlFormId                  name
 #>   <chr>                      <chr>
-#> 1 eri_test_river_prospection ERI Test — River Prospection
+#> 1 eri_test_river_prospection ERI Test, River Prospection
 ```
 
 So our sandbox is **project `11`**, form **`eri_test_river_prospection`**. Keep those handy:
@@ -146,7 +146,7 @@ form_id    <- "eri_test_river_prospection"
 
 ### Monitor submissions
 
-`eri_survey_status()` is your at-a-glance health check — how many submissions, the most recent one,
+`eri_survey_status()` is your at-a-glance health check: how many submissions, the most recent one,
 and recent activity:
 
 ```{r status}
@@ -155,22 +155,22 @@ eri_survey_status(project_id = project_id, form_id = form_id, con = con)
 #> • eri_test_river_prospection [open] - 3 total, last: 2026-06-25T19:57:33.690Z
 ```
 
-It prints a one-line summary, but it is really a tibble — store it to see the full metrics (7- and
+It prints a one-line summary, but it is really a tibble, store it to see the full metrics (7- and
 30-day counts, open/closed state):
 
 ```{r status-tibble}
 st <- eri_survey_status(project_id = project_id, form_id = form_id, con = con)
 as.data.frame(st)
 #>   project_id project_name                    form_id                    form_name           server_url status total_submissions   last_submission_at submissions_7d submissions_30d
-#> 1         11      testing eri_test_river_prospection ERI Test — River Prospection https://your-odk… open                 3 2026-06-25T19:57:33.690Z              3               3
+#> 1         11      testing eri_test_river_prospection ERI Test, River Prospection https://your-odk… open                 3 2026-06-25T19:57:33.690Z              3               3
 ```
 
 Called with just `project_id` it reports **every** form in the project; with neither argument, every
-form on every project you can see — handy for a Monday-morning sweep across all your surveys.
+form on every project you can see, handy for a Monday-morning sweep across all your surveys.
 
 ### Manage who collects: app users
 
-Field staff collect through **app users** — per-project data-collection accounts. You can create one
+Field staff collect through **app users**, per-project data-collection accounts. You can create one
 and assign it to a form straight from R. (These calls change your live project; we remove the demo
 user in [Clean up](#clean-up).)
 
@@ -204,7 +204,7 @@ update_odk_app_user_role(
 #> [1] TRUE
 ```
 
-Check the form's assignments — your new collector should be listed:
+Check the form's assignments, your new collector should be listed:
 
 ```{r list-form-users}
 list_odk_form_users(con = con, project_id = project_id, form_id = form_id)
@@ -215,7 +215,7 @@ list_odk_form_users(con = con, project_id = project_id, form_id = form_id)
 #> 2     250      2
 ```
 
-Each row pairs an `actorId` (an app user) with the `roleId` it holds on this form — your new collector
+Each row pairs an `actorId` (an app user) with the `roleId` it holds on this form, your new collector
 (`actorId 250`, `roleId 2` = ODK's App User role) is now listed alongside anyone already assigned.
 
 ### Managing a whole team at once
@@ -223,7 +223,7 @@ Each row pairs an `actorId` (an app user) with the `roleId` it holds on this for
 Don't click through 40 collectors one at a time. Put the actions in a CSV with columns
 `project_id, form_id, action, actor_name` (action is `create`, `assign`, or `remove`) and hand it to
 [`eri_odk_bulk_users()`](../reference/eri_odk_bulk_users.html). Always run it once with
-`dry_run = TRUE` first — it validates **every** row against the live server and reports *all* problems
+`dry_run = TRUE` first, it validates **every** row against the live server and reports *all* problems
 together before changing anything:
 
 ```{r bulk-dry}
@@ -238,17 +238,17 @@ eri_odk_bulk_users("collectors.csv", con = con, dry_run = TRUE)
 ## 3. Pull the data into the governed pipeline {#pull}
 
 This is where ODK meets the rest of the system. We use a sandbox **country/disease** so it is easy to
-clean up: `country = "uga"`, `disease = "demo"`. (ODK registration requires a real ERI country code —
-`uga`, `ht`, `eth`, … — but the disease is free text, so `demo` keeps this clearly a practice run.)
+clean up: `country = "uga"`, `disease = "demo"`. (ODK registration requires a real ERI country code,
+`uga`, `ht`, `eth`, …, but the disease is free text, so `demo` keeps this clearly a practice run.)
 
 ### Register the form
 
-Registering records the form in the shared **ODK registry** (`odk/registry.yaml`) — the team's single
+Registering records the form in the shared **ODK registry** (`odk/registry.yaml`), the team's single
 source of truth for which forms are tracked, and which country/disease each one feeds.
 
 > **The registry is shared and team-visible.** Your registration lands in the **same** `odk/registry.yaml`
 > as everyone's real forms. For a real form, [Clean up](#clean-up)'s `eri_odk_deregister()` is a
-> **soft-delete** (`active: false`) that preserves the audit trail — so a practice entry would linger
+> **soft-delete** (`active: false`) that preserves the audit trail, so a practice entry would linger
 > (inactive) rather than vanishing. For **sandbox** work, use an obviously-fake `project_id`/`country`,
 > and tear the entry down completely with `eri_odk_purge()` (a hard-delete) so no practice rows are left
 > behind in the shared registry.
@@ -271,8 +271,8 @@ eri_odk_list_registered(data_con = data_con)
 #> # A tibble: 5 × 9
 #>   server_url               project_id form_id                    form_display_name … country disease added_by  added_at   last_synced
 #>   <chr>                         <int> <chr>                      <chr>                <chr>   <chr>   <chr>     <chr>      <chr>
-#> 1 https://your-odk-server…         11 eri_test_river_prospection ERI Test — River …   uga     demo    your.name 2026-06-29 NA
-#> # ℹ 4 more rows — the registry is shared, so you also see teammates' registered forms
+#> 1 https://your-odk-server…         11 eri_test_river_prospection ERI Test, River …   uga     demo    your.name 2026-06-29 NA
+#> # ℹ 4 more rows, the registry is shared, so you also see teammates' registered forms
 ```
 
 ### Sync the submissions
@@ -302,7 +302,7 @@ names(raw)
 #> [21] "ReviewState"      "DeviceID"         "Edits"            "FormVersion"
 ```
 
-This practice form is **flat** — one row per submission — so it lands as a single table in one
+This practice form is **flat**, one row per submission, so it lands as a single table in one
 Parquet. Most real forms have *repeat groups* and come down as several tables; [section
 4](#repeat-groups) shows how to pull and sync those.
 
@@ -349,21 +349,21 @@ eri_catalog_query(country = "uga", disease = "demo", data_con = data_con)
 ```
 
 (`data_type` is `<NA>` because we approved at the channel level; `row_count` is `NA` until the entry is
-verified. Assign a measure on approval — `eri_approve(…, data_type = "prevalence")` — to fill it in.)
+verified. Assign a measure on approval, `eri_approve(…, data_type = "prevalence")`, to fill it in.)
 
 ## 4. Forms with repeat groups {#repeat-groups}
 
-The form above was deliberately simple — one row per submission, one table. Most real ODK forms have
-**repeat groups**: a section the enumerator fills in *more than once per submission* — several larvae
+The form above was deliberately simple, one row per submission, one table. Most real ODK forms have
+**repeat groups**: a section the enumerator fills in *more than once per submission*, several larvae
 sampled at one site, several household members in one visit, several nets given to one household. ODK
 Central exports each repeat group as its **own table**, so a form with one repeat comes down as
 **two** tables:
 
-- a **parent** table — one row per submission (named `{form_id}`), and
-- a **child** table — one row per repeat instance (named `{form_id}-{repeat_name}`), linked back to
+- a **parent** table, one row per submission (named `{form_id}`), and
+- a **child** table, one row per repeat instance (named `{form_id}-{repeat_name}`), linked back to
   its parent by a `PARENT_KEY` column whose value matches the parent row's `KEY`.
 
-`erifunctions` captures all of them — nothing is silently dropped.
+`erifunctions` captures all of them, nothing is silently dropped.
 
 ### Upload the repeat practice form
 
@@ -375,7 +375,7 @@ repeat_xlsx <- system.file("extdata", "odk-test-form-repeat.xlsx", package = "er
 ```
 
 Upload it to your `test` project exactly as before (**New ▸ Form**, then publish). Submit two or three
-entries — and for each one, use the **＋ Add** button inside the *Larva sample* group to record **two
+entries, and for each one, use the **＋ Add** button inside the *Larva sample* group to record **two
 or three samples** before sending. Those extra samples are what populate the child table.
 
 ### Pull every table
@@ -397,7 +397,7 @@ names(tabs)
 #> [1] "eri_test_river_repeat"              "eri_test_river_repeat-larva_sample"
 ```
 
-The **parent** table holds one row per submission — the site fields plus ODK's system columns,
+The **parent** table holds one row per submission, the site fields plus ODK's system columns,
 including the `KEY` that uniquely identifies each submission:
 
 ```{r repeat-parent}
@@ -426,13 +426,13 @@ tabs[["eri_test_river_repeat-larva_sample"]]
 #> 7 s_neavei             3 uuid:621e3b01-4825-43c5-9cf3-1ac734eb0426 uuid:621e3b01-4825-43c5-9cf3-1ac…
 ```
 
-Here three submissions produced seven samples — submission `5e70e2a3…` was sampled three times,
+Here three submissions produced seven samples, submission `5e70e2a3…` was sampled three times,
 `621e3b01…` three times, and `b3ce44d7…` once.
 
 ### Sync writes one Parquet per table
 
 `eri_odk_sync()` handles repeat forms automatically. Register the form first (just as in
-[section 3](#pull)), then sync — it writes **each** table to its own Parquet in the `raw/` layer:
+[section 3](#pull)), then sync, it writes **each** table to its own Parquet in the `raw/` layer:
 
 ```{r repeat-sync}
 eri_odk_sync(project_id = project_id, form_id = repeat_form_id, con = con, data_con = data_con)
@@ -443,7 +443,7 @@ eri_odk_sync(project_id = project_id, form_id = repeat_form_id, con = con, data_
 #> ✔ Synced "eri_test_river_repeat": 3 submissions + 1 repeat table to 'uga/demo/research/raw/'.
 ```
 
-You now have two files in `raw/` — a flat form would have left exactly one:
+You now have two files in `raw/`, a flat form would have left exactly one:
 
 ```
 uga/demo/research/raw/eri_test_river_repeat.parquet                # parent: 3 submissions
@@ -452,7 +452,7 @@ uga/demo/research/raw/eri_test_river_repeat-larva_sample.parquet   # child:  7 s
 
 ### Rejoin them for analysis
 
-The tables are kept separate on purpose — that is the faithful, lossless shape of the data. When you
+The tables are kept separate on purpose, that is the faithful, lossless shape of the data. When you
 want one flat table (one row per sample, carrying its site context), join the child to the parent on
 `PARENT_KEY` = `KEY`:
 
@@ -485,15 +485,15 @@ Approve the parent and its repeats together so they stay in step.
 ## 5. Backfilling records into a form {#backfill}
 
 Everything so far moved data **out of** ODK Central. Sometimes you need the other direction: a stack of
-records that already exist — collected on **paper**, or living in an **old spreadsheet** — that you want
+records that already exist, collected on **paper**, or living in an **old spreadsheet**, that you want
 to land in ODK Central so they sit alongside the field submissions and flow through the same pipeline.
 [`eri_odk_upload()`](../reference/eri_odk_upload.html) does exactly that: it reads a table and **creates
 one submission per row** on an existing **published** form.
 
 It is the mirror image of a download: columns are matched to form fields **by name**, using the same
-flattening you saw above — a field nested in a `visit` group is the column `visit-date`, and repeat
+flattening you saw above, a field nested in a `visit` group is the column `visit-date`, and repeat
 groups are supplied as the same `{form_id}-{repeat}` child tables linked by `PARENT_KEY`. So a
-`download_odk_form(tables = TRUE)` result is itself a valid input — **download and upload round-trip.**
+`download_odk_form(tables = TRUE)` result is itself a valid input, **download and upload round-trip.**
 
 Say you have a few historical river-prospection records to backfill. Build (or read) a table whose
 columns match the form's fields:
@@ -509,8 +509,8 @@ backfill <- data.frame(
 )
 ```
 
-**Always dry-run first.** `dry_run = TRUE` validates the table against the live form — unknown columns,
-required fields, value types (dates, numbers, geopoints), and select-value choice lists — and sends
+**Always dry-run first.** `dry_run = TRUE` validates the table against the live form, unknown columns,
+required fields, value types (dates, numbers, geopoints), and select-value choice lists, and sends
 **nothing**:
 
 ```{r backfill-dryrun}
@@ -539,7 +539,7 @@ eri_odk_upload(backfill, project_id = project_id, form_id = form_id,
 
 The `instanceID` of each submission is **derived deterministically** from `key_col` (here `record_id`).
 That makes the upload **safe to re-run**: the second time, ODK Central recognises the same ids and
-rejects them, so nothing is duplicated —
+rejects them, so nothing is duplicated,
 
 ```{r backfill-rerun}
 eri_odk_upload(backfill, project_id = project_id, form_id = form_id,
@@ -547,13 +547,13 @@ eri_odk_upload(backfill, project_id = project_id, form_id = form_id,
 #> ✔ Uploaded to "eri_test_river_prospection": 0 created, 2 already present.
 ```
 
-— and if you fix a couple of rows and run again, only those change while the rest skip. A bad row never
+If you fix a couple of rows and run again, only those change while the rest skip. A bad row never
 aborts the batch: it comes back as `failed` (with the server's message) while its neighbours load.
 
 ### Headers that don't match the form
 
 A paper or legacy spreadsheet rarely uses the form's exact column names. Rather than editing the source
-file, pass a **`mapping`** — `c(your_header = "field-column", …)` — and `eri_odk_upload()` renames the
+file, pass a **`mapping`**, `c(your_header = "field-column", …)`, and `eri_odk_upload()` renames the
 columns before it validates:
 
 ```{r backfill-mapping}
@@ -577,7 +577,7 @@ eri_odk_upload(paper, project_id = project_id, form_id = form_id, con = con,
 #> # ℹ 4 variables: table <chr>, column <chr>, row <int>, issue <chr>
 ```
 
-Map only the columns that differ — anything already matching a field is left alone — then drop
+Map only the columns that differ, anything already matching a field is left alone, then drop
 `dry_run` to send. The targets are the same flattened field-column names (`group-field`).
 
 ### Forms with repeat groups
@@ -614,17 +614,17 @@ eri_odk_upload(repeat_data, project_id = project_id, form_id = "eri_test_river_r
 #> 2 uuid:ec5ea8c7e5364fa80c6a68dceeb4916b created         200 NA
 ```
 
-Downloaded back, the first submission carries **two** `larva_sample` rows and the second **one** — each
+Downloaded back, the first submission carries **two** `larva_sample` rows and the second **one**, each
 child attached to its parent by `PARENT_KEY`. (`KEY` is just the link column here; it seeds the
 deterministic `instanceID` via `key_col` and is otherwise treated as a system column.)
 
 > **Two limits to know.** The form must be **published** (you can't backfill into a draft), and
-> **attachments can't be sent at creation** — that is an ODK Central API constraint, so photos/GPS traces
+> **attachments can't be sent at creation**: that is an ODK Central API constraint, so photos/GPS traces
 > are out of scope for the upload.
 
 ## 6. Clean up {#clean-up}
 
-Practice run done — remove everything you created so you leave no trace.
+Practice run done, remove everything you created so you leave no trace.
 
 ```{r cleanup-odk-user}
 # Remove the demo collector from ODK Central (revoke its form access, then delete the account).
@@ -650,14 +650,14 @@ eri_odk_purge(project_id = project_id, form_id = "eri_test_river_repeat",
 
 ```{r cleanup-azure}
 # Delete the whole uga/demo sandbox namespace (raw + staged + processed + logs).
-# eri_dir_delete() removes it recursively — the in-package path, no Storage Explorer.
+# eri_dir_delete() removes it recursively, the in-package path, no Storage Explorer.
 eri_dir_delete("uga/demo", azcontainer = data_con)
 ```
 
 Finally, in the ODK Central web interface, delete the test form (Form ▸ ⋯ ▸ Delete) from your `test`
 project if you want it gone there too.
 
-> **Deregister vs purge.** For a **real** form, `eri_odk_deregister()` *soft*-deletes — it flips the
+> **Deregister vs purge.** For a **real** form, `eri_odk_deregister()` *soft*-deletes, it flips the
 > registry entry to `active: false` rather than erasing it, so the record of what was once tracked (and
 > its sync history) survives for audit; the inactive entry is harmless and won't show up in
 > `eri_odk_list_registered()`. We used **`eri_odk_purge()`** above because this was a sandbox: it
@@ -665,9 +665,9 @@ project if you want it gone there too.
 > found it.
 
 > **Why we could delete freely here:** the form and its submissions are invented. **Real ODK forms and
-> field submissions are never deleted casually** — they are the primary record of work done in the
-> field. The discipline this guide builds — register, sync to `raw/`, quality-check, and approve
-> through the human gate — is what keeps that real data trustworthy.
+> field submissions are never deleted casually**, they are the primary record of work done in the
+> field. The discipline this guide builds, register, sync to `raw/`, quality-check, and approve
+> through the human gate, is what keeps that real data trustworthy.
 
 ## What's next
 
@@ -675,8 +675,8 @@ You have run the full ODK loop: connect, monitor, manage collectors, sync to the
 and approve into the canonical layer.
 
 - **Incremental sync** (only the new/edited submissions, rather than re-downloading everything) is on
-  the roadmap (Phase 4) — the registry already reserves a `last_cursor` for it.
-- **Backfilling the other direction** — pushing a CSV/Excel table of historical records *into* a form —
+  the roadmap (Phase 4), the registry already reserves a `last_cursor` for it.
+- **Backfilling the other direction**: pushing a CSV/Excel table of historical records *into* a form,
   is [`eri_odk_upload()`](../reference/eri_odk_upload.html), shown in section 5 above.
 - **Attachments** (photos, GPS traces) come down with
   [`download_form_attachments()`](../reference/download_form_attachments.html).

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -18,10 +18,10 @@ knitr::opts_chunk$set(
 Before any data can flow through `erifunctions`, the **space for it has to exist**: a data-quality
 schema that describes the data, and the `raw → staged → processed` folders it will move through. This
 guide is for a **Data Analyst** standing up that space for a new country, disease, or data type. It is
-the **prequel** to the [ingest](da-ingest-guide.html) and [ODK](da-odk-guide.html) guides — do this
+the **prequel** to the [ingest](da-ingest-guide.html) and [ODK](da-odk-guide.html) guides, do this
 once, and those workflows have somewhere to land.
 
-We will practise on a make-believe country — **Atlantis** — so you can run every step and then delete
+We will practise on a make-believe country, **Atlantis**, so you can run every step and then delete
 it. Each `eri_onboard_*` function also has a **dry-run** mode, so you can always look before you touch
 anything.
 
@@ -34,7 +34,7 @@ anything.
 > **Onboarding scaffolds; it doesn't finish for you.** `erifunctions` writes you a **schema template**
 > with the standard structure and `TODO` markers, and creates the Azure folders. *You* fill in the
 > disease-specific details, **validate** the schema, and submit it to the package. Nothing is
-> guessed — the template is a correct starting point you complete.
+> guessed, the template is a correct starting point you complete.
 
 ```{=html}
 <div class="mermaid">
@@ -51,8 +51,8 @@ flowchart TD
 ## Before you start {#before-you-start}
 
 1. **R and RStudio** installed.
-2. **The package** — `remotes::install_github("thecartercenter/erifunctions")`.
-3. **Azure access** — zero-config browser sign-in; see the
+2. **The package**: `remotes::install_github("thecartercenter/erifunctions")`.
+3. **Azure access**: zero-config browser sign-in; see the
    [connections guide](connections-guide.html) if this is your first time.
 
 ```{r library}
@@ -100,7 +100,7 @@ staged,processed}/` in the data blob.
 
 ### Fill in the template
 
-Open `atlantis_malaria_surveillance_aggregate.yaml`. It is a **correct, structured starting point** — the standard
+Open `atlantis_malaria_surveillance_aggregate.yaml`. It is a **correct, structured starting point**, the standard
 sections are there, with `TODO` markers where your data is unique. Here it is **trimmed for
 readability** (your actual file also lists `aliases:` for each column and a few commented options like
 `time_grain` and `admin1_name_field`):
@@ -154,13 +154,13 @@ consistency:
   # TODO: add cross-field rules here
 ```
 
-The schema structure — `columns` with `type`/`required`/`range`/`allowed_values`, the `temporal`
-block, `consistency` rules — is exactly what the data-quality engine reads. The
+The schema structure, `columns` with `type`/`required`/`range`/`allowed_values`, the `temporal`
+block, `consistency` rules, is exactly what the data-quality engine reads. The
 [ingest guide](da-ingest-guide.html) shows what each rule *does* when data runs through it.
 
 ### Validate your edits
 
-`eri_schema_validate()` checks the **structure** — required sections, valid column types, and that
+`eri_schema_validate()` checks the **structure**, required sections, valid column types, and that
 temporal/consistency rules reference columns that actually exist. Run it on the file you just edited:
 
 ```{r validate-good}
@@ -193,13 +193,13 @@ Fix the schema and re-run until you get the clean ✔. That is the green light t
 
 **Case Management Reports (CMR)** are the monthly Excel returns from country programs. Onboarding one
 writes a CMR schema template and (when you pass `create_dirs = TRUE`) the staging folders under the
-combined **`rblf`** disease code (RB + LF — the programmes these reports cover), where
+combined **`rblf`** disease code (RB + LF, the programmes these reports cover), where
 [`eri_stage_cmr()`](da-cmr-guide.html) lands the raw Excel. Dry-run it first:
 
 > **`rblf`/`cmr` is the staging archive, not the canonical home.** Under the
 > [source ≠ measure model (ADR-0012)](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md),
 > CMR is a *format* of the `programmatic` channel. [`eri_split_cmr()`](da-cmr-guide.html) reads the
-> staged Excel and routes **each sheet to its own disease and measure** —
+> staged Excel and routes **each sheet to its own disease and measure**,
 > e.g. RB Treatment → `{country}/oncho/programmatic/treatment/`, then you approve **each disease/measure**.
 > So `rblf/cmr/` is the transitional landing/archive; the canonical, approved data is per-disease
 > (shared sheets like Training route together under the combined `rblf` disease). See the
@@ -227,14 +227,14 @@ eri_onboard_cmr("atlantis", "Atlantis", create_dirs = TRUE)
 #>   4. Test ingestion with eri_ingest_cmr('your_file.xlsx', country = 'atlantis').
 ```
 
-A CMR template ships with the common report sheets commented out — uncomment the ones your country
+A CMR template ships with the common report sheets commented out, uncomment the ones your country
 files, and make each sheet's `field_code_prefix` match the `#tag_` row in the Excel file. Then test
 with `eri_ingest_cmr()`.
 
 ## 4. Onboard an NTD disease (MDA + prevalence) {#ntd}
 
 For an **NTD treatment/survey program**, `eri_onboard_disease()` scaffolds the two schemas that
-pattern needs — **MDA** (mass drug administration) and **prevalence**. Note the argument order here is
+pattern needs, **MDA** (mass drug administration) and **prevalence**. Note the argument order here is
 **disease first, then country**:
 
 ```{r onboard-disease}
@@ -247,11 +247,11 @@ eri_onboard_disease("schisto", "atlantis")
 #>   3. Submit via pull request to inst/schemas/.
 ```
 
-These are **local-only** templates (no Azure folders) — an MDA schema with `year`, `round`,
+These are **local-only** templates (no Azure folders), an MDA schema with `year`, `round`,
 `target_pop`, `treated`, and a `TODO` for the geographic unit, and a matching prevalence schema. Fill,
 validate, and submit them exactly as in §2.
 
-> **Contributing the schema to the package — and disease analytics.** Submitting your finished schema
+> **Contributing the schema to the package, and disease analytics.** Submitting your finished schema
 > via pull request, the schema-validation test, and adding disease-specific analytics functions are
 > covered in depth in the [**Adding a new program**](adding-a-program.html) vignette. This guide gets
 > the space stood up; that one gets your schema merged.
@@ -268,13 +268,13 @@ system**. You can now:
 
 ## 6. Clean up {#clean-up}
 
-Practice run — remove everything you created. Delete the Azure namespace and the local schema files:
+Practice run, remove everything you created. Delete the Azure namespace and the local schema files:
 
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
 # Deletes atlantis/malaria/surveillance/* and atlantis/rblf/cmr/* in one go,
-# recursively — the in-package path, so you stay in erifunctions instead of
+# recursively, the in-package path, so you stay in erifunctions instead of
 # dropping to raw AzureStor / Storage Explorer.
 eri_dir_delete("atlantis", azcontainer = con)
 
@@ -284,17 +284,17 @@ unlink(c("atlantis_malaria_surveillance_aggregate.yaml", "atlantis_cmr_schema.ya
 ```
 
 > **Why deleting was fine here:** *Atlantis* is invented. **A real onboarded country is not torn down
-> casually** — once data lands in it, those folders are the home of real surveillance records. There
+> casually**, once data lands in it, those folders are the home of real surveillance records. There
 > is deliberately no one-click "un-onboard" command; removing a real space is a considered, manual act.
 
 ## What's next
 
-You have stood up a new space three ways — surveillance, CMR, and an NTD program — and validated the
+You have stood up a new space three ways, surveillance, CMR, and an NTD program, and validated the
 schemas. The data guides take it from here:
 
 - [Ingesting a surveillance dataset](da-ingest-guide.html)
 - [Working with ODK Central](da-odk-guide.html)
-- [Adding a new program](adding-a-program.html) — contribute your schema to the package.
+- [Adding a new program](adding-a-program.html): contribute your schema to the package.
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) for
 the full set, and the [reference](../reference/index.html) for every function grouped by purpose.

--- a/vignettes/da-qc-feedback-guide.Rmd
+++ b/vignettes/da-qc-feedback-guide.Rmd
@@ -11,7 +11,7 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
-When a country sends a data extract, quality-checking it is only half the job — the other half is
+When a country sends a data extract, quality-checking it is only half the job, the other half is
 telling them, **specifically and clearly, what needs fixing**. `run_dq_checks()` does both: it
 **auto-corrects** the safe, unambiguous things (and records what it changed) and **flags** the rest for
 a human. The flags are your feedback to the country.
@@ -20,16 +20,16 @@ a human. The flags are your feedback to the country.
 
 > **Auto-corrections are applied and logged; flags are handed back.** A correction is something the
 > schema can fix unambiguously (a known spelling, a translation). A flag is something only the country
-> can resolve (an impossible age, an unknown locality). Never "fix" a flag by guessing — send it back.
+> can resolve (an impossible age, an unknown locality). Never "fix" a flag by guessing, send it back.
 
-This is offline — the DQ engine runs on a plain data frame. For where DQ sits in the full pipeline see
+This is offline, the DQ engine runs on a plain data frame. For where DQ sits in the full pipeline see
 the [ingest guide](da-ingest-guide.html); for the engine internals and custom checks, the
 [DQ pipeline](dq-pipeline.html).
 
 ## The extract {#extract}
 
 In practice you'd read the submitted file (`eri_read()` / the raw layer). Here is a small DR malaria
-surveillance extract with a few deliberate problems — two values that the schema can normalise, and a
+surveillance extract with a few deliberate problems, two values that the schema can normalise, and a
 few that it cannot:
 
 ```{r data}
@@ -74,7 +74,7 @@ dq_report(res)
 
 ## What was fixed automatically {#corrections}
 
-`res$log` is the audit trail of every auto-correction — what changed, in which row, and why. Share it
+`res$log` is the audit trail of every auto-correction, what changed, in which row, and why. Share it
 so the country knows what was normalised on their behalf (it is not an error on their part, but they
 should see it):
 
@@ -90,7 +90,7 @@ res$log
 
 ## What the country must fix {#flags}
 
-`res$flags` is the feedback list — the rows the schema could **not** resolve. This is what you send
+`res$flags` is the feedback list, the rows the schema could **not** resolve. This is what you send
 back:
 
 ```{r flags}
@@ -111,7 +111,7 @@ Turn it into a clean artifact to attach to your message with
 ```{r feedback-table}
 eri_table(
   res$flags,
-  title    = "DR malaria — items to correct and resubmit",
+  title    = "DR malaria, items to correct and resubmit",
   footnote = "Auto-corrected values are not listed; only rows needing your review."
 )
 ```
@@ -119,7 +119,7 @@ eri_table(
 ## Notify the team / country {#notify}
 
 [`eri_notify_dq()`](../reference/eri_notify_dq.html) posts a one-glance summary (rows, corrections,
-flags, the most-flagged columns) to Teams — handy for a shared channel that tracks each country's
+flags, the most-flagged columns) to Teams, handy for a shared channel that tracks each country's
 submissions:
 
 ```{r notify}
@@ -138,15 +138,15 @@ Top flagged    : Age, EpiWeek, Province_Residence, SampleDate, Sex
 ```
 
 To target a specific Teams channel instead of the default webhook, pass `team =` / `channel =` with a
-token (the Graph-API path) — see the [connections guide](connections-guide.html#teams).
+token (the Graph-API path), see the [connections guide](connections-guide.html#teams).
 
 ## What's next
 
-- The cleaned data (`res$data`) continues through the pipeline — see the
+- The cleaned data (`res$data`) continues through the pipeline, see the
   [ingest guide](da-ingest-guide.html) for stage → **approve**.
-- The [DQ pipeline](dq-pipeline.html) — the check engine, schema rules, and adding `custom_checks`.
-- The [epi anomaly guide](epi-dq-guide.html) — spikes, gaps, and cross-field/spatial anomalies beyond
+- The [DQ pipeline](dq-pipeline.html), the check engine, schema rules, and adding `custom_checks`.
+- The [epi anomaly guide](epi-dq-guide.html), spikes, gaps, and cross-field/spatial anomalies beyond
   cell-level validity.
-- Persist the flags to the shared backlog with `eri_dq_log()` — the
+- Persist the flags to the shared backlog with `eri_dq_log()`, the
   [log-triage guide](da-logs-guide.html).
 ```

--- a/vignettes/da-reporting-guide.Rmd
+++ b/vignettes/da-reporting-guide.Rmd
@@ -11,12 +11,12 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
-Once data is approved, a lot of the job is turning it into **outputs** — a table for a memo, a figure
+Once data is approved, a lot of the job is turning it into **outputs**, a table for a memo, a figure
 for proceedings, a workbook for a partner, a slide deck for a meeting. `erifunctions` ships a small,
 consistent **reporting toolkit** so those come out on-brand without fiddling with styling each time.
 
 This guide is the general toolkit (it runs on any data frame). Specific recurring reports get their own
-templates as they're defined; the domain figures — **maps** and **epidemic curves** — live in the
+templates as they're defined; the domain figures, **maps** and **epidemic curves**, live in the
 [spatial workflow](spatial-workflow.html) and [epi analytics](epi-analytics.html) guides.
 
 ## Before you start {#before-you-start}
@@ -25,7 +25,7 @@ templates as they're defined; the domain figures — **maps** and **epidemic cur
 library(erifunctions)
 ```
 
-In practice you'd pull approved data first — `eri_query()` for a roll-up (see the
+In practice you'd pull approved data first, `eri_query()` for a roll-up (see the
 [ad-hoc guide](da-adhoc-guide.html)) or `eri_read()` for one dataset. Here we use a small frame so every
 chunk runs as-is:
 
@@ -41,8 +41,8 @@ dat$positivity <- round(dat$cases / dat$tested * 100, 1)
 ## A branded table {#table}
 
 [`eri_table()`](../reference/eri_table.html) turns a data frame into a styled
-[`flextable`](https://davidgohel.github.io/flextable/) — ERI navy header, banded rows, an optional
-title and footnote — ready to drop into an HTML/Word/PowerPoint output:
+[`flextable`](https://davidgohel.github.io/flextable/): ERI navy header, banded rows, an optional
+title and footnote, ready to drop into an HTML/Word/PowerPoint output:
 
 ```{r table}
 eri_table(
@@ -54,7 +54,7 @@ eri_table(
 ```
 
 It returns a `flextable` object; print it in a report, or hand it to the Word/PowerPoint/HTML helpers.
-`highlight_cols` is a **named list** mapping a column to a fill colour (`list(col = "#hex")`) — use it to
+`highlight_cols` is a **named list** mapping a column to a fill colour (`list(col = "#hex")`), use it to
 shade the column you want the eye to land on.
 
 ## An on-brand figure {#figure}
@@ -70,7 +70,7 @@ p <- ggplot(dat, aes(x = province, y = cases)) +
 p
 ```
 
-For domain figures there are purpose-built helpers — `eri_plot_theme("map" | "epicurve")` and
+For domain figures there are purpose-built helpers, `eri_plot_theme("map" | "epicurve")` and
 `eri_color_scheme()` (e.g. the standard `"malaria.incidence"` bins), and the `eri_map_*` family for
 choropleths and point maps. Those need boundary data; the [spatial workflow](spatial-workflow.html)
 guide covers them end-to-end, and [epi analytics](epi-analytics.html) covers `eri_epidemic_curve()`.
@@ -78,7 +78,7 @@ guide covers them end-to-end, and [epi analytics](epi-analytics.html) covers `er
 ## An Excel workbook {#excel}
 
 For a partner who wants the numbers, [`eri_report_excel()`](../reference/eri_report_excel.html) writes a
-styled multi-sheet workbook in one call — each named element of `sheets` becomes a tab:
+styled multi-sheet workbook in one call, each named element of `sheets` becomes a tab:
 
 ```{r excel}
 eri_report_excel(
@@ -94,7 +94,7 @@ Need finer control (multiple sheets, added titles)? Build it up with `eri_wb_cre
 
 ## A slide deck for proceedings {#pptx}
 
-The `eri_pptx_*` family builds a PowerPoint slide by slide — title, sections, tables, and plots — so a
+The `eri_pptx_*` family builds a PowerPoint slide by slide, title, sections, tables, and plots, so a
 meeting deck is reproducible code, not manual copy-paste:
 
 ```{r pptx}
@@ -117,8 +117,8 @@ accepts a `template =` to start from a branded master.
 
 ## What's next
 
-- **Maps:** the [spatial workflow](spatial-workflow.html) — choropleths, incidence maps, insets.
-- **Curves & indicators:** [epi analytics](epi-analytics.html) — `eri_epidemic_curve()`, incidence,
+- **Maps:** the [spatial workflow](spatial-workflow.html), choropleths, incidence maps, insets.
+- **Curves & indicators:** [epi analytics](epi-analytics.html), `eri_epidemic_curve()`, incidence,
   disease helpers.
 - **Where the data comes from:** the [ad-hoc guide](da-adhoc-guide.html) (`eri_query`) and the
   [ingest guide](da-ingest-guide.html).

--- a/vignettes/da-survey-report-guide.Rmd
+++ b/vignettes/da-survey-report-guide.Rmd
@@ -23,13 +23,13 @@ result. The summary itself is offline.
 
 > **Report from the approved (`processed/`) dataset, not a working copy.** The number in your report
 > should trace to a specific approved file in the catalog. Pull it with `eri_read()` / `eri_query()`,
-> summarise, then package — don't re-summarise an ad-hoc export that never went through the gate.
+> summarise, then package, don't re-summarise an ad-hoc export that never went through the gate.
 
 ## The survey data {#data}
 
 In practice you'd read the approved survey: `eri_read("ht/lf/research/processed/…")` or an
 `eri_query()` roll-up. Here is a small individual-level **LF TAS** (Transmission Assessment Survey)
-extract — one row per child tested, with FTS and RDT antigen results:
+extract, one row per child tested, with FTS and RDT antigen results:
 
 ```{r data}
 tas <- data.frame(
@@ -64,16 +64,16 @@ summary
 Read it per commune by summing the `Positive` FTS rows: Saut-d'Eau has **2 of 6** FTS-positive children,
 Mirebalais **3 of 6**. In a real
 TAS you compare that antigen-positive count against the survey's **critical cutoff** to decide
-pass/fail — the helper gives you the counts the decision rests on.
+pass/fail, the helper gives you the counts the decision rests on.
 
 Other survey measures have their own helpers: `eri_lf_pooled_prev()` for entomology/xenomonitoring
-pooled prevalence, and `eri_oncho_program_levels()` / `eri_oncho_status_map()` for oncho — see
+pooled prevalence, and `eri_oncho_program_levels()` / `eri_oncho_status_map()` for oncho, see
 [epi analytics](epi-analytics.html).
 
 ## Package it for sharing {#package}
 
 The summary is an ordinary tibble, so the [reporting toolkit](da-reporting-guide.html) takes it the rest
-of the way — a branded table for the report:
+of the way, a branded table for the report:
 
 ```{r table}
 eri_table(
@@ -99,8 +99,8 @@ spatial helpers (see the [spatial workflow](spatial-workflow.html)).
 
 ## What's next
 
-- The [reporting guide](da-reporting-guide.html) — the full table/figure/deck/Excel toolkit.
-- [Epi analytics](epi-analytics.html) — the disease helpers (LF/oncho) and indicators.
-- [Working with ODK Central](da-odk-guide.html) — pulling the survey in the first place.
+- The [reporting guide](da-reporting-guide.html), the full table/figure/deck/Excel toolkit.
+- [Epi analytics](epi-analytics.html): the disease helpers (LF/oncho) and indicators.
+- [Working with ODK Central](da-odk-guide.html): pulling the survey in the first place.
 - The [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md).
 ```

--- a/vignettes/data-model-card.Rmd
+++ b/vignettes/data-model-card.Rmd
@@ -17,7 +17,7 @@ values.*
 data / {country} / {disease} / {data_source} / {data_type} / {layer}
 ```
 
-Two of them — `data_source` and `data_type` — are the ones people mix up. They are **independent**:
+Two of them, `data_source` and `data_type`, are the ones people mix up. They are **independent**:
 
 | Axis | Plain-English question | It is NOT… |
 |------|------------------------|------------|
@@ -30,19 +30,19 @@ Two of them — `data_source` and `data_type` — are the ones people mix up. Th
 - One **CMR** (programmatic) fans out to **7 measures across 3 diseases** (treatment, MMDP, training,
   surveys…).
 - DR malaria **surveillance** is **`case`** (one row per patient); Haiti malaria surveillance is
-  **`aggregate`** (facility × month counts). Same source, same disease — different measure.
+  **`aggregate`** (facility × month counts). Same source, same disease, different measure.
 
 ## Answer these four, in order
 
-1. **country** — `dr`, `ht`, `eth`, `uga`, `nga`, `sdn`, `ssd`, `tcd`, `mad`, `oepa`, …
-2. **disease** — `malaria`, `oncho`, `lf`, `sch`, `sth` (free text; lowercase).
-3. **data_source (channel)** — pick one:
-   - **`surveillance`** — routine MoH feed (DR/Haiti malaria). Output: cases or aggregate counts.
-   - **`programmatic`** — country-team activity/coverage data: CMR, or a direct MDA feed. Spans
+1. **country**: `dr`, `ht`, `eth`, `uga`, `nga`, `sdn`, `ssd`, `tcd`, `mad`, `oepa`, …
+2. **disease**: `malaria`, `oncho`, `lf`, `sch`, `sth` (free text; lowercase).
+3. **data_source (channel)**: pick one:
+   - **`surveillance`**: routine MoH feed (DR/Haiti malaria). Output: cases or aggregate counts.
+   - **`programmatic`**: country-team activity/coverage data: CMR, or a direct MDA feed. Spans
      diseases (split per disease on ingest).
-   - **`research`** — survey instruments launched + monitored via ODK, then cleaned into a final
+   - **`research`**: survey instruments launched + monitored via ODK, then cleaned into a final
      analytic dataset (TAS, prevalence, entomology).
-4. **data_type (measure)** — what the rows count:
+4. **data_type (measure)**: what the rows count:
    `case` · `aggregate` · `treatment` · `mmdp` · `training` · `survey` · `tas` · `prevalence` ·
    `entomology`.
 
@@ -72,10 +72,10 @@ Two of them — `data_source` and `data_type` — are the ones people mix up. Th
 
 ## Two things that trip people up
 
-- **`format` ≠ `data_source`.** "CMR" and "ODK" are input *formats*, recorded in a `format` field —
+- **`format` ≠ `data_source`.** "CMR" and "ODK" are input *formats*, recorded in a `format` field,
   not channels. A CMR is `programmatic`; an ODK form is `research`. (The `cmr`/`odk` path tokens you may
-  see in older data are transitional and being retired — ADR-0012.)
+  see in older data are transitional and being retired, ADR-0012.)
 - **A missing combination is normal.** If `load_dq_schema()` / `eri_data_path()` doesn't recognise a
-  value, you get a **warning**, not an error — adding a new country/disease/source/measure is a *data*
+  value, you get a **warning**, not an error, adding a new country/disease/source/measure is a *data*
   change (a schema + a registry entry), not a code change. See the
   [onboarding a new program guide](da-onboard-guide.html).

--- a/vignettes/dq-pipeline.Rmd
+++ b/vignettes/dq-pipeline.Rmd
@@ -95,24 +95,24 @@ consistency:
 
 The pipeline runs these steps in order:
 
-1. **Preprocessing** — removes smart quotes, optionally strips column name
+1. **Preprocessing**: removes smart quotes, optionally strips column name
    whitespace, drops rows with a missing year value.
-2. **Alias resolution** — renames recognised alternative column headers to the
+2. **Alias resolution**: renames recognised alternative column headers to the
    canonical name defined in the schema.
-3. **Required-column check** — adds a `NA`-row flag for any column marked
+3. **Required-column check**: adds a `NA`-row flag for any column marked
    `required: true` that is completely absent from the data.
-4. **Type coercion** — converts columns to `numeric`, `date`, or `character`
+4. **Type coercion**: converts columns to `numeric`, `date`, or `character`
    as declared; flags values that cannot be coerced.
-5. **Range checks** — flags numeric values outside the `[min, max]` range.
-6. **Translations and corrections** — applies the lookup maps silently,
+5. **Range checks**: flags numeric values outside the `[min, max]` range.
+6. **Translations and corrections**: applies the lookup maps silently,
    logging each change to `$log`.
-7. **Allowed-values check** — flags values not in the `allowed_values` list.
-8. **NA fill** — fills `NA` in `na_fill`-annotated columns with the specified
+7. **Allowed-values check**: flags values not in the `allowed_values` list.
+8. **NA fill**: fills `NA` in `na_fill`-annotated columns with the specified
    default and logs the change.
-9. **Temporal cross-check** — flags rows where `year(date_col) != year_col`.
-10. **Derived columns** — evaluates each `formula` with `with(data, ...)` and
+9. **Temporal cross-check**: flags rows where `year(date_col) != year_col`.
+10. **Derived columns**: evaluates each `formula` with `with(data, ...)` and
     adds the result as a new column.
-11. **Aggregate consistency** — for any derived column, checks the formula
+11. **Aggregate consistency**: for any derived column, checks the formula
     against the existing value and flags discrepancies (useful for pre-computed
     totals).
 
@@ -145,7 +145,7 @@ The `$flags` tibble records everything requiring review:
 
 After the baseline checks you can chain additional anomaly detectors. All
 three accept either a plain tibble or a `dq_result`, and return the same
-type — so they compose with `|>`.
+type, so they compose with `|>`.
 
 ### Period-over-period percent change
 

--- a/vignettes/epi-analytics.Rmd
+++ b/vignettes/epi-analytics.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 This vignette covers the epidemiological helper functions for malaria, lymphatic
-filariasis, and onchocerciasis analyses — from computing incidence rates and
+filariasis, and onchocerciasis analyses, from computing incidence rates and
 epiweek dates to LF pooled prevalence and onchocerciasis programme-status maps.
 
 ## Malaria: incidence and epidemic curves
@@ -54,7 +54,7 @@ ggplot(weekly, aes(week_start, n_cases, colour = province)) +
 
 ### Study week
 
-`eri_study_week()` expresses epiweeks relative to an index event — useful for
+`eri_study_week()` expresses epiweeks relative to an index event, useful for
 intervention analyses such as IRS campaigns:
 
 ```{r study-week}

--- a/vignettes/epi-dq-guide.Rmd
+++ b/vignettes/epi-dq-guide.Rmd
@@ -15,13 +15,13 @@ knitr::opts_chunk$set(
 )
 ```
 
-A fresh surveillance extract can be **valid cell-by-cell and still wrong epidemiologically** — a week
+A fresh surveillance extract can be **valid cell-by-cell and still wrong epidemiologically**, a week
 that suddenly triples, a reporting week that never arrived, a count that exceeds what was tested. This
 guide, for **epidemiologists**, is about that second layer: after the basic
 [data-quality checks](da-ingest-guide.html), run the **anomaly detectors** to catch the patterns only
 a domain eye would question, *before* the numbers reach a curve or a map.
 
-It runs **fully offline** on a small synthetic extract — no Azure, no real data. For the schema
+It runs **fully offline** on a small synthetic extract, no Azure, no real data. For the schema
 mechanics and the full anomaly reference, see the
 [data-quality pipeline](dq-pipeline.html) vignette; this guide is about **what the flags mean and what
 you do about them**.
@@ -53,14 +53,14 @@ library(dplyr)
 
 ## 1. The extract {#extract}
 
-We use a bundled case-level malaria schema (no Azure needed — `azcontainer = NULL` loads the copy that
+We use a bundled case-level malaria schema (no Azure needed, `azcontainer = NULL` loads the copy that
 ships with the package) and a small synthetic line-list: two provinces over six epiweeks, one row per
-case. It has three planted problems — a species typo, a **case spike**, and a **missing week** — the
+case. It has three planted problems, a species typo, a **case spike**, and a **missing week**, the
 kinds of thing a real extract hides:
 
 ```{r extract}
 # Load by the four-part identity (ADR-0012): country, disease, data_source (the
-# channel — surveillance/programmatic/research), data_type (the measure — here
+# channel, surveillance/programmatic/research), data_type (the measure, here
 # "case", the case-level line-list). The legacy compound key still works too:
 # load_dq_schema("dr", "malaria_case") resolves via an alias during the migration.
 schema <- load_dq_schema("dr", "malaria", "surveillance", "case", azcontainer = NULL)
@@ -85,7 +85,7 @@ nrow(cases)   # 48 cases across 2 provinces, epiweeks 1-6
 
 ## 2. Baseline: the cell-level checks {#baseline}
 
-Start with `run_dq_checks()` — the same engine the [ingest guide](da-ingest-guide.html) covers. It
+Start with `run_dq_checks()`, the same engine the [ingest guide](da-ingest-guide.html) covers. It
 catches *cell* problems (bad types, out-of-range values, values off the allowed list):
 
 ```{r baseline}
@@ -104,10 +104,10 @@ result
 #> ℹ See `result$flags` for the full row-level detail.
 ```
 
-One flag — a mistyped species. Useful, but it tells you nothing about whether the *epidemiology* makes
+One flag, a mistyped species. Useful, but it tells you nothing about whether the *epidemiology* makes
 sense. For that, chain on the anomaly detectors.
 
-## 3. Spikes — `add_anomaly_pct_change()` {#spikes}
+## 3. Spikes, `add_anomaly_pct_change()` {#spikes}
 
 Epidemic data moves week to week; a sudden jump is either a real outbreak or a data error, and you
 need to know which. Aggregate to weekly counts per province, then flag period-over-period changes above
@@ -134,19 +134,19 @@ flagged[flagged$anomaly_pct_change_n_cases, c("epiweek", "province", "n_cases", 
 #> 2       6 Azua           4             -0.733
 ```
 
-Azua jumped from 3 cases to **15 in week 5** — a five-fold rise (the detector reports
-`pct_change = 4`, i.e. +400%) — then fell back in week 6 (`-73%`). Both are flagged, because a spike
+Azua jumped from 3 cases to **15 in week 5**, a five-fold rise (the detector reports
+`pct_change = 4`, i.e. +400%), then fell back in week 6 (`-73%`). Both are flagged, because a spike
 produces *two* large changes (up, then down). The week-5 row is the one to investigate: **is this a
 genuine cluster the field should respond to, or did a batch of cases get entered twice?** The detector
-doesn't decide — it points you at the week worth a phone call.
+doesn't decide, it points you at the week worth a phone call.
 
-(We aggregated `result$data` as-is, so the one still-flagged species row is rolled in — harmless for
+(We aggregated `result$data` as-is, so the one still-flagged species row is rolled in, harmless for
 these per-week counts, but on a real extract you'd resolve the cell flags from §2 before rolling
 anything up.)
 
-## 4. Missing weeks — `add_anomaly_gaps()` {#gaps}
+## 4. Missing weeks, `add_anomaly_gaps()` {#gaps}
 
-A week with **no rows at all** never shows up as a bad value — it's simply absent, and easy to miss.
+A week with **no rows at all** never shows up as a bad value, it's simply absent, and easy to miss.
 `add_anomaly_gaps()` infers the expected run of weeks and returns the ones that aren't there:
 
 ```{r gaps}
@@ -166,12 +166,12 @@ gaps
 #> 1 San Juan 2024      4   structural_gap
 ```
 
-San Juan reported weeks 1, 2, 3, 5, and 6 — but **not week 4**. That is not zero cases; it is *no
+San Juan reported weeks 1, 2, 3, 5, and 6, but **not week 4**. That is not zero cases; it is *no
 report*. Before you draw an epidemic curve, you need to know whether the clinic didn't report that
 week (chase it) or the data were dropped in transfer (fix it). A silent gap becomes a fake "dip" in
 the curve if you don't.
 
-## 5. Cross-field rules — `add_anomaly_consistency()` {#consistency}
+## 5. Cross-field rules, `add_anomaly_consistency()` {#consistency}
 
 Some errors only show up when two columns are read together. The schema's `consistency` block defines
 named rules; the detector checks each one and appends violations to the flags. Chain it onto the result:
@@ -181,11 +181,11 @@ result <- result |> add_anomaly_consistency(schema)
 #> ✔ All consistency checks passed.
 ```
 
-Here the schema's epiweek rules all hold, so it passes. The real power is **cross-field** rules — e.g.
-`positives <= tested`, or `treated <= target_population` — which catch the impossible combinations that
+Here the schema's epiweek rules all hold, so it passes. The real power is **cross-field** rules, e.g.
+`positives <= tested`, or `treated <= target_population`, which catch the impossible combinations that
 range checks can't see. The [data-quality pipeline](dq-pipeline.html) vignette shows how to write them.
 
-## 6. Geographic names — `add_anomaly_spatial()` {#spatial}
+## 6. Geographic names, `add_anomaly_spatial()` {#spatial}
 
 The last detector flags admin-unit names in the data that don't appear in the official boundary (a
 common symptom of a typo or an un-reconciled locality). It needs an `admin` block in the schema and the
@@ -198,12 +198,12 @@ result <- result |> add_anomaly_spatial(schema, azcontainer = NULL)
 ```
 
 With a schema that defines admin boundaries (and Azure access), this flags province or district names
-that aren't on the official list. The upstream fix — mapping messy place names to canonical units in
-the first place — is the [locality reconciliation guide](epi-reconcile-guide.html).
+that aren't on the official list. The upstream fix, mapping messy place names to canonical units in
+the first place, is the [locality reconciliation guide](epi-reconcile-guide.html).
 
 ## 7. What to do with the flags {#act}
 
-The detectors don't clean anything — they hand you a short list of **questions to answer before you
+The detectors don't clean anything, they hand you a short list of **questions to answer before you
 analyse**:
 
 | Detector | Flag | The epi question |
@@ -218,9 +218,9 @@ interrogated.
 
 ## What's next
 
-- [Data-quality pipeline](dq-pipeline.html) — the schema reference and how to author consistency rules.
-- [Reconciling localities](epi-reconcile-guide.html) — fixing the geographic names the spatial check flags.
-- [Epi analytics](epi-analytics.html) — incidence, epiweeks, and epidemic curves, *after* the extract is clean.
+- [Data-quality pipeline](dq-pipeline.html): the schema reference and how to author consistency rules.
+- [Reconciling localities](epi-reconcile-guide.html): fixing the geographic names the spatial check flags.
+- [Epi analytics](epi-analytics.html): incidence, epiweeks, and epidemic curves, *after* the extract is clean.
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) for the
 full set, and the [reference](../reference/index.html) for the anomaly-detector help pages.

--- a/vignettes/epi-reconcile-guide.Rmd
+++ b/vignettes/epi-reconcile-guide.Rmd
@@ -15,8 +15,8 @@ knitr::opts_chunk$set(
 )
 ```
 
-Surveillance data arrives with **messy, free-text place names** — `"Jínova"`, `"JUAN DE HERRERA"`,
-`"S. Juan"` — that have to be matched to the **canonical admin units** in an authoritative boundary
+Surveillance data arrives with **messy, free-text place names**, `"Jínova"`, `"JUAN DE HERRERA"`,
+`"S. Juan"`: that have to be matched to the **canonical admin units** in an authoritative boundary
 before you can aggregate cases, compute incidence, or map anything. Doing that by hand is slow and
 error-prone. This guide, for **epidemiologists**, shows how
 [`eri_spatial_reconcile()`](../reference/eri_spatial_reconcile.html) does it: match what it safely can,
@@ -44,7 +44,7 @@ flowchart TD
 - `remotes::install_github("thecartercenter/erifunctions")`, plus the **`sf`** package
   (`install.packages("sf")`).
 - The **string-match** step runs fully offline. The optional **geocoding** step uses **OpenStreetMap
-  (Nominatim)** by default — keyless, so no setup — though it makes network calls. (Higher-quality
+  (Nominatim)** by default, keyless, so no setup, though it makes network calls. (Higher-quality
   geocoding via Google is available with a key; see [the end](#real-data).)
 
 ```{r library}
@@ -54,7 +54,7 @@ library(sf)
 
 ## 1. The reference boundary and your messy data {#inputs}
 
-Reconciliation needs an **authoritative boundary** — an `sf` object whose columns hold the canonical
+Reconciliation needs an **authoritative boundary**, an `sf` object whose columns hold the canonical
 admin names. In real work you load it with
 [`eri_spatial_load()`](../reference/eri_spatial_load.html); for this guide we build a tiny one by hand
 (two real places so the live geocoder has somewhere to land):
@@ -73,7 +73,7 @@ boundary <- st_sf(
 )
 ```
 
-And the incoming data — five localities with the usual problems (case, a typo, names not in the
+And the incoming data, five localities with the usual problems (case, a typo, names not in the
 boundary, and one that is pure noise):
 
 ```{r messy-data, eval=TRUE}
@@ -89,7 +89,7 @@ messy
 You describe the hierarchy with two **parallel** vectors, **finest → coarsest**: your data's columns
 (`loc_cols`) and the matching boundary columns (`admin_cols`).
 
-## 2. Pass 1 — string match (offline) {#match}
+## 2. Pass 1, string match (offline) {#match}
 
 First, match what you can with no network at all. Setting `method = NULL` disables geocoding entirely,
 and `max_dist = 1` allows a one-character typo at the finest level:
@@ -100,7 +100,7 @@ matched <- eri_spatial_reconcile(
   loc_cols   = c("locality", "county", "state"),
   admin_cols = c("adm3_name", "adm2_name", "adm1_name"),
   shapefile  = boundary,
-  method     = NULL,    # string match only — fully offline
+  method     = NULL,    # string match only, fully offline
   max_dist   = 1L       # tolerate a 1-character typo in the finest name
 )
 #> ✔ Reconciled 5 distinct localities: 2 matched, 0 geocoded, 0 need review, 3 unresolved.
@@ -118,11 +118,11 @@ matched[, c("locality", "county", "state", "reconcile_status")]
 
 Two wins already, offline: `"boston"` matched `Boston` (case-insensitive, accent-insensitive), and the
 typo `"Cambrige"` matched `Cambridge` (within `max_dist`). For a `matched` row the **whole hierarchy**
-is rewritten to the boundary's canonical spelling — not just the locality, but the county and state too
-— so a misspelled parent gets fixed as well. The other three don't appear in the boundary, so they're
-`unresolved` — they're the residual to geocode.
+is rewritten to the boundary's canonical spelling, not just the locality, but the county and state too,
+so a misspelled parent gets fixed as well. The other three don't appear in the boundary, so they're
+`unresolved`: they're the residual to geocode.
 
-## 3. Pass 2 — geocode the residual {#geocode}
+## 3. Pass 2, geocode the residual {#geocode}
 
 Now let geocoding handle the rows that didn't match. `method = "osm"` uses keyless OpenStreetMap;
 `country_name` is appended to each address to anchor it:
@@ -155,18 +155,18 @@ result[, c("locality", "county", "longitude", "latitude", "reconcile_status")]
 Three different outcomes for the three residual rows:
 
 - **`Fenway Park` → `geocoded`.** It geocoded to a point inside the **Boston/Suffolk** polygon, which
-  *agrees* with the county you supplied — so it's trusted: the name is rewritten to the canonical
+  *agrees* with the county you supplied, so it's trusted: the name is rewritten to the canonical
   `Boston` and you get coordinates.
 - **`MIT` → `geocoded_review`.** It geocoded fine, but the point falls in the **Cambridge/Middlesex**
-  polygon — while you claimed **Suffolk**. That disagreement is the **trust guard** firing: the
+  polygon, while you claimed **Suffolk**. That disagreement is the **trust guard** firing: the
   coordinates are kept for you to inspect, but the names are **left exactly as you supplied them** (not
-  silently "corrected"). Maybe MIT really is across the county line from where you expected — or maybe
+  silently "corrected"). Maybe MIT really is across the county line from where you expected, or maybe
   the county was mis-entered. *You* decide.
 - **`Zzqxborough Nowhere` → `unresolved`.** The geocoder returned nothing. No coordinates, nothing
   changed.
 
 You don't have to take "Cambridge/Middlesex" on faith. `eri_spatial_reconcile()` returns the admin
-units the geocoded point actually fell into as `geocoded_<admin_col>` columns — so a flagged row tells
+units the geocoded point actually fell into as `geocoded_<admin_col>` columns, so a flagged row tells
 you *exactly* what it disagreed with, with no manual `sf::st_join()` to re-derive it:
 
 ```{r inspect-review}
@@ -178,17 +178,17 @@ result[result$reconcile_status == "geocoded_review",
 #> 1 MIT      Suffolk Cambridge          Middlesex
 ```
 
-Your `county` is still **Suffolk** (untouched — the trust guard never overwrote it), but
+Your `county` is still **Suffolk** (untouched, the trust guard never overwrote it), but
 `geocoded_adm2_name` shows the point landed in **Middlesex**. That side-by-side is the whole conflict,
 ready for you to confirm or fix. (These columns are `NA` for `matched`, `unresolved`, and
 outside-polygon rows.)
 
-## 4. What the statuses mean — and what to do {#statuses}
+## 4. What the statuses mean, and what to do {#statuses}
 
 | `reconcile_status` | What happened | What you do |
 |---|---|---|
-| `matched` | Name matched the boundary (offline) | Trust it — canonical name assigned |
-| `geocoded` | Geocoded **and** the admin parents agree with your data | Trust it — canonical name + coordinates assigned |
+| `matched` | Name matched the boundary (offline) | Trust it, canonical name assigned |
+| `geocoded` | Geocoded **and** the admin parents agree with your data | Trust it, canonical name + coordinates assigned |
 | `geocoded_review` | Geocoded, but the assigned admin unit **disagrees** with your claim (or the service flagged low confidence) | **Inspect** the `geocoded_*` columns to see what it disagreed with. Coordinates kept; names left untouched. Confirm or fix before using |
 | `unresolved` | No match, and either no geocode result **or** a point that fell outside every boundary (such rows may still carry coordinates) | Chase the source, or exclude with a note |
 
@@ -197,7 +197,7 @@ need a human** before they enter an analysis.
 
 ## 5. Feed it downstream {#downstream}
 
-The result is a plain tibble — your original rows, with canonical names filled in where confident and
+The result is a plain tibble, your original rows, with canonical names filled in where confident and
 `longitude`/`latitude` for anything geocoded. From here it is ordinary analysis (in *your* research
 project, not the package): aggregate the trusted rows, join to case counts, or map them. For mapping
 and spatial joins on the canonical units, see the
@@ -215,11 +215,11 @@ aggregate(cases ~ county, data = trusted, sum)
   `eri_spatial_load("dr", level = 3)` (or your country/level) to reconcile against the real admin
   units.
 - **Better geocoding:** OpenStreetMap is free and keyless but coarse. For higher accuracy use
-  `method = "google"` — it needs your own API key in `.Renviron`
+  `method = "google"`, it needs your own API key in `.Renviron`
   (`GOOGLEGEOCODE_API_KEY=...`); `eri_spatial_reconcile()` checks for it up front and tells you exactly
   what to add if it's missing. **Never put a key in a script or commit it.** Google also returns a
   `partial_match` flag, which feeds the same `geocoded_review` trust guard.
-- **No clean-up needed:** reconciliation is entirely in-memory — it reads your boundary and writes
+- **No clean-up needed:** reconciliation is entirely in-memory, it reads your boundary and writes
   nothing to Azure.
 
 ## What's next
@@ -227,8 +227,8 @@ aggregate(cases ~ county, data = trusted, sum)
 You can now turn a column of messy place names into canonical admin units with coordinates, with the
 uncertain ones flagged rather than hidden. From here:
 
-- [Running a research study](epi-research-guide.html) — where reconciled data feeds the analysis.
-- [Spatial workflow](spatial-workflow.html) — mapping and joining on the canonical units.
+- [Running a research study](epi-research-guide.html): where reconciled data feeds the analysis.
+- [Spatial workflow](spatial-workflow.html): mapping and joining on the canonical units.
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) and the
 [reference](../reference/index.html) for the full set.

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -16,25 +16,25 @@ knitr::opts_chunk$set(
 ```
 
 This is a hands-on, **start-to-finish walkthrough** of running a research study with
-`erifunctions`. It is written for **epidemiologists** — domain experts who are *not*
+`erifunctions`. It is written for **epidemiologists**, domain experts who are *not*
 software developers. You do not need to memorise anything: work through it once, in order,
 and you will have done every step a real study needs.
 
-To keep the focus on the *process* rather than the science, we use **`mtcars`** — the little
+To keep the focus on the *process* rather than the science, we use **`mtcars`**, the little
 car dataset that ships with R. It is public, tiny, and safe to copy anywhere, so you can run
 every command on your own laptop without touching any real Carter Center data. The
 analysis itself is deliberately trivial (a linear regression of fuel economy). **What
 matters here is the data management and the research lifecycle**, not the model.
 
 > **You can run this for real.** Every command below works against the live Azure system. If
-> you follow along, the very last section — [**Clean up**](#clean-up) — deletes everything you
+> you follow along, the very last section, [**Clean up**](#clean-up), deletes everything you
 > created, so you can practise the whole loop end-to-end and leave no trace.
 
 ## What you are about to build
 
 We will run a small study twice. First on an **initial dataset** (automatic-transmission cars
 only), then we will simulate **"new data arriving"** by expanding to the full dataset and
-re-running — exactly the situation you hit when a fresh extract lands months into a project.
+re-running, exactly the situation you hit when a fresh extract lands months into a project.
 
 ```{=html}
 <div class="mermaid">
@@ -55,7 +55,7 @@ The golden rule that shapes everything:
 
 > **`erifunctions` sources your data reproducibly and keeps it disciplined. _You_ do the
 > analysis.** The package gets data in and out, tracks where every input came from, and freezes
-> citable versions. The modelling, the epidemiology, the judgement calls — those live in *your*
+> citable versions. The modelling, the epidemiology, the judgement calls, those live in *your*
 > project's analysis code, not in the package.
 
 ## Before you start {#before-you-start}
@@ -70,7 +70,7 @@ You need four things, once:
    ```
 3. **Azure access.** There is nothing to configure. The first time a command needs Azure, your
    browser opens and you sign in with your Carter Center account; the sign-in is remembered for
-   the rest of the session. (No keys, no environment variables — see `?get_azure_storage_connection`.)
+   the rest of the session. (No keys, no environment variables, see `?get_azure_storage_connection`.)
 4. **A GitHub account**, and [GitHub Desktop](https://desktop.github.com/) if you prefer clicking
    to typing. We will use it below.
 
@@ -87,7 +87,7 @@ eri_verbosity("quiet")   # headline results, warnings and errors only
 ## 1. Start a project {#start-a-project}
 
 A study is its own self-contained project folder *and* its own GitHub repository (this keeps
-each study independently reproducible — see ADR-0006). One command builds the whole skeleton:
+each study independently reproducible, see ADR-0006). One command builds the whole skeleton:
 
 ```{r scaffold}
 eri_research_scaffold(
@@ -122,14 +122,14 @@ next step.
 
 ## 2. Make it a GitHub repository with the reproducibility check {#github-repo}
 
-Your study should live on GitHub so it is backed up, shareable, and — crucially — so the
+Your study should live on GitHub so it is backed up, shareable, and, crucially, so the
 **reproducibility check** runs. That check (`.github/workflows/ci.yaml`, created for you above)
 confirms that anyone can rebuild your exact software environment and load `erifunctions`. It
 stays dormant until you give it a `renv.lock` to check against.
 
 ### Put the project under version control
 
-You can do all of this **from inside R** — no command line needed:
+You can do all of this **from inside R**, no command line needed:
 
 ```{r git}
 install.packages("usethis")
@@ -156,12 +156,12 @@ renv::snapshot(type = "all")                    # write renv.lock
 ```
 
 Then **commit `renv.lock`** (and the `renv/` activation files). The moment that lockfile lands on
-GitHub, the reproducibility check goes green on every push — it restores your pinned environment
+GitHub, the reproducibility check goes green on every push, it restores your pinned environment
 on a clean machine and confirms `erifunctions` loads.
 
 > **Two `renv` gotchas worth avoiding.**
 >
-> - Install **`thecartercenter/erifunctions`**, not a personal fork, *before* you snapshot —
+> - Install **`thecartercenter/erifunctions`**, not a personal fork, *before* you snapshot,
 >   otherwise the lockfile pins the wrong source and a collaborator restoring it gets the wrong
 >   package.
 > - Use `renv::snapshot(type = "all")` so packages you only use for analysis (e.g. `ggplot2`) are
@@ -169,11 +169,11 @@ on a clean machine and confirms `erifunctions` loads.
 
 ## 3. Add your data and give it metadata {#add-data}
 
-Data does not live in your git repository — it lives in Azure, with a record of what it is. We
+Data does not live in your git repository, it lives in Azure, with a record of what it is. We
 register a file as an **artifact**: the file plus its *metadata* (a name, a type, a description,
 a version). This is how teammates later discover and trust it.
 
-First, create our **initial dataset** — automatic-transmission cars only (`am == 0`) — and save
+First, create our **initial dataset**, automatic-transmission cars only (`am == 0`), and save
 it locally:
 
 ```{r make-v1, eval=TRUE}
@@ -192,21 +192,21 @@ eri_artifact_upload(
   local_path  = "data/cars.csv",
   name        = "mtcars_study_data",
   type        = "study_data",
-  description = "mtcars fuel-economy study data — automatic transmissions only.",
+  description = "mtcars fuel-economy study data, automatic transmissions only.",
   version     = "1.0"
 )
 #> ✔ Artifact "mtcars_study_data" (study_data) uploaded to artifacts/study_data/mtcars_study_data/cars.csv.
 ```
 
-That `name`, `type`, `description`, and `version` **are the metadata** — they travel with the
+That `name`, `type`, `description`, and `version` **are the metadata**, they travel with the
 file and show up in `eri_artifact_list()` so anyone can see what it is without opening it.
 
-> **"Metadata" and "tags" are two different things — don't mix them up.**
+> **"Metadata" and "tags" are two different things, don't mix them up.**
 >
 > | | What it describes | When you set it | Function |
 > |---|---|---|---|
-> | **Artifact metadata** | *a single file* — what it is, its version | every time you upload data | `eri_artifact_upload()` |
-> | **A version tag** | *the whole study* — data **+** analysis code **+** outputs, frozen together and citable | at milestones only (see §10) | `eri_research_tag()` |
+> | **Artifact metadata** | *a single file*, what it is, its version | every time you upload data | `eri_artifact_upload()` |
+> | **A version tag** | *the whole study*, data **+** analysis code **+** outputs, frozen together and citable | at milestones only (see §10) | `eri_research_tag()` |
 >
 > Think of metadata as the **label on a jar**, and a version tag as a **photograph of the entire
 > kitchen** at one moment. We create our first tag in §10.
@@ -225,12 +225,12 @@ eri_research_pull(path = "artifacts/study_data/mtcars_study_data/cars.csv", dest
 
 > **Two ways to pull, on purpose.** `eri_artifact_pull("mtcars_study_data")` is the quick
 > registry shortcut. Here we pull by *path* with `eri_research_pull()` because it also records the
-> pull in `research.yaml`, archives any superseded version, and counts updates — exactly the
+> pull in `research.yaml`, archives any superseded version, and counts updates, exactly the
 > lifecycle this guide demonstrates in §11.
 
 > **Sourcing canonical, team-approved data.** When your study draws on data the analysts already
 > approved (not a study artifact you uploaded), **discover it in the catalog and pull it with the same
-> coordinates** — `eri_research_pull()` takes the four tokens `eri_catalog_query()` reports
+> coordinates**, `eri_research_pull()` takes the four tokens `eri_catalog_query()` reports
 > (`country`, `disease`, `data_source`, `data_type`):
 >
 > ```r
@@ -240,17 +240,17 @@ eri_research_pull(path = "artifacts/study_data/mtcars_study_data/cars.csv", dest
 >                   data_source = "surveillance", data_type = "case", dest = "data")
 > ```
 >
-> Discover what exists, then pull it with the coordinates the catalog handed you — one vocabulary,
+> Discover what exists, then pull it with the coordinates the catalog handed you, one vocabulary,
 > end to end.
 
 > **Never commit `data/` to git.** The scaffold's `.gitignore` already excludes it. Data lives in
 > Azure; your repository holds only *code* and the `research.yaml` record of what was pulled. For
 > `mtcars` it would not matter, but this is the habit that keeps real, protected country data safe
-> — see [Clean up](#clean-up).
+>, see [Clean up](#clean-up).
 
 ## 5. Where to run your analysis {#run-analysis}
 
-Your analysis goes in **`analysis/workflow.qmd`** in the project — that is what the scaffold
+Your analysis goes in **`analysis/workflow.qmd`** in the project, that is what the scaffold
 seeded it for, and what gets version-controlled and reproducibility-checked. Open it and write
 ordinary R. Read the data you just pulled, and fit the model:
 
@@ -268,7 +268,7 @@ model <- lm(mpg ~ wt + hp + disp, data = cars)
 summary(model)
 ```
 
-That is the whole analysis. Notice that **none of it used `erifunctions`** — the modelling is
+That is the whole analysis. Notice that **none of it used `erifunctions`**, the modelling is
 yours. The package's job starts again when you want to *save* and *freeze* what you found.
 
 ## 6. Save your analysis and figures {#save-outputs}
@@ -298,7 +298,7 @@ eri_research_upload_figure(
 ```
 
 As you make decisions, jot them in the project's **logbook**. These notes are timestamped and
-stay with the project — they are how "why did we drop those rows?" gets answered a year later:
+stay with the project, they are how "why did we drop those rows?" gets answered a year later:
 
 ```{r log}
 eri_research_log("Started with automatic transmissions only (am == 0); 19 cars.")
@@ -322,23 +322,23 @@ eri_research_status()
 #> 1 pull  artifacts/study_data/mtcars_study_data/cars.csv 2026-06-17T15:01:00Z       0 FALSE
 ```
 
-`eri_research_resume()` is the shorter "where was I?" view — last pull, last logbook entry,
+`eri_research_resume()` is the shorter "where was I?" view, last pull, last logbook entry,
 snapshot count. Use it at the **top of every work session** (more on that in §9).
 
 ## 8. Save a figure again later (updating it) {#update-figure}
 
-Figures evolve. When you improve one, just **re-upload it under the same filename** — it replaces
+Figures evolve. When you improve one, just **re-upload it under the same filename**, it replaces
 the previous version in Azure and the project keeps pointing at the current figure. There is no
 special "update" command; uploading the same name *is* the update. (We will do exactly this in
 §11 when the data changes.)
 
-## 9. Pause work — and pick it up weeks later {#pause-and-resume}
+## 9. Pause work, and pick it up weeks later {#pause-and-resume}
 
 Real studies stop and start. Here is how to put one down safely and find your way back.
 
 ### Pausing
 
-Before you walk away, take a **snapshot** — a timestamped freeze of your whole `data/` directory
+Before you walk away, take a **snapshot**, a timestamped freeze of your whole `data/` directory
 in Azure, so the exact inputs are recoverable even if a file changes later. Leave yourself a note,
 commit your code, and you are done:
 
@@ -372,15 +372,15 @@ eri_research_status()   # the fuller picture: inputs, outputs, tags
 Between `resume()` (what was I doing?) and `status()` (what do I have?), you are oriented in
 under a minute, however long it has been.
 
-## 10. When — and how — to tag a version {#tagging}
+## 10. When, and how, to tag a version {#tagging}
 
-A **tag** freezes the whole study at a moment — the data snapshot, the exact analysis code
-commit, and the outputs — under a name you can cite. It is the answer to *"reproduce the numbers
+A **tag** freezes the whole study at a moment, the data snapshot, the exact analysis code
+commit, and the outputs, under a name you can cite. It is the answer to *"reproduce the numbers
 in the report dated March."*
 
 > **When should you tag?** At **milestones**, not on a schedule. Good moments: you have finished
 > an analysis you will share or present; you are about to make a big change; you are submitting or
-> publishing. **Do not tag every day** — a tag marks *significant progress*, and tags are
+> publishing. **Do not tag every day**, a tag marks *significant progress*, and tags are
 > immutable, so a flurry of throwaway tags just adds noise. (Snapshots, from §9, are the cheap,
 > frequent safety net; tags are the rare, citable landmarks.)
 
@@ -399,18 +399,18 @@ eri_research_tag(
 That tag now binds *this data + this code + these outputs* together forever. Anyone with the
 label can reconstruct exactly what you did.
 
-## 11. New data arrives — update and re-run {#new-data}
+## 11. New data arrives, update and re-run {#new-data}
 
 Months in, a fuller dataset lands: we are no longer restricted to automatic cars. This is the
-moment most workflows handle badly — overwriting the old data and losing the trail. `erifunctions`
+moment most workflows handle badly, overwriting the old data and losing the trail. `erifunctions`
 handles it cleanly: the old version is archived, the change is counted, and your earlier tag still
 reproduces the original.
 
-Build the **expanded dataset** (drop the `am == 0` filter — all cars now) and re-upload it under
+Build the **expanded dataset** (drop the `am == 0` filter, all cars now) and re-upload it under
 the **same artifact name**, bumping the version. Re-using the name is an *update*, not a duplicate:
 
 ```{r make-v2, eval=TRUE}
-cars_v2 <- mtcars          # the full dataset now — both transmission types
+cars_v2 <- mtcars          # the full dataset now, both transmission types
 nrow(cars_v2)              # 32 cars, up from 19
 ```
 
@@ -421,7 +421,7 @@ eri_artifact_upload(
   local_path  = "data/cars.csv",
   name        = "mtcars_study_data",      # same name → updates the existing artifact
   type        = "study_data",
-  description = "mtcars fuel-economy study data — all transmissions (expanded).",
+  description = "mtcars fuel-economy study data, all transmissions (expanded).",
   version     = "2.0"
 )
 ```
@@ -443,9 +443,9 @@ eri_research_status()
 #> 1 pull  artifacts/study_data/mtcars_study_data/cars.csv 2026-07-01T09:00:00Z       1 TRUE
 ```
 
-See how `updates` ticked to `1` and `archived` is now `TRUE` — the original 19-car extract is
+See how `updates` ticked to `1` and `archived` is now `TRUE`, the original 19-car extract is
 safely archived, not gone. Re-run the analysis on the fuller data, update the figure (same
-filename — §8), log the change, and **tag the new version**:
+filename, §8), log the change, and **tag the new version**:
 
 ```{r rerun, eval=TRUE}
 cars <- mtcars
@@ -476,7 +476,7 @@ eri_research_tag(
 
 You now have **two citable versions**: `mtcars-am0-v1` (the original) and `mtcars-full-v1` (the
 update). The first still reproduces the original analysis exactly, even though the data has moved
-on — which is the whole point.
+on, which is the whole point.
 
 ## 12. Clean up {#clean-up}
 
@@ -486,7 +486,7 @@ Azure. This deletes the project folder, all snapshots and tags, and the artifact
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = "data")
 
-# eri_dir_delete() removes a non-empty directory recursively in one call — the
+# eri_dir_delete() removes a non-empty directory recursively in one call, the
 # in-package path, so cleanup stays in erifunctions instead of raw AzureStor.
 eri_dir_delete("research/mtcars_study", azcontainer = con)
 eri_dir_delete("artifacts/study_data/mtcars_study_data", azcontainer = con)
@@ -502,7 +502,7 @@ unlink("../mtcars_study", recursive = TRUE)   # remove the local project folder
 ```
 
 > **Why we could delete freely here:** `mtcars` is public sample data. **Real Carter Center data
-> is different** — country surveillance and study data must never be deleted casually, copied off
+> is different**, country surveillance and study data must never be deleted casually, copied off
 > Azure, or committed to git. The discipline this guide builds (data stays in Azure, pulled with
 > provenance, frozen with tags) is exactly what keeps protected data safe. When in doubt, ask
 > before you delete.
@@ -512,7 +512,7 @@ unlink("../mtcars_study", recursive = TRUE)   # remove the local project folder
 You have now done the full research lifecycle: start, version-control, add and source data,
 analyse, save, tag, pause, resume, handle new data, and tidy up.
 
-This is the first of a planned set of short, task-oriented guides — **one for each common
+This is the first of a planned set of short, task-oriented guides, **one for each common
 job** an analyst or epidemiologist does (running a monthly country report, ingesting a
 surveillance dataset, onboarding a new country, and more). See
 [the guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md)

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-`erifunctions` is the Carter Center ERI team's R package — the way **Data Analysts** and
+`erifunctions` is the Carter Center ERI team's R package, the way **Data Analysts** and
 **Epidemiologists** work with TCC's Azure-centred data system across countries (Haiti, DR, Uganda,
 OEPA, …) and diseases (malaria, oncho, LF, SCH, STH). You install it, authenticate through your
 browser, and call functions; you don't edit the package. This page is the **front door**: learn the
@@ -29,9 +29,9 @@ remotes::install_github("thecartercenter/erifunctions")
 library(erifunctions)
 ```
 
-Azure access is **zero-config** — the first command that needs it opens your browser to sign in. ODK,
+Azure access is **zero-config**, the first command that needs it opens your browser to sign in. ODK,
 SharePoint, and Teams need a little setup. The **[Connecting to Azure, ODK, SharePoint &
-Teams](connections-guide.html)** guide walks through each and how to confirm it works — including the
+Teams](connections-guide.html)** guide walks through each and how to confirm it works, including the
 one thing to do **before your first governed action**: set `ERI_ANALYST_ID` so approvals and logs
 carry your name, not your OS username.
 
@@ -49,7 +49,7 @@ what it measures (`data_type`)**. The same `surveillance` channel is a `case` li
 and an `aggregate` weekly count in another; one CMR fans out to `treatment`, `mmdp`, and survey
 measures across diseases.
 
-Run `eri_data_model()` once — it prints the whole vocabulary, so you never have to guess a value:
+Run `eri_data_model()` once, it prints the whole vocabulary, so you never have to guess a value:
 
 ```{r data-model}
 eri_data_model()
@@ -63,7 +63,7 @@ eri_data_model()
 #>   (… plus the measures, formats, and layers, and the transitional cmr/odk tokens.)
 ```
 
-Everything moves through three **layers** — `raw/` (as received) → `staged/` (DQ-checked) →
+Everything moves through three **layers**, `raw/` (as received) → `staged/` (DQ-checked) →
 `processed/` (the canonical data the whole team trusts). Nothing reaches `processed/` without a human
 calling `eri_approve()`.
 
@@ -79,9 +79,9 @@ keep the [**DA cheat sheet**](da-cheatsheet.html) and the [data-model card](data
 you work.
 
 1. [Connecting to the services](connections-guide.html)
-2. [Onboarding a new country / disease / data type](da-onboard-guide.html) — stand up the space
-3. [Ingesting a surveillance dataset](da-ingest-guide.html) — raw → DQ → staged → **approved**
-4. [Triaging the error & DQ log backlog](da-logs-guide.html) — find what failed and close it out
+2. [Onboarding a new country / disease / data type](da-onboard-guide.html): stand up the space
+3. [Ingesting a surveillance dataset](da-ingest-guide.html): raw → DQ → staged → **approved**
+4. [Triaging the error & DQ log backlog](da-logs-guide.html): find what failed and close it out
 
 Then, as those feeds arrive: [monthly **CMR** reports](da-cmr-guide.html) and
 [**ODK Central** forms](da-odk-guide.html).
@@ -89,9 +89,9 @@ Then, as those feeds arrive: [monthly **CMR** reports](da-cmr-guide.html) and
 ### New Epidemiologist
 
 1. [Connecting to the services](connections-guide.html)
-2. [A complete research workflow](epi-research-guide.html) — source approved data, analyse, tag a version
-3. [Reconciling localities to admin units](epi-reconcile-guide.html) — messy place names → canonical units
-4. [Catching anomalies in a new extract](epi-dq-guide.html) — QC for epidemiological sense
+2. [A complete research workflow](epi-research-guide.html): source approved data, analyse, tag a version
+3. [Reconciling localities to admin units](epi-reconcile-guide.html): messy place names → canonical units
+4. [Catching anomalies in a new extract](epi-dq-guide.html): QC for epidemiological sense
 
 Then the [epi analytics helpers](epi-analytics.html) for incidence, epiweeks, and curves.
 
@@ -100,7 +100,7 @@ Then the [epi analytics helpers](epi-analytics.html) for incidence, epiweeks, an
 - **Topic deep-dives** explain the engines behind the role guides: the
   [data-quality pipeline](dq-pipeline.html), the [spatial workflow](spatial-workflow.html), and
   [SharePoint & Teams](sharepoint-workflow.html).
-- **Extending the package** — [adding a new program](adding-a-program.html): contribute a schema and
+- **Extending the package**: [adding a new program](adding-a-program.html): contribute a schema and
   disease analytics for a new country/disease.
 - The [function reference](../reference/index.html) groups every function by purpose, and the
   [roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) tracks where the

--- a/vignettes/onboarding.Rmd
+++ b/vignettes/onboarding.Rmd
@@ -13,29 +13,29 @@ tribal knowledge. It ships with the package, so when a guide or function changes
 with it.
 
 > **Who this is for:** a new DA who can run R scripts and edit code but isn't yet fluent. Every step is
-> copy-paste on **safe sandbox data** — you cannot harm real country data by following it.
+> copy-paste on **safe sandbox data**, you cannot harm real country data by following it.
 
 ## How the learning is kept safe
 
 You practice in throwaway namespaces that are designed to be created and deleted:
 
-- **`atlantis`** — a make-believe country for the ingest/onboard guides.
-- **`uga/demo`** — a sandbox country/disease for the ODK pipeline (not the real `uga/oncho`).
-- **`eri_test_river_prospection` / `eri_test_river_repeat`** — practice ODK forms in the ODK `testing`
+- **`atlantis`**: a make-believe country for the ingest/onboard guides.
+- **`uga/demo`**: a sandbox country/disease for the ODK pipeline (not the real `uga/oncho`).
+- **`eri_test_river_prospection` / `eri_test_river_repeat`**: practice ODK forms in the ODK `testing`
   project.
 
 Every guide ends with a **Clean up** section that removes what it created. Real `processed/` data is
-never deleted casually — the sandbox is where you make mistakes.
+never deleted casually, the sandbox is where you make mistakes.
 
-## Week 0 — Setup (before day one)
+## Week 0, Setup (before day one)
 
 Get the environment standing so day one is learning, not yak-shaving. Use the
 [connections guide](connections-guide.html).
 
 - [ ] Install **R + RStudio**.
 - [ ] Install the package: `renv` + `remotes::install_github("thecartercenter/erifunctions")`.
-- [ ] **Azure access granted** — your account needs RBAC on the `data` blob (a ticket to an ERI admin;
-      this is the long-lead item — start it first).
+- [ ] **Azure access granted**, your account needs RBAC on the `data` blob (a ticket to an ERI admin;
+      this is the long-lead item, start it first).
 - [ ] **ODK Central account** with access to the `testing` project.
 - [ ] `.Renviron` set: `ERI_ANALYST_ID`, `ODK_URL/USER/PASS` (see the connections guide). **Restart R.**
 - [ ] **Verify:** `eri_list("", azcontainer = get_azure_storage_connection(storage_name = "data"))`
@@ -43,7 +43,7 @@ Get the environment standing so day one is learning, not yak-shaving. Use the
 
 ✅ **Gate:** you can connect to Azure and ODK.
 
-## Day 1 — Orientation
+## Day 1, Orientation
 
 - [ ] Read [Getting started](getting-started.html) and the [Orientation](orientation.html) overview.
 - [ ] Run **`eri_data_model()`** and read the [data-model card](data-model-card.html) until the
@@ -52,31 +52,31 @@ Get the environment standing so day one is learning, not yak-shaving. Use the
 
 ✅ **Gate:** you can explain what the five path axes mean and why `eri_approve()` is the gate.
 
-## Days 2–4 — The ingestion spine (do it live)
+## Days 2–4, The ingestion spine (do it live)
 
 Work these guides in order, on the sandbox, running every chunk. Stop at each checkpoint.
 
-- [ ] [Connections guide](connections-guide.html) — connect to all four services.
-- [ ] [Onboard a space](da-onboard-guide.html) — stand up a new `atlantis` space (schema + dirs).
+- [ ] [Connections guide](connections-guide.html), connect to all four services.
+- [ ] [Onboard a space](da-onboard-guide.html), stand up a new `atlantis` space (schema + dirs).
       *Checkpoint: you scaffolded a space and validated its schema.*
-- [ ] [Ingest a surveillance dataset](da-ingest-guide.html) — raw → DQ → staged → **approve**.
+- [ ] [Ingest a surveillance dataset](da-ingest-guide.html), raw → DQ → staged → **approve**.
       *Checkpoint: you approved a dataset and saw it in the catalog.*
-- [ ] [Upload & split a CMR](da-cmr-guide.html) — upload → split → approve a monthly CMR.
+- [ ] [Upload & split a CMR](da-cmr-guide.html), upload → split → approve a monthly CMR.
       *Checkpoint: you split a CMR per disease.*
-- [ ] [Work with ODK Central](da-odk-guide.html) — connect → monitor → register → sync → approve.
+- [ ] [Work with ODK Central](da-odk-guide.html), connect → monitor → register → sync → approve.
       *Checkpoint: you synced submissions into the pipeline.*
-- [ ] [Triage the log backlog](da-logs-guide.html) — triage and resolve a log.
+- [ ] [Triage the log backlog](da-logs-guide.html), triage and resolve a log.
       *Checkpoint: you closed an item in the backlog.*
 
 ✅ **Gate:** you can take a file from each of the three channels through to `processed/` on the sandbox.
 
-## Week 2 — Downstream work + shadowing
+## Week 2, Downstream work + shadowing
 
 - [ ] [Answer an ad-hoc request](da-adhoc-guide.html) with `eri_query()`. Other downstream guides (QC +
-      country feedback, routine reporting, final survey reports) ship as they land — check the
+      country feedback, routine reporting, final survey reports) ship as they land, check the
       [Articles menu](https://thecartercenter.github.io/erifunctions/articles/) for what's available.
 - [ ] **Pair** with a senior DA on a real (but sandboxed) task end-to-end.
-- [ ] Take a **first supervised real task** — a real ingest or QC review, reviewed before you approve.
+- [ ] Take a **first supervised real task**, a real ingest or QC review, reviewed before you approve.
 - [ ] Make your **first contribution**: fix a typo or unclear line in a guide via a PR. This teaches the
       issue → branch → PR workflow and how the docs are maintained.
 
@@ -102,6 +102,6 @@ A DA is "onboarded" when both of you can tick every box from observed work, not 
 - The [DA cheat sheet](da-cheatsheet.html) and the [troubleshooting card](troubleshooting.html) are your
   desk reference.
 - The [Articles menu](https://thecartercenter.github.io/erifunctions/articles/) is the **"how do I do
-  X?"** lookup — start there, not the function reference.
+  X?"** lookup, start there, not the function reference.
 - Keep a **buddy/mentor** for the first month; questions are faster than docs at first.
-- When you hit something the guides don't cover, that's a gap worth filing — open an issue.
+- When you hit something the guides don't cover, that's a gap worth filing, open an issue.

--- a/vignettes/orientation.Rmd
+++ b/vignettes/orientation.Rmd
@@ -7,15 +7,15 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-The big picture for a new Data Analyst — the data system, the human-gated pipeline, and where your
+The big picture for a new Data Analyst, the data system, the human-gated pipeline, and where your
 tasks live. Read this once before the hands-on guides; it's also the basis for a first training
 session. (For the step-by-step path, see [Onboarding](onboarding.html).)
 
 ## What erifunctions is
 
-The ERI team's R package — the **API to TCC's Azure data system** across countries (Haiti, DR, Uganda,
+The ERI team's R package, the **API to TCC's Azure data system** across countries (Haiti, DR, Uganda,
 OEPA, …) and diseases (malaria, oncho, LF, SCH, STH). You are a **domain expert**, not a software
-developer: you install it and **call functions** — you don't edit the package. Every function is built
+developer: you install it and **call functions**, you don't edit the package. Every function is built
 to make *your* work clearer and more reliable.
 
 ## The data lives in three layers
@@ -24,7 +24,7 @@ to make *your* work clearer and more reliable.
 data/{country}/{disease}/{data_source}/{data_type}/
    raw/        as-received from the source
    staged/     DQ-checked, awaiting sign-off
-   processed/  analyst-approved — the data the whole team trusts
+   processed/  analyst-approved, the data the whole team trusts
 ```
 
 Data flows **one way**: `raw → staged → processed`. Raw is untouched; staged is cleaned but
@@ -32,7 +32,7 @@ provisional; processed is canonical. The direction never reverses.
 
 ## The golden rule
 
-> **Nothing reaches `processed/` without `eri_approve()` — the human gate.**
+> **Nothing reaches `processed/` without `eri_approve()`, the human gate.**
 
 `eri_approve()` moves staged → processed, writes an approval log, and registers the file in the
 catalog. **You are the gate**: nothing is "official" until you sign off, and the sign-off is stamped
@@ -48,9 +48,9 @@ data / country / disease / data_source / data_type / layer
 - **`data_source`** = the **channel** (how it arrives): surveillance · programmatic · research
 - **`data_type`** = the **measure** (what it counts): case · aggregate · treatment · mmdp · survey · …
 
-Run **`eri_data_model()`** to print the live vocabulary. Channel and measure are **independent** — the
+Run **`eri_data_model()`** to print the live vocabulary. Channel and measure are **independent**, the
 same channel carries different measures, and the same (channel, disease) differs by country (DR malaria
-surveillance is `case`; Haiti malaria surveillance is `aggregate`). A missing combination is *normal* —
+surveillance is `case`; Haiti malaria surveillance is `aggregate`). A missing combination is *normal*,
 it warns, it doesn't error. The [data-model card](data-model-card.html) is the deep reference.
 
 ## Which pipeline for which data?
@@ -78,18 +78,18 @@ full decision tree.
 ## A boundary worth stating
 
 **Creating ODK forms is *not* an erifunctions task.** Survey **forms are authored in the ODK Central
-UI** (XLSForm); erifunctions picks up at **sync** — it pulls submissions, monitors deployment, and
+UI** (XLSForm); erifunctions picks up at **sync**, it pulls submissions, monitors deployment, and
 backfills records. (In R, you don't *make* a form; you make it in ODK, then the package takes over.)
 
 ## Three golden rules to leave with
 
 1. **The gate is sacred.** Nothing is real until `eri_approve()`; never touch `processed/` by hand.
-2. **Secrets live only in `.Renviron`** — never in a script, never in git. Set `ERI_ANALYST_ID` first.
+2. **Secrets live only in `.Renviron`**: never in a script, never in git. Set `ERI_ANALYST_ID` first.
 3. **Real country data never leaves the system.** Practice on the sandbox; protect the real thing.
 
 ## Where to learn next
 
-- The [onboarding path](onboarding.html) — the paced Week-0 → Week-2 track.
+- The [onboarding path](onboarding.html), the paced Week-0 → Week-2 track.
 - The [cheat sheet](da-cheatsheet.html), [data-model card](data-model-card.html), and
-  [troubleshooting card](troubleshooting.html) — your desk reference.
+  [troubleshooting card](troubleshooting.html), your desk reference.
 - The run-it-live guides in the **Articles** menu, and `eri_data_model()` as your in-session lookup.

--- a/vignettes/spatial-workflow.Rmd
+++ b/vignettes/spatial-workflow.Rmd
@@ -81,7 +81,7 @@ case_data <- eri_spatial_join(
 )
 ```
 
-The result is a plain tibble — geometry is dropped automatically, so downstream
+The result is a plain tibble, geometry is dropped automatically, so downstream
 analysis does not need to handle `sf` objects.
 
 ## Bounding box expansion
@@ -148,7 +148,7 @@ communes$population <- exact_extract(pop_raster, communes, "sum")
 ## Onchocerciasis programme-status maps
 
 For OEPA onchocerciasis data, `eri_oncho_status_map()` wraps the full mapping
-pipeline — it joins status data to a shapefile, applies the standard ERI
+pipeline, it joins status data to a shapefile, applies the standard ERI
 programme-status colour palette, and adds a scale bar and north arrow:
 
 ```{r oncho-map}

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -16,11 +16,11 @@ backlog with `eri_logs()`.*
 |----------------------|---------------|-----|
 | `403 Forbidden` (Azure) | Your account isn't granted access to that storage (RBAC). **Not** a code bug. | Ask an ERI admin to add you. |
 | `ODK username is required` / `password is required` | `ODK_USER` / `ODK_PASS` not set | Add to `.Renviron`; **restart R**. |
-| `… is not a known ERI country` | `eri_odk_register()` checks a fixed list — `dr/ht/eth/nga/sdn/ssd/uga/mad/tcd` (disease is free text). Note: the general pipeline (`eri_ingest`/`eri_approve`) takes free-text country, so `oepa` etc. work there but not for ODK registration. | Use a listed code; sandbox practice uses a real code + a fake disease (e.g. `uga`/`demo`). |
+| `… is not a known ERI country` | `eri_odk_register()` checks a fixed list, `dr/ht/eth/nga/sdn/ssd/uga/mad/tcd` (disease is free text). Note: the general pipeline (`eri_ingest`/`eri_approve`) takes free-text country, so `oepa` etc. work there but not for ODK registration. | Use a listed code; sandbox practice uses a real code + a fake disease (e.g. `uga`/`demo`). |
 | `Form … is not in the ODK registry` | You called `eri_odk_sync()` for an unregistered form | `eri_odk_register()` it first. |
 | `No schema found` / `load_dq_schema()` can't resolve | The `{country}_{disease}_{source}_{measure}.yaml` schema doesn't exist | Check the four axes match a bundled schema; if it's a new space, author one ([onboarding guide](da-onboard-guide.html)). |
 | `File not found: …` | A local path (CMR Excel, upload CSV) is wrong | Check the path; use an absolute path. |
-| Warning: *unknown `data_source`/`data_type`* | The axis value isn't in the registry | Expected for a new space — it **warns, not errors**. Confirm the spelling, or onboard the new value. |
+| Warning: *unknown `data_source`/`data_type`* | The axis value isn't in the registry | Expected for a new space, it **warns, not errors**. Confirm the spelling, or onboard the new value. |
 | `data_type will be "NA"` on approve | You approved without the measure (5th arg) | Pass `data_type = "case"` (etc.) to record the measure in the catalog. |
 | Output looks stale after editing `.Renviron` | `.Renviron` is read once at startup | **Restart R** after every `.Renviron` edit. |
 | A change to exports/docs isn't reflected | `NAMESPACE`/`man/` out of date | (Maintainers) re-run `devtools::document()`. |
@@ -31,7 +31,7 @@ backlog with `eri_logs()`.*
 
 ## Working the log backlog (task: review errors & logs)
 
-Every operation leaves a structured log in Azure. `eri_logs()` is the **shared backlog** — any analyst
+Every operation leaves a structured log in Azure. `eri_logs()` is the **shared backlog**, any analyst
 can see what failed or needs review and close it out.
 
 ```r
@@ -45,8 +45,8 @@ eri_logs_resolve(log_path, note = "re-ran ingest after fixing the date column")
 eri_logs(include_handled = TRUE)           # confirm it's closed
 ```
 
-- `eri_logs()` hides handled items by default — the open list shrinks as you resolve.
+- `eri_logs()` hides handled items by default, the open list shrinks as you resolve.
 - Persist a DQ result's flags yourself with
   `eri_dq_log(result, country, disease, data_source, data_type = )` (note: `data_source` is the 4th
-  argument, the measure `data_type` the 5th — mind the source/measure order).
+  argument, the measure `data_type` the 5th, mind the source/measure order).
 - Full walkthrough: the [log-triage guide](da-logs-guide.html).


### PR DESCRIPTION
Closes #258.

Applies Nishant's writing-voice standard to the public pkgdown documentation, plus one factual accuracy fix. **Prose only; no code behavior changes.**

## What changed
- **Em-dash sweep: 517 → 0** across all 24 vignettes, `README.md`, `docs/roadmap.md`, `docs/guides.md`, and `docs/vision.md`. Em dashes were the one hard rule in the style guide (zero in Nishant's own prose) and the dominant drift.
- **Documentation-voice standard** added to `CONTRIBUTING.md` so this does not regress: no em-dash connectors, Oxford commas, register-by-file (how-to guides keep "you"/imperatives; narrative docs carry the declarative voice), bolding for UI/role/layer terms is fine.
- **README Setup accuracy fix.** The Setup block listed the full Azure tenant/app/endpoint/SP env vars as required. Per ADR-0008 (`R/dal.R:15-17`) those are baked-in defaults and Azure auth is zero-config interactive; ODK needs only user/pass. Rewrote Setup to the real minimum (`ERI_ANALYST_ID` + ODK creds), with the rest under "advanced, rarely needed."

## How the sweep was done (not a blind replace)
- Definition lead-ins at line start → colon (`**repeat groups**:`, `[Orientation](…):`).
- Mid-sentence connectors → comma; parenthetical double-dashes → commas/parens; wrapped and line-initial dashes merged by hand.
- Register-neutral: the how-to guides keep their instructional "you" voice; only tell-level fixes applied.

## Verification
- 0 em-dashes across the corpus.
- No punctuation artifacts (`,,` / `, ,` / `,.` / stray leading commas).
- No R code touched (one code *comment* only); all code fences balanced.
- The four README guide bullets read consistently as `[Link](…): description`.

## Note on GitHub Pages
The pkgdown site deploys on push/PR to `main` and on release, not on `dev`. These docs go live when `dev` is merged to `main`.