### PR TITLE
Release 0.9.1 — fix ADR-0002 conditional metadata writes on ADLS Gen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.0
+Version: 0.9.1
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,26 @@
-# erifunctions (development version)
+# erifunctions 0.9.1
+
+## Fix: metadata writes on ADLS Gen2, and ODK auto-connect
+
+- **Concurrency-safe metadata writes now work on the ADLS Gen2 (`dfs`) endpoint.**
+  The conditional write behind `.eri_yaml_update()` (ADR-0002) issued a blob-API
+  PUT (`x-ms-blob-type: BlockBlob` with `If-Match`/`If-None-Match`) that the `dfs`
+  endpoint — the package default — rejects with `HTTP 400 ("An HTTP header that's
+  mandatory for this request is not specified")`, writing nothing. Every metadata
+  store was affected: the ODK registry, the data catalog, the artifact registry,
+  and `eri_feedback()`. The versioned read and conditional write now route through
+  the same account's **blob** endpoint, which supports these operations natively —
+  including the `412` stale-ETag conflict that guards the optimistic-concurrency
+  retry loop. Parquet/file writes (which already used the correct `storage_upload`
+  path) are unchanged. This had surfaced as `eri_odk_sync()` erroring on its final
+  `last_synced` update even though every Parquet had already landed in `raw/`.
+  See ADR-0016.
+- **The ODK functions auto-connect again.** With no `data_con` passed,
+  `.odk_data_con()` built its token from bare `Sys.getenv()` reads and sent an
+  empty `client_id` when those vars were unset, failing with `AADSTS900144`. It now
+  delegates to `get_azure_storage_connection()` — the same zero-config connector
+  the rest of the package uses — so auto-connect inherits the interactive-auth
+  defaults (mirrors `.eri_research_con()` / `.eri_logs_con()`).
 
 ## Feature: `eri_simulate_check()` — confirm the cutover gate catches divergence
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -10,11 +10,34 @@
 # fails with HTTP 412; we re-read, re-apply `mutate` to the *fresh* data, and
 # retry — so neither writer's entry is lost. See ADR-0002.
 
