### PR TITLE
feat(cmr): atlantis synthetic training sandbox schema (0.9.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.1
+Version: 0.9.2
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# erifunctions 0.9.2
+
+## Add: `atlantis` synthetic training sandbox for the CMR pipeline
+
+- **New demo CMR schema `inst/schemas/cmr/atlantis.yaml`.** `atlantis` is a
+  fictional country whose CMR schema mirrors `uga.yaml`'s sheet routing, so the
+  bundled synthetic `inst/extdata/cmr-example.xlsx` drives the full
+  `eri_split_cmr()` → `eri_approve()` → `eri_read()`/`eri_catalog_query()` flow
+  **without writing into any real country's namespace**. This closes the gap that
+  the CMR path — unlike the general pipeline, whose `eri_approve()` is not
+  country-locked — could only be exercised end-to-end against a real reporting
+  country, because `load_cmr_schema()` requires a per-country schema file. Use it
+  for training and for testing the CMR pipeline; it is not a real reporting
+  country.
+
 # erifunctions 0.9.1
 
 ## Fix: metadata writes on ADLS Gen2, and ODK auto-connect

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -1,5 +1,11 @@
 # CMR - Monthly Report ingestion and schema loading
 
+# Synthetic, non-real "countries" whose CMR schema exists only to exercise the
+# pipeline for training/testing (no real reporting country's namespace touched).
+# Listed separately in the schema-not-found hint so a DA who mistypes a real
+# code isn't offered a fictional one as if it were real.
+.eri_cmr_sandbox_countries <- "atlantis"
+
 #' Load a CMR country schema
 #'
 #' @description
@@ -9,7 +15,10 @@
 #' `inst/schemas/cmr/` and define which sheets are present for that country and
 #' the required field codes expected in each sheet.
 #'
-#' @param country `str` Three-letter country code (e.g. `"uga"`, `"eth"`).
+#' @param country `str` Country code, usually the three-letter reporting code
+#'   (e.g. `"uga"`, `"eth"`). A training sandbox schema such as `"atlantis"` —
+#'   a fictional country for exercising the pipeline without touching real data
+#'   — is also accepted.
 #'
 #' @returns A named list with keys `country`, `country_code`, `language`,
 #'   `template`, and `sheets`. Each element of `sheets` is itself a named list
@@ -25,12 +34,17 @@ load_cmr_schema <- function(country) {
   }
   path <- file.path(schema_dir, paste0(country, ".yaml"))
   if (!file.exists(path)) {
-    available <- tools::file_path_sans_ext(
+    all_schemas <- tools::file_path_sans_ext(
       list.files(schema_dir, pattern = "\\.yaml$")
     )
+    sandbox   <- intersect(all_schemas, .eri_cmr_sandbox_countries)
+    available <- setdiff(all_schemas, sandbox)
     cli::cli_abort(c(
       "No CMR schema found for country {.val {country}}.",
-      "i" = "Available: {.val {available}}"
+      "i" = "Available: {.val {available}}",
+      if (length(sandbox) > 0) {
+        c("i" = "Training sandbox (not a real country): {.val {sandbox}}")
+      }
     ))
   }
   yaml::read_yaml(path)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -199,6 +199,11 @@ against existing Azure data as a simulation; validated against real uploads when
   CMR period/sheet hardening (#252); the DQ→triage fold was already in place (`eri_ingest()` persists
   flags via `eri_dq_log()` into the `eri_logs()` backlog), and stage/ingest already have full op-log +
   tryCatch capture.
+- **Training/testing sandbox for the CMR pipeline** — shipped a synthetic `atlantis` CMR schema
+  (`inst/schemas/cmr/atlantis.yaml`) so the full `eri_split_cmr → eri_approve → eri_read` flow runs
+  end-to-end without writing into a real country's namespace. Deliberately **narrow** (CMR-only) for
+  now; a general first-class "registered sandbox" namespace usable across pipelines (ODK, general
+  ingest, research) is a candidate for a future ADR rather than one fake schema per pipeline.
 - **Retire the legacy adapters** that [ADR-0012](adr/0012-source-measure-data-model.md) isolates: the
   `projects`-blob dual-write (`mirror_pipeline`), `.eri_pipeline_registry`, `.eri_schema_country_map`,
   and the `rblf` combined code. **Deferred to the cutover itself** (irreversible; only once a stream's

--- a/inst/schemas/cmr/atlantis.yaml
+++ b/inst/schemas/cmr/atlantis.yaml
@@ -1,0 +1,214 @@
+country: atlantis
+country_code: atlantis
+language: en
+template: english_cmr
+
+# SYNTHETIC TRAINING SANDBOX. `atlantis` is a fictional country used for teaching
+# and testing the CMR pipeline end-to-end WITHOUT touching a real country's
+# namespace. Sheet routing mirrors uga.yaml so the bundled synthetic
+# inst/extdata/cmr-example.xlsx (sheets "RB Treatment"/"SCH Treatment", field
+# codes #rbtrt_/#schtrt_) routes identically. Not a real reporting country.
+#
+# Per-sheet `disease`/`data_type` route eri_split_cmr()
+# to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
+# sheet; Training sheets -> combined `rblf`). Sheets without routing keys
+# (reference tabs with no field codes) are skipped; ToT routes with the trainings.
+# `required_fields` lists the stable (non-monthly) identifier columns.
+
+sheets:
+  "RB Treatment":
+    field_code_prefix: "#rbtrt_"
+    disease: oncho
+    data_type: treatment
+    required_fields:
+      - "#rbtrt_year"
+      - "#rbtrt_adm0"
+      - "#rbtrt_adm0_id"
+      - "#rbtrt_adm1"
+      - "#rbtrt_adm1_id"
+      - "#rbtrt_adm2"
+      - "#rbtrt_adm2_id"
+      - "#rbtrt_adm3"
+      - "#rbtrt_disease"
+  "SCH Treatment":
+    field_code_prefix: "#schtrt_"
+    disease: sch
+    data_type: treatment
+    required_fields:
+      - "#schtrt_year"
+      - "#schtrt_adm0"
+      - "#schtrt_adm0_id"
+      - "#schtrt_adm1"
+      - "#schtrt_adm1_id"
+      - "#schtrt_adm2"
+      - "#schtrt_adm2_id"
+      - "#schtrt_adm3"
+      - "#schtrt_disease"
+  "LF MMDP":
+    field_code_prefix: "#lfdmdi_"
+    disease: lf
+    data_type: mmdp
+    required_fields:
+      - "#lfdmdi_year"
+      - "#lfdmdi_adm0"
+      - "#lfdmdi_adm0_id"
+      - "#lfdmdi_adm1"
+      - "#lfdmdi_adm1_id"
+      - "#lfdmdi_adm2"
+      - "#lfdmdi_adm2_id"
+      - "#lfdmdi_adm3"
+      - "#lfdmdi_disease"
+  "VHT Training":
+    field_code_prefix: "#vhttrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#vhttrn_year"
+      - "#vhttrn_adm0"
+      - "#vhttrn_adm0_id"
+      - "#vhttrn_adm1"
+      - "#vhttrn_adm1_id"
+      - "#vhttrn_adm2"
+      - "#vhttrn_adm2_id"
+      - "#vhttrn_adm3"
+      - "#vhttrn_disease"
+  "Parish Supervisors Training":
+    field_code_prefix: "#pstrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#pstrn_year"
+      - "#pstrn_adm0"
+      - "#pstrn_adm0_id"
+      - "#pstrn_adm1"
+      - "#pstrn_adm1_id"
+      - "#pstrn_adm2"
+      - "#pstrn_adm2_id"
+      - "#pstrn_adm3"
+      - "#pstrn_disease"
+  "Local Leaders Training":
+    field_code_prefix: "#lltrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#lltrn_year"
+      - "#lltrn_adm0"
+      - "#lltrn_adm0_id"
+      - "#lltrn_adm1"
+      - "#lltrn_adm1_id"
+      - "#lltrn_adm2"
+      - "#lltrn_adm2_id"
+      - "#lltrn_adm3"
+      - "#lltrn_disease"
+  "Subcounty Supervisor Training":
+    field_code_prefix: "#sstrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#sstrn_year"
+      - "#sstrn_adm0"
+      - "#sstrn_adm0_id"
+      - "#sstrn_adm1"
+      - "#sstrn_adm1_id"
+      - "#sstrn_adm2"
+      - "#sstrn_adm2_id"
+      - "#sstrn_adm3"
+      - "#sstrn_disease"
+  "MMDP (surgery) Training":
+    field_code_prefix: "#dmditrnsx_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#dmditrnsx_year"
+      - "#dmditrnsx_adm0"
+      - "#dmditrnsx_adm0_id"
+      - "#dmditrnsx_adm1"
+      - "#dmditrnsx_adm1_id"
+      - "#dmditrnsx_adm2"
+      - "#dmditrnsx_adm2_id"
+      - "#dmditrnsx_adm3"
+      - "#dmditrnsx_disease"
+  "MMDP (patient) Training":
+    field_code_prefix: "#dmditrnpt_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#dmditrnpt_year"
+      - "#dmditrnpt_adm0"
+      - "#dmditrnpt_adm0_id"
+      - "#dmditrnpt_adm1"
+      - "#dmditrnpt_adm1_id"
+      - "#dmditrnpt_adm2"
+      - "#dmditrnpt_adm2_id"
+      - "#dmditrnpt_adm3"
+      - "#dmditrnpt_disease"
+  "Field Ento Training":
+    field_code_prefix: "#entotrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#entotrn_year"
+      - "#entotrn_adm0"
+      - "#entotrn_adm0_id"
+      - "#entotrn_adm1"
+      - "#entotrn_adm1_id"
+      - "#entotrn_adm2"
+      - "#entotrn_adm2_id"
+      - "#entotrn_adm3"
+      - "#entotrn_disease"
+  "Lab Training":
+    field_code_prefix: "#labtrn_"
+    disease: rblf
+    data_type: training
+    required_fields:
+      - "#labtrn__year"
+      - "#labtrn__adm0"
+      - "#labtrn__adm0_id"
+      - "#labtrn__adm1"
+      - "#labtrn__adm1_id"
+      - "#labtrn__adm2"
+      - "#labtrn__adm2_id"
+      - "#labtrn__adm3"
+      - "#labtrn__disease"
+  "LF Surveys":
+    field_code_prefix: "#lfsurv_"
+    disease: lf
+    data_type: tas
+    required_fields:
+      - "#lfsurv_year"
+      - "#lfsurv_adm0"
+      - "#lfsurv_adm0_id"
+      - "#lfsurv_adm1"
+      - "#lfsurv_adm1_id"
+      - "#lfsurv_adm2"
+      - "#lfsurv_adm2_id"
+      - "#lfsurv_adm3"
+      - "#lfsurv_disease"
+  "RB Epi Surveys":
+    field_code_prefix: "#rb_epi_surv_"
+    disease: oncho
+    data_type: prevalence
+    required_fields:
+      - "#rb_epi_surv_year"
+      - "#rb_epi_surv_adm0"
+      - "#rb_epi_surv_adm0_id"
+      - "#rb_epi_surv_adm1"
+      - "#rb_epi_surv_adm1_id"
+      - "#rb_epi_surv_adm2"
+      - "#rb_epi_surv_adm2_id"
+      - "#rb_epi_surv_adm3"
+      - "#rb_epi_surv_disease"
+  "RB Ento Surveys":
+    field_code_prefix: "#rb_ento_surv_"
+    disease: oncho
+    data_type: entomology
+    required_fields:
+      - "#rb_ento_surv_year"
+      - "#rb_ento_surv_adm0"
+      - "#rb_ento_surv_adm0_id"
+      - "#rb_ento_surv_adm1"
+      - "#rb_ento_surv_adm1_id"
+      - "#rb_ento_surv_adm2"
+      - "#rb_ento_surv_adm2_id"
+      - "#rb_ento_surv_adm3"
+      - "#rb_ento_surv_disease"

--- a/inst/schemas/cmr/atlantis.yaml
+++ b/inst/schemas/cmr/atlantis.yaml
@@ -9,6 +9,11 @@ template: english_cmr
 # inst/extdata/cmr-example.xlsx (sheets "RB Treatment"/"SCH Treatment", field
 # codes #rbtrt_/#schtrt_) routes identically. Not a real reporting country.
 #
+# This is a DELIBERATE full copy of the uga template (all sheets) so the demo
+# faithfully resembles a real CMR and reproduces the "Skipped N sheets" routing
+# message. Only "RB Treatment"/"SCH Treatment" are exercised by the bundled
+# workbook; if uga's routing changes, re-copy this file from uga.yaml.
+#
 # Per-sheet `disease`/`data_type` route eri_split_cmr()
 # to {country}/{disease}/programmatic/{data_type}/staged/ (disease from the
 # sheet; Training sheets -> combined `rblf`). Sheets without routing keys

--- a/man/load_cmr_schema.Rd
+++ b/man/load_cmr_schema.Rd
@@ -7,7 +7,10 @@
 load_cmr_schema(country)
 }
 \arguments{
-\item{country}{\code{str} Three-letter country code (e.g. \code{"uga"}, \code{"eth"}).}
+\item{country}{\code{str} Country code, usually the three-letter reporting code
+(e.g. \code{"uga"}, \code{"eth"}). A training sandbox schema such as \code{"atlantis"} —
+a fictional country for exercising the pipeline without touching real data
+— is also accepted.}
 }
 \value{
 A named list with keys \code{country}, \code{country_code}, \code{language},

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -173,6 +173,12 @@ test_that("load_cmr_schema atlantis is a synthetic sandbox mirroring uga routing
   expect_equal(schema$sheets[["RB Treatment"]]$field_code_prefix, "#rbtrt_")
 })
 
+test_that("load_cmr_schema lists the atlantis sandbox separately from real countries", {
+  # A DA who mistypes a real code should not be offered the fictional sandbox as
+  # if it were a real reporting country.
+  expect_error(load_cmr_schema("zzz"), "Training sandbox")
+})
+
 test_that("eri_split_cmr dry_run routes the bundled example under atlantis/", {
   ex <- system.file("extdata", "cmr-example.xlsx", package = "erifunctions")
   skip_if(!nzchar(ex) || !file.exists(ex), "bundled cmr-example.xlsx not available")

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -161,6 +161,27 @@ test_that("load_cmr_schema Ethiopia has the RB+LF entomology/survey sheets (real
   expect_false("SCH Treatment" %in% sheet_names)
 })
 
+#### Tests for the atlantis training sandbox schema (demo) ####
+
+test_that("load_cmr_schema atlantis is a synthetic sandbox mirroring uga routing", {
+  schema <- load_cmr_schema("atlantis")
+  expect_equal(schema$country_code, "atlantis")
+  # Routes the two treatment sheets to the same diseases as uga, so the bundled
+  # synthetic workbook can drive the whole pipeline without a real namespace.
+  expect_equal(schema$sheets[["RB Treatment"]]$disease, "oncho")
+  expect_equal(schema$sheets[["SCH Treatment"]]$disease, "sch")
+  expect_equal(schema$sheets[["RB Treatment"]]$field_code_prefix, "#rbtrt_")
+})
+
+test_that("eri_split_cmr dry_run routes the bundled example under atlantis/", {
+  ex <- system.file("extdata", "cmr-example.xlsx", package = "erifunctions")
+  skip_if(!nzchar(ex) || !file.exists(ex), "bundled cmr-example.xlsx not available")
+  plan <- eri_split_cmr(ex, country = "atlantis", dry_run = TRUE)
+  expect_s3_class(plan, "tbl_df")
+  expect_true(all(startsWith(plan$dest, "atlantis/")))
+  expect_setequal(plan$disease, c("oncho", "sch"))
+})
+
 #### Tests for French CMR schemas (issue #29) ####
 
 test_that("load_cmr_schema tcd has correct metadata", {


### PR DESCRIPTION
Closes #263.

## What

Adds `inst/schemas/cmr/atlantis.yaml` — a demo CMR schema for the fictional `atlantis` country, mirroring `uga.yaml`'s sheet routing.

## Why

The CMR pipeline is country-schema-locked (`eri_split_cmr()` → `load_cmr_schema()` needs a per-country schema file), so — unlike the general pipeline, whose `eri_approve()` is not country-locked — it could only be run end-to-end against a **real** country's namespace. That's a problem for training and for testing the pipeline: you'd write synthetic rows into a real country's `processed/` layer. With `atlantis`, the bundled synthetic `inst/extdata/cmr-example.xlsx` drives the whole `split → approve → read → catalog` flow into an `atlantis/...` namespace instead.

## Scope / safety

- **Additive only.** A new schema file activates solely when a caller passes `country = "atlantis"`; no existing code path changes. No behavior change for any real country.
- Bundled workbook already has the matching sheet names / field-code prefixes.
- `atlantis` is documented in-file as a synthetic sandbox, not a real reporting country.

## Validation

- Live end-to-end on the `atlantis` namespace: `eri_split_cmr` → `eri_approve` (catalog + approval logs written, ADLS metadata writes clean) → `eri_read` (3×7) → `eri_catalog_query` → cleanup removed every trace.
- `devtools::test()` on `test-cmr.R`: **748 pass, 0 fail** incl. two new tests (schema routing; dry-run plan lands under `atlantis/`).

## Version

Bumps to 0.9.2 + NEWS entry.

## Motivation

Built to support a hands-on training session on the CMR workflow, but the sandbox is generally useful for anyone testing the pipeline. Related nice-to-haves (a one-call demo+teardown helper; `eri_list()` returning empty instead of erroring on a missing dir) are tracked separately for their own PRs.