### PR TITLE
feat(dq): atlantis data-quality schema for the training sandbox (0.9.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.3
+Version: 0.9.4
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# erifunctions 0.9.4
+
+## Add: `atlantis` data-quality schema for the training sandbox
+
+- **New DQ schema `inst/schemas/atlantis_oncho_programmatic_treatment.yaml`.** Lets
+  `load_dq_schema("atlantis", "oncho", "programmatic", "treatment")` and
+  `run_dq_checks()` run on the synthetic CMR training data. The schema maps the CMR
+  field codes (`#rbtrt_*`) to canonical columns via aliases, corrects district
+  casing, flags an unknown district (allowed-values) and an out-of-range treated
+  count, so training can demonstrate the correct-and-flag behaviour without a real
+  country schema. Not a real reporting country.
+
 # erifunctions 0.9.3
 
 ## Improve: richer bundled CMR example data

--- a/inst/schemas/atlantis_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/atlantis_oncho_programmatic_treatment.yaml
@@ -1,0 +1,76 @@
+country: atlantis
+disease: oncho
+data_source: programmatic
+data_type: treatment
+version: "1.0"
+description: "Atlantis synthetic training sandbox: river blindness (onchocerciasis) MDA treatment coverage. Not a real reporting country; used to teach and test the data-quality checks."
+language: en
+time_grain: annual
+
+# Aliases map the CMR field codes (#rbtrt_*) onto the canonical DQ columns, so
+# run_dq_checks() works directly on data parsed by eri_ingest_cmr().
+
+temporal:
+  year_col: year
+
+preprocessing:
+  - remove_smart_quotes
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, YEAR, "#rbtrt_year"]
+    range: [1990, 2035]
+
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#rbtrt_adm1"]
+
+  district:
+    required: true
+    type: character
+    aliases: [District, district_name, adm2, "#rbtrt_adm2"]
+    allowed_values: [Kampala, Mbarara, Soroti, Gulu, Lira, Jinja, Mbale, Arua, Masaka, Hoima, "Fort Portal", Moroto]
+    corrections:
+      kampala: Kampala
+      mbarara: Mbarara
+      soroti: Soroti
+      gulu: Gulu
+      lira: Lira
+      jinja: Jinja
+      mbale: Mbale
+      arua: Arua
+      masaka: Masaka
+      hoima: Hoima
+      moroto: Moroto
+
+  target_pop:
+    required: true
+    type: numeric
+    aliases: [TargetPop, target_population, eligible_pop, target, "#rbtrt_target"]
+    range: [0, 10000000]
+
+  treated:
+    required: true
+    type: numeric
+    aliases: [Treated, people_treated, ivermectin_treated, "#rbtrt_treated"]
+    range: [0, 10000000]
+
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: "<="
+    rhs: target_pop
+    message: "treated exceeds target_pop (coverage over 100%)"
+  treated_nonneg:
+    lhs: treated
+    op: ">="
+    rhs_value: 0
+    message: "negative treated count"
+  target_positive:
+    lhs: target_pop
+    op: ">"
+    rhs_value: 0
+    message: "target_pop must be positive"


### PR DESCRIPTION
## What
Adds `inst/schemas/atlantis_oncho_programmatic_treatment.yaml`, a data-quality schema for the synthetic `atlantis` training country, so `load_dq_schema("atlantis", "oncho", "programmatic", "treatment")` and `run_dq_checks()` work on CMR training data.

## Why
The Session 2 training materials now include a data-quality act (the same pattern as the published `da-ingest-guide`): run the parsed CMR against the schema, auto-correct what is safe, flag what needs a person. That needs a DQ schema for `atlantis`, which did not exist. This adds it.

The schema maps the CMR field codes (`#rbtrt_*`) to the canonical DQ columns via `aliases`, corrects district casing, and flags an unknown district (allowed-values) and an out-of-range treated count.

## Behaviour (verified)
- Clean parsed CMR: `0 corrections, 0 flags for review`
- Dirty extract (a lowercased district, an added row with district "Atlantica" and treated -500): `1 correction, 2 flags for review` (soroti to Soroti corrected; treated -500 out of range and "Atlantica" not in allowed_values flagged)

## Scope / safety
- Data/schema only, no code changes. `atlantis` is a fictional training country, not a real reporting country.
- Test-safe: `test-dq.R` = **70 pass, 0 fail**.
- Bumps to 0.9.4 + NEWS. Follow-on to #264.