+# The conditional metadata ops below use blob-API semantics — `x-ms-blob-type:
+# BlockBlob` with an `If-Match`/`If-None-Match` PUT of the whole body. The ADLS
+# Gen2 **dfs** endpoint (the package default) rejects that shape with HTTP 400
+# ("An HTTP header that's mandatory for this request is not specified") and writes
+# nothing; the same account's **blob** endpoint serves the identical files and
+# supports these ops natively (create/conditional-update/412-on-stale). So the
+# versioned read *and* the conditional write route through the blob endpoint,
+# derived in-place from the passed container (dfs host -> blob host, same token
+# and filesystem). A container that is already blob-backed — or any test double
+# that isn't a real ADLS filesystem — is returned unchanged. See ADR-0016.
+#' @keywords internal
+.eri_blob_metadata_con <- function(con) {
+  if (!inherits(con, "adls_filesystem")) return(con)
+  ep      <- con$endpoint
+  blob_ep <- AzureStor::blob_endpoint(
+    sub("\\.dfs\\.", ".blob.", ep$url),
+    token = ep$token, key = ep$key, sas = ep$sas,
+    api_version = ep$api_version
+  )
+  AzureStor::storage_container(blob_ep, con$name)
+}
+
 # Read a YAML blob together with its ETag in a single GET.
 # Returns list(data = <parsed yaml or `default`>, etag = <chr or NULL>).
 # A missing blob yields the default and a NULL etag (signals "create").
 #' @keywords internal
 .eri_yaml_read_versioned <- function(con, path, default = list()) {
+  con  <- .eri_blob_metadata_con(con)
   resp <- AzureStor::do_container_op(
     con, path, http_verb = "GET", http_status_handler = "pass"
   )
@@ -46,7 +69,10 @@
   tmp <- tempfile(fileext = ".yaml")
   on.exit(unlink(tmp))
   yaml::write_yaml(data, tmp)
+  # Ensure the parent directory on the ADLS container (where the rest of the
+  # package reads/writes); the conditional PUT itself goes to the blob endpoint.
   .eri_create_azure_dir(con, dirname(path))
+  blob_con <- .eri_blob_metadata_con(con)
 
   body    <- readBin(tmp, "raw", n = file.info(tmp)$size)
   headers <- list(
@@ -60,7 +86,7 @@
   }
 
   resp <- AzureStor::do_container_op(
-    con, path, headers = headers, body = body,
+    blob_con, path, headers = headers, body = body,
     http_verb = "PUT", http_status_handler = "pass"
   )
   status <- resp$status_code
@@ -68,7 +94,7 @@
   if (status >= 300L) {
     # Re-issue with the "stop" handler to surface the real storage error.
     AzureStor::do_container_op(
-      con, path, headers = headers, body = body, http_verb = "PUT"
+      blob_con, path, headers = headers, body = body, http_verb = "PUT"
     )
   }
   TRUE

--- a/R/odk_registry.R
+++ b/R/odk_registry.R
@@ -27,15 +27,15 @@
 #' @keywords internal
 .odk_data_con <- function(data_con) {
   if (!is.null(data_con)) return(data_con)
-  token <- AzureAuth::get_azure_token(
-    resource  = "https://storage.azure.com/",
-    tenant    = Sys.getenv("ERIFUNCTIONS_TENANT_ID"),
-    app       = Sys.getenv("ERIFUNCTIONS_APP_ID"),
-    auth_type = "authorization_code"
-  )
-  AzureStor::storage_container(
-    AzureStor::storage_endpoint(Sys.getenv("ERIFUNCTIONS_RESOURCE_ENDPOINT"), token = token),
-    Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", unset = "data")
+  # Delegate to the shared connector so auto-connect inherits the zero-config
+  # interactive-auth defaults (app_id / tenant_id / resource_endpoint). Building
+  # the token here from bare `Sys.getenv()` reads — as this once did — sent an
+  # empty `client_id` when those vars were unset, failing with AADSTS900144.
+  # Mirrors `.eri_research_con()` / `.eri_logs_con()` / `.eri_catalog_con()`.
+  suppressMessages(
+    get_azure_storage_connection(
+      storage_name = Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", unset = "data")
+    )
   )
 }
 

--- a/docs/adr/0016-metadata-conditional-writes-blob-endpoint.md
+++ b/docs/adr/0016-metadata-conditional-writes-blob-endpoint.md
@@ -1,0 +1,58 @@
+# ADR-0016 — Conditional metadata writes go through the blob endpoint
+
+- **Status:** Accepted
+- **Date:** 2026-07-07
+
+## Context
+
+The concurrency-safe metadata stores (ADR-0002) — the data catalog, the ODK registry, the artifact
+registry, and the feedback log — are single YAML blobs updated by an optimistic-concurrency
+read-modify-write. `.eri_yaml_update()` reads the blob with its ETag, applies the caller's mutate, and
+writes back **conditionally**: `If-None-Match: *` to create, `If-Match: <etag>` to update, re-reading and
+retrying on the `HTTP 412` a losing race produces.
+
+That conditional write was implemented as a single blob-API `PUT` — `x-ms-blob-type: BlockBlob` plus the
+`If-*` header and the whole body — issued through `AzureStor::do_container_op()` against the container the
+rest of the package uses. That container is an **ADLS Gen2 filesystem on the `dfs` endpoint**
+(`https://eridev.dfs.core.windows.net/`, the baked default — see `R/dal.R`). The `dfs` endpoint does not
+serve the blob `Put Blob` API; it rejects that request shape with `HTTP 400 ("An HTTP header that's
+mandatory for this request is not specified")` and writes nothing.
+
+The bug was latent because the unit tests mock `do_container_op`, and the file/Parquet write path
+(`storage_upload`, which AzureStor maps to the correct DataLake create/append/flush sequence) works fine —
+so data landed while the *metadata* write silently failed. It surfaced in the Phase-3 pilot when a live
+`eri_odk_sync()` wrote all its Parquet tables to `raw/` and then errored on the final `last_synced`
+registry update. Every conditional metadata write was affected on the default endpoint, `eri_feedback()`
+included.
+
+An ADLS Gen2 storage account is multi-protocol: the same files are reachable, with the same AAD token, via
+the account's **blob** endpoint (`https://eridev.blob.core.windows.net/`), which *does* support `Put Blob`
+with conditional `If-Match`/`If-None-Match` and returns `412` on a stale ETag. Verified live against the
+`eridev` account: create → `201`, conditional update → `201`, stale-ETag update → `412`.
+
+## Decision
+
+The ADR-0002 conditional **read and write** (`.eri_yaml_read_versioned()` / `.eri_yaml_write_conditional()`
+in `R/metadata.R`) route through the same account's **blob** endpoint, derived in-place from the passed
+container by `.eri_blob_metadata_con()`: swap the `dfs` host for the `blob` host, reuse the token / key /
+SAS and the filesystem name. A container that is already blob-backed — or any test double that is not a real
+`adls_filesystem` — is returned unchanged, so callers and the mocked test seam are unaffected.
+
+- **Scope is deliberately narrow.** Only the small, conditional metadata ops move to the blob endpoint.
+  Bulk data I/O (`eri_read`/`eri_write`, snapshots, artifacts) keeps using the `dfs`/ADLS container and its
+  `storage_upload` path, which works and gives ADLS the hierarchical-namespace semantics the data layout
+  relies on. The parent-directory ensure still runs on the ADLS container.
+- **Reuse, don't reinvent** (per the CLAUDE.md guardrail): the routing is one helper shared by both metadata
+  ops, not a per-store fix.
+
+## Consequences
+
+- **Easier:** every metadata store (catalog, ODK registry, artifact registry, feedback) writes correctly on
+  the default ADLS Gen2 endpoint, with the optimistic-concurrency guarantee intact. No configuration change
+  for users.
+- **Harder:** the metadata path now assumes the account exposes its blob endpoint (true for any ADLS Gen2
+  account) and that the `dfs`↔`blob` host substitution holds. Both are standard, but they are now an
+  implicit dependency of ADR-0002.
+- **Not doing:** implementing conditional writes via the native DataLake create/append/**flush** sequence
+  (which also supports `If-Match`). It is a three-call dance for a small blob; the blob endpoint is one call
+  and the exact semantics the code already expresses.

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -76,6 +76,76 @@ test_that(".eri_yaml_write_conditional sends If-Match for an update and reports 
   expect_equal(seen[["If-Match"]], "\"v1\"")
 })
 
+# --- .eri_blob_metadata_con (ADLS Gen2 -> blob routing, ADR-0016) -------------
+
+test_that(".eri_blob_metadata_con routes an ADLS (dfs) container to the blob endpoint", {
+  seen_url <- NULL; seen_name <- NULL
+  local_mocked_bindings(
+    blob_endpoint = function(endpoint, ...) {
+      seen_url <<- endpoint
+      structure(list(url = endpoint), class = "blob_endpoint")
+    },
+    storage_container = function(endpoint, name) {
+      seen_name <<- name
+      structure(list(endpoint = endpoint, name = name),
+                class = c("blob_container", "storage_container"))
+    },
+    .package = "AzureStor"
+  )
+  adls <- structure(
+    list(
+      endpoint = structure(
+        list(url = "https://eridev.dfs.core.windows.net/",
+             token = "T", key = NULL, sas = NULL),
+        class = "adls_endpoint"),
+      name = "data"),
+    class = c("adls_filesystem", "storage_container"))
+
+  out <- erifunctions:::.eri_blob_metadata_con(adls)
+  expect_equal(seen_url, "https://eridev.blob.core.windows.net/")  # dfs host -> blob host
+  expect_equal(seen_name, "data")                                  # same filesystem
+  expect_s3_class(out, "blob_container")
+})
+
+test_that(".eri_blob_metadata_con leaves a non-ADLS container unchanged", {
+  expect_identical(erifunctions:::.eri_blob_metadata_con("con"), "con")   # test double
+  blob <- structure(list(name = "data"), class = c("blob_container", "storage_container"))
+  expect_identical(erifunctions:::.eri_blob_metadata_con(blob), blob)     # already blob
+})
+
+test_that(".eri_yaml_write_conditional PUTs to the blob endpoint but ensures the dir on ADLS", {
+  # The load-bearing split of the fix: given a real ADLS (dfs) container, the
+  # conditional PUT must target the blob-derived container while the parent-dir
+  # ensure stays on the ADLS container (HNS directories are a dfs concept).
+  adls <- structure(
+    list(
+      endpoint = structure(
+        list(url = "https://eridev.dfs.core.windows.net/",
+             token = "T", key = NULL, sas = NULL, api_version = "2023-11-03"),
+        class = "adls_endpoint"),
+      name = "data"),
+    class = c("adls_filesystem", "storage_container"))
+  blob <- structure(list(name = "data"), class = c("blob_container", "storage_container"))
+
+  put_con <- NULL; dir_con <- NULL
+  local_mocked_bindings(
+    blob_endpoint     = function(endpoint, ...) structure(list(url = endpoint), class = "blob_endpoint"),
+    storage_container = function(endpoint, name) blob,
+    do_container_op   = function(container, operation, ...) { put_con <<- container; fake_resp(201L) },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    .eri_create_azure_dir = function(azcontainer, path) { dir_con <<- azcontainer; invisible(NULL) },
+    .package = "erifunctions"
+  )
+
+  ok <- erifunctions:::.eri_yaml_write_conditional(adls, "odk/registry.yaml",
+                                                   list(forms = list()), etag = NULL)
+  expect_true(ok)
+  expect_s3_class(put_con, "blob_container")     # conditional PUT -> blob endpoint
+  expect_s3_class(dir_con, "adls_filesystem")    # dir-ensure -> ADLS container
+})
+
 # --- .eri_yaml_update (retry / re-apply) --------------------------------------
 
 test_that(".eri_yaml_update commits the mutated value when there is no conflict", {

--- a/tests/testthat/test-odk_registry.R
+++ b/tests/testthat/test-odk_registry.R
@@ -251,3 +251,27 @@ test_that("form_display_name defaults to form_id when not supplied", {
 
   expect_equal(store$data$forms[[1]]$form_display_name, "MyForm")
 })
+
+# --- .odk_data_con auto-connect ------------------------------------------------
+
+test_that(".odk_data_con delegates auto-connect to get_azure_storage_connection", {
+  # A passed connection short-circuits (no auth).
+  expect_equal(erifunctions:::.odk_data_con("passed"), "passed")
+
+  # Auto-connect (NULL) routes through the shared connector — which carries the
+  # zero-config auth defaults — targeting the data container. Reimplementing the
+  # token from bare Sys.getenv() (as this once did) sent an empty client_id.
+  seen <- NULL
+  local_mocked_bindings(
+    get_azure_storage_connection = function(storage_name, ...) {
+      seen <<- storage_name
+      "auto_con"
+    },
+    .package = "erifunctions"
+  )
+  # NA unsets the var on every platform; "" would stay an empty string on Linux
+  # but unset the var on Windows, so `unset=` diverges across OSes.
+  withr::local_envvar(ERIFUNCTIONS_DATA_STORAGE_NAME = NA)
+  expect_equal(erifunctions:::.odk_data_con(NULL), "auto_con")
+  expect_equal(seen, "data")   # default when the env var is unset
+})


### PR DESCRIPTION
Release **0.9.1** to `main`. Carries a single change over `main`: the ADLS Gen2 metadata-write fix (PR #261).

## What ships
- **Conditional metadata writes now work on the default ADLS Gen2 (`dfs`) endpoint.** `.eri_yaml_update()`'s conditional write (ADR-0002) issued a blob-API PUT (`x-ms-blob-type: BlockBlob` + `If-Match`/`If-None-Match`) that the `dfs` endpoint rejects with `HTTP 400 ("An HTTP header that's mandatory for this request is not specified")`, writing nothing. This broke every conditional metadata store on the default endpoint — the ODK registry, the data catalog, the artifact registry, and `eri_feedback()`. The versioned read and conditional write now route through the same account's **blob** endpoint (which supports these operations natively, incl. the `412` stale-ETag conflict). Bulk data/file writes were always fine and are unchanged. See ADR-0016.
- **`.odk_data_con()` auto-connect** no longer sends an empty `client_id` (`AADSTS900144`); it delegates to `get_azure_storage_connection()` like the other data-container connectors.

## Why now
Surfaced by the live Phase-3 pilot: a DA's `eri_odk_sync()` wrote all Parquet tables to `raw/` and then errored on the final `last_synced` update. Shipping to `main` lets the DA `install_github(...@main)` and drop the workaround.

## Verification
- Root cause + fix reproduced live against the eridev account (201 create / 201 conditional update / 412 stale ETag).
- Full offline suite green (0 failures); regression tests added; CI green on ubuntu + windows in #261.
- review-agent: Comment, no blockers (both suggestions applied).