### PR TITLE
fix(dq): rebuild CMR treatment DQ schemas against real field codes (0.9.5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.4
+Version: 0.9.5
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,36 @@
+# erifunctions 0.9.5
+
+## Fix / add: data-quality schemas rebuilt against the real CMR field codes
+
+- **`uga_oncho_programmatic_treatment.yaml` rewritten.** It previously targeted a
+  community-level format (`round`, `sub_county`, `community` all required) that
+  the real monthly CMR does not have. Against a real Uganda submission it
+  returned 7 "required column missing" flags and nothing else, because none of
+  its aliases resolved. It now maps the real `#rbtrt_*` field codes
+  (`eri_ingest_cmr()` output) to canonical columns, with `district`, `year`, and
+  `treated` required and the rest range-checked.
+- **New: `uga_sch_programmatic_treatment.yaml`, `ssd_oncho_programmatic_treatment.yaml`,
+  `sdn_oncho_programmatic_treatment.yaml`.** Same real-field-code structure.
+  District `allowed_values` are the real historical district lists for each
+  country (public administrative units).
+- **Verified against real submitted CMR** (read-only recon, aggregate counts
+  only): all four schemas resolve every column with 0 "missing required column"
+  errors. Confirmed two real anomalies the schemas now catch automatically via
+  the `target_pop` range floor: Sudan's most recent submission had a target of 0
+  for all 10 districts, and Uganda's had a target of 0 for 45 of 52 districts.
+- **Known but not auto-corrected:** the historical district lists carry
+  near-duplicate entries ("Moyo" / "MOYO" in Uganda; "Aweil West" / "Awiel West"
+  in South Sudan) and non-geographic values ("Passive", "Refugees" in Uganda;
+  "Maban Refugees" in South Sudan). All are left in `allowed_values` rather than
+  merged, since it has not been confirmed which are real duplicates versus
+  distinct reporting categories.
+- **Note:** a schema's `consistency:` block is not run automatically by
+  `run_dq_checks()`; it requires an explicit
+  `run_dq_checks(data, schema) |> add_anomaly_consistency(schema)` chain. The
+  schemas here rely on automatic `range` checks instead, which cover the cases
+  that matter for a first pass (a present-but-invalid target, an out-of-range
+  treated count, coverage outside 0-150%).
+
 # erifunctions 0.9.4
 
 ## Add: `atlantis` data-quality schema for the training sandbox

--- a/inst/schemas/sdn_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/sdn_oncho_programmatic_treatment.yaml
@@ -1,0 +1,114 @@
+country: sdn
+disease: oncho
+data_source: programmatic
+data_type: treatment
+version: "1.0"
+description: "Sudan river blindness (onchocerciasis) MDA coverage, RB Treatment sheet of the monthly CMR"
+language: en
+time_grain: annual
+
+# Built 2026-07-08 against the REAL CMR field codes (eri_ingest_cmr() output,
+# #rbtrt_* prefix). Same structure as uga_oncho_programmatic_treatment.yaml.
+#
+# The most recent real submission scanned (period 202605) had #rbtrt_trttarget
+# = 0 for every row. The target_pop range floor below (>= 1) is set specifically
+# so this class of error is flagged automatically rather than silently passing.
+
+temporal:
+  year_col: year
+
+preprocessing:
+  - remove_smart_quotes
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, YEAR, "#rbtrt_year"]
+    range: [1990, 2035]
+
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#rbtrt_adm1"]
+
+  district:
+    required: true
+    type: character
+    aliases: [District, district_name, adm2, "#rbtrt_adm2"]
+    allowed_values: ["Abu Hamad", "Al Buhaira", "Al Qureisha", "Al Radom", Barbar,
+      Basundah, "Galabat Ash-Shargiah", Geisan, Merwoe, "Wad El Mahi"]
+
+  sub_county:
+    required: false
+    type: character
+    aliases: [SubCounty, sub_county, adm3, "#rbtrt_adm3"]
+
+  disease_reported:
+    required: false
+    type: character
+    aliases: ["#rbtrt_disease"]
+
+  population:
+    required: false
+    type: numeric
+    aliases: [Population, "#rbtrt_pop"]
+    range: [0, 5000000]
+
+  treatment_round:
+    required: false
+    type: numeric
+    aliases: [Round, MDA_round, treatment_round, "#rbtrt_trtrd"]
+    range: [0, 10]
+
+  target_pop:
+    required: false
+    type: numeric
+    aliases: [TargetPop, target_population, eligible_pop, "#rbtrt_trttarget"]
+    # A present target of 0 is a real, confirmed anomaly in this country's data
+    # (the 202605 submission had target = 0 for every district); this floor
+    # catches it automatically.
+    range: [1, 2000000]
+
+  village_target:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_villagetarget"]
+    range: [0, 5000]
+
+  male_treated:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_male_tot"]
+    range: [0, 2000000]
+
+  female_treated:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_fem_tot"]
+    range: [0, 2000000]
+
+  treated:
+    required: true
+    type: numeric
+    aliases: [Treated, people_treated, "#rbtrt_tot"]
+    range: [0, 2000000]
+
+  coverage_pct:
+    required: false
+    type: numeric
+    aliases: [CoveragePct, coverage, "#rbtrt_coverage"]
+    range: [0, 150]
+
+# NOTE: consistency rules require explicit chaining, see uga_oncho's header note.
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: "<="
+    rhs: target_pop
+    message: "treated exceeds target_pop (over 100% raw coverage)"
+  treated_nonneg:
+    lhs: treated
+    op: ">="
+    rhs_value: 0
+    message: "Negative treated count"

--- a/inst/schemas/sdn_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/sdn_oncho_programmatic_treatment.yaml
@@ -16,6 +16,7 @@ time_grain: annual
 
 temporal:
   year_col: year
+  period_col: treatment_round
 
 preprocessing:
   - remove_smart_quotes

--- a/inst/schemas/ssd_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/ssd_oncho_programmatic_treatment.yaml
@@ -1,0 +1,116 @@
+country: ssd
+disease: oncho
+data_source: programmatic
+data_type: treatment
+version: "1.0"
+description: "South Sudan river blindness (onchocerciasis) MDA coverage, RB Treatment sheet of the monthly CMR"
+language: en
+time_grain: annual
+
+# Built 2026-07-08 against the REAL CMR field codes (eri_ingest_cmr() output,
+# #rbtrt_* prefix). Same structure as uga_oncho_programmatic_treatment.yaml.
+#
+# KNOWN DATA ISSUE, not auto-corrected: the historical district list carries both
+# "Aweil West" and "Awiel West", which read as a likely entry typo of the same
+# place, and "Maban" alongside "Maban Refugees". Both spellings/variants are left
+# as allowed_values rather than merged, since this has not been confirmed with
+# the maintainer. Flag before assuming either is wrong.
+
+temporal:
+  year_col: year
+
+preprocessing:
+  - remove_smart_quotes
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, YEAR, "#rbtrt_year"]
+    range: [1990, 2035]
+
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#rbtrt_adm1"]
+
+  district:
+    required: true
+    type: character
+    aliases: [District, district_name, adm2, "#rbtrt_adm2"]
+    allowed_values: [Akobo, "Aweil Center", "Aweil South", "Aweil West", "Awiel West",
+      Cueibet, Ezo, "Gogrial East", "Gogrial West", Ibba, Juba, "Jur River", Maban,
+      "Maban Refugees", Magwi, Maridi, "Mundri East", "Mundri West", Mvolo, Nagero,
+      Nzara, Pibor, Pochalla, Raja, "Rumbek East", "Rumbek North", Tambura, Terekeka,
+      "Tonj South", Torit, "Twic Mayerdit", Wau, Wulu, Yambio, "Yirol East", "Yirol West"]
+
+  sub_county:
+    required: false
+    type: character
+    aliases: [SubCounty, sub_county, adm3, "#rbtrt_adm3"]
+
+  disease_reported:
+    required: false
+    type: character
+    aliases: ["#rbtrt_disease"]
+
+  population:
+    required: false
+    type: numeric
+    aliases: [Population, "#rbtrt_pop"]
+    range: [0, 5000000]
+
+  treatment_round:
+    required: false
+    type: numeric
+    aliases: [Round, MDA_round, treatment_round, "#rbtrt_trtrd"]
+    range: [0, 10]
+
+  target_pop:
+    required: false
+    type: numeric
+    aliases: [TargetPop, target_population, eligible_pop, "#rbtrt_trttarget"]
+    range: [1, 2000000]
+
+  village_target:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_villagetarget"]
+    range: [0, 5000]
+
+  male_treated:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_male_tot"]
+    range: [0, 2000000]
+
+  female_treated:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_fem_tot"]
+    range: [0, 2000000]
+
+  treated:
+    required: true
+    type: numeric
+    aliases: [Treated, people_treated, "#rbtrt_tot"]
+    range: [0, 2000000]
+
+  coverage_pct:
+    required: false
+    type: numeric
+    aliases: [CoveragePct, coverage, "#rbtrt_coverage"]
+    range: [0, 150]
+
+# NOTE: consistency rules require explicit chaining, see uga_oncho's header note.
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: "<="
+    rhs: target_pop
+    message: "treated exceeds target_pop (over 100% raw coverage)"
+  treated_nonneg:
+    lhs: treated
+    op: ">="
+    rhs_value: 0
+    message: "Negative treated count"

--- a/inst/schemas/ssd_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/ssd_oncho_programmatic_treatment.yaml
@@ -18,6 +18,7 @@ time_grain: annual
 
 temporal:
   year_col: year
+  period_col: treatment_round
 
 preprocessing:
   - remove_smart_quotes

--- a/inst/schemas/uga_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/uga_oncho_programmatic_treatment.yaml
@@ -12,8 +12,7 @@ time_grain: annual
 # this schema targeted a different, community-level format (round/sub_county/
 # community required) that the real CMR does not have; run_dq_checks() against a
 # real file returned 7 "required column missing" flags because none of its
-# aliases matched. See docs/adr or the erifunctions nice-to-haves memory for the
-# full recon.
+# aliases matched. See PR #267 for the full recon against real submitted CMR.
 #
 # KNOWN DATA ISSUE, not auto-corrected: the historical district list carries both
 # "Moyo" and "MOYO", and "Passive" / "Refugees" appear as district values (likely

--- a/inst/schemas/uga_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/uga_oncho_programmatic_treatment.yaml
@@ -24,6 +24,7 @@ time_grain: annual
 
 temporal:
   year_col: year
+  period_col: treatment_round
 
 preprocessing:
   - remove_smart_quotes

--- a/inst/schemas/uga_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/uga_oncho_programmatic_treatment.yaml
@@ -2,14 +2,28 @@ country: uga
 disease: oncho
 data_source: programmatic
 data_type: treatment
-version: "1.0"
-description: "Uganda river blindness (onchocerciasis) MDA coverage -- APOC community-directed treatment (CDT)"
+version: "2.0"
+description: "Uganda river blindness (onchocerciasis) MDA coverage, RB Treatment sheet of the monthly CMR"
 language: en
 time_grain: annual
 
+# Rewritten 2026-07-08 against the REAL CMR field codes (eri_ingest_cmr() output,
+# #rbtrt_* prefix, one row per district per reporting year). The prior version of
+# this schema targeted a different, community-level format (round/sub_county/
+# community required) that the real CMR does not have; run_dq_checks() against a
+# real file returned 7 "required column missing" flags because none of its
+# aliases matched. See docs/adr or the erifunctions nice-to-haves memory for the
+# full recon.
+#
+# KNOWN DATA ISSUE, not auto-corrected: the historical district list carries both
+# "Moyo" and "MOYO", and "Passive" / "Refugees" appear as district values (likely
+# non-geographic reporting categories, not typos). All are left as allowed_values
+# rather than merged or dropped, since it is not yet confirmed which are distinct
+# real categories and which are entry duplicates. Flag to the maintainer before
+# assuming either.
+
 temporal:
   year_col: year
-  period_col: round
 
 preprocessing:
   - remove_smart_quotes
@@ -18,68 +32,98 @@ columns:
   year:
     required: true
     type: numeric
-    aliases: [Year, YEAR]
+    aliases: [Year, YEAR, "#rbtrt_year"]
     range: [1990, 2035]
 
-  round:
-    required: true
-    type: numeric
-    aliases: [Round, MDA_round, treatment_round]
-    range: [1, 4]
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#rbtrt_adm1"]
 
   district:
     required: true
     type: character
-    aliases: [District, district_name, adm2]
+    aliases: [District, district_name, adm2, "#rbtrt_adm2"]
+    allowed_values: [Adjumani, Amuru, Arua, Bududa, Buhweju, Buliisa, Bushenyi, Gulu,
+      "Gulu City", Hoima, Ibanda, Jinja, Kabarole, Kagadi, Kamuli, Kanungu, Kasese,
+      Kayunga, Kikuube, Kisoro, Kitagwenda, Kitgum, KOBOKO, Kyenjojo, Lamwo, Lira,
+      MadI-Okollo, Manafwa, "Maracha/Teregago", Masindi, Mayuge, Mbale, "Mbale City",
+      Mitooma, Moyo, MOYO, Mukono, Namisindwa, Nebbi, Nwoya, Obongi, Omoro, Oyam,
+      Pader, Pakwach, Passive, Refugees, Rubanda, Rubirizi, Sironko, Terego, YUMBE, Zombo]
 
   sub_county:
     required: false
     type: character
-    aliases: [SubCounty, sub_county, parish]
+    aliases: [SubCounty, sub_county, adm3, "#rbtrt_adm3"]
 
-  community:
-    required: true
+  disease_reported:
+    required: false
     type: character
-    aliases: [Community, village, community_name]
+    aliases: ["#rbtrt_disease"]
+
+  population:
+    required: false
+    type: numeric
+    aliases: [Population, "#rbtrt_pop"]
+    range: [0, 5000000]
+
+  treatment_round:
+    required: false
+    type: numeric
+    aliases: [Round, MDA_round, treatment_round, "#rbtrt_trtrd"]
+    range: [0, 10]
 
   target_pop:
-    required: true
+    required: false
     type: numeric
-    aliases: [TargetPop, target_population, eligible_pop]
+    aliases: [TargetPop, target_population, eligible_pop, "#rbtrt_trttarget"]
+    # A present target of 0 (or negative) is implausible for a reporting district
+    # and is what this range floor catches; a MISSING target is common (roughly
+    # half of historical rows) and is not flagged, since it is not required.
+    range: [1, 2000000]
+
+  village_target:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_villagetarget"]
+    range: [0, 5000]
+
+  male_treated:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_male_tot"]
+    range: [0, 2000000]
+
+  female_treated:
+    required: false
+    type: numeric
+    aliases: ["#rbtrt_fem_tot"]
+    range: [0, 2000000]
 
   treated:
     required: true
     type: numeric
-    aliases: [Treated, people_treated, ivermectin_treated]
+    aliases: [Treated, people_treated, ivermectin_treated, "#rbtrt_tot"]
+    range: [0, 2000000]
 
   coverage_pct:
-    required: true
+    required: false
     type: numeric
-    aliases: [CoveragePct, coverage, geographic_coverage]
+    aliases: [CoveragePct, coverage, geographic_coverage, "#rbtrt_coverage"]
     range: [0, 150]
 
-  albendazole_coadmin:
-    required: false
-    type: categorical
-    aliases: [AlbendazoleCoadmin, alb_coadmin, co_admin]
-    allowed_values: [Yes, No, yes, no]
-    translations:
-      yes: Yes
-      no: No
-
+# NOTE: consistency rules are NOT run automatically by run_dq_checks(). They must
+# be chained explicitly: run_dq_checks(data, schema) |> add_anomaly_consistency(schema).
+# The automatic range checks above (target_pop >= 1, treated >= 0, coverage_pct in
+# [0, 150]) already catch the cases that matter most for a first pass.
 consistency:
   implausible_overcoverage:
     lhs: treated
     op: "<="
     rhs: target_pop
-    message: "treated exceeds target_pop (>100% raw coverage)"
-  coverage_nonneg:
+    message: "treated exceeds target_pop (over 100% raw coverage)"
+  treated_nonneg:
     lhs: treated
     op: ">="
     rhs_value: 0
     message: "Negative treated count"
-  target_positive:
-    lhs: target_pop
-    op: ">"
-    rhs_value: 0
-    message: "target_pop must be positive"

--- a/inst/schemas/uga_sch_programmatic_treatment.yaml
+++ b/inst/schemas/uga_sch_programmatic_treatment.yaml
@@ -1,0 +1,111 @@
+country: uga
+disease: sch
+data_source: programmatic
+data_type: treatment
+version: "1.0"
+description: "Uganda schistosomiasis MDA coverage, SCH Treatment sheet of the monthly CMR"
+language: en
+time_grain: annual
+
+# Built 2026-07-08 against the REAL CMR field codes (eri_ingest_cmr() output,
+# #schtrt_* prefix, one row per district per reporting year). Same structure as
+# uga_oncho_programmatic_treatment.yaml; see that file's header note for the
+# recon and known district-list data issues.
+#
+# SCH is currently reported by a small set of districts (7 seen historically).
+# This allowed_values list will need extending if new districts start reporting.
+
+temporal:
+  year_col: year
+
+preprocessing:
+  - remove_smart_quotes
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, YEAR, "#schtrt_year"]
+    range: [1990, 2035]
+
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#schtrt_adm1"]
+
+  district:
+    required: true
+    type: character
+    aliases: [District, district_name, adm2, "#schtrt_adm2"]
+    allowed_values: [Adjumani, Amuru, Kitgum, Lamwo, Moyo, Passive, Refugees]
+
+  sub_county:
+    required: false
+    type: character
+    aliases: [SubCounty, sub_county, adm3, "#schtrt_adm3"]
+
+  disease_reported:
+    required: false
+    type: character
+    aliases: ["#schtrt_disease"]
+
+  population:
+    required: false
+    type: numeric
+    aliases: [Population, "#schtrt_pop"]
+    range: [0, 5000000]
+
+  treatment_round:
+    required: false
+    type: numeric
+    aliases: [Round, MDA_round, treatment_round, "#schtrt_trtrd"]
+    range: [0, 10]
+
+  target_pop:
+    required: false
+    type: numeric
+    aliases: [TargetPop, target_population, eligible_pop, "#schtrt_trttarget"]
+    range: [1, 2000000]
+
+  village_target:
+    required: false
+    type: numeric
+    aliases: ["#schtrt_villagetarget"]
+    range: [0, 5000]
+
+  male_treated:
+    required: false
+    type: numeric
+    aliases: ["#schtrt_male_tot"]
+    range: [0, 2000000]
+
+  female_treated:
+    required: false
+    type: numeric
+    aliases: ["#schtrt_fem_tot"]
+    range: [0, 2000000]
+
+  treated:
+    required: true
+    type: numeric
+    aliases: [Treated, people_treated, "#schtrt_tot"]
+    range: [0, 2000000]
+
+  coverage_pct:
+    required: false
+    type: numeric
+    aliases: [CoveragePct, coverage, "#schtrt_coverage"]
+    range: [0, 150]
+
+# NOTE: consistency rules require explicit chaining, see uga_oncho's header note.
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: "<="
+    rhs: target_pop
+    message: "treated exceeds target_pop (over 100% raw coverage)"
+  treated_nonneg:
+    lhs: treated
+    op: ">="
+    rhs_value: 0
+    message: "Negative treated count"

--- a/inst/schemas/uga_sch_programmatic_treatment.yaml
+++ b/inst/schemas/uga_sch_programmatic_treatment.yaml
@@ -17,6 +17,7 @@ time_grain: annual
 
 temporal:
   year_col: year
+  period_col: treatment_round
 
 preprocessing:
   - remove_smart_quotes

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -432,3 +432,62 @@ test_that("load_dq_schema resolves the ADR-0012 identity and legacy aliases", {
   expect_equal(load_dq_schema("haiti", "malaria", azcontainer = NULL)$data_type, "aggregate")
   expect_equal(load_dq_schema("ht", "malaria_case", azcontainer = NULL)$data_type, "case")
 })
+
+#### Tests for the real-field-code CMR treatment schemas (uga/ssd/sdn) ####
+
+test_that("uga_oncho_programmatic_treatment schema resolves the real #rbtrt_ field codes", {
+  schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  expect_true("district" %in% names(schema$columns))
+  expect_true("#rbtrt_adm2" %in% schema$columns$district$aliases)
+  expect_true("#rbtrt_tot" %in% schema$columns$treated$aliases)
+  # rewritten schema: only district/year/treated required, NOT the old
+  # community-level fields (round/sub_county/community), which the real CMR
+  # does not carry at this grain
+  expect_true(schema$columns$district$required)
+  expect_true(schema$columns$treated$required)
+  expect_false(isTRUE(schema$columns$sub_county$required))
+})
+
+test_that("uga_oncho schema flags a present-but-zero target_pop, not a missing one", {
+  schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  df <- tibble::tibble(
+    `#rbtrt_year` = c("2026", "2026", "2026"),
+    `#rbtrt_adm2` = c("Arua", "Gulu", "Jinja"),
+    `#rbtrt_tot`  = c("100", "200", "300"),
+    `#rbtrt_trttarget` = c("0", NA_character_, "500")   # zero flagged; NA not required
+  )
+  res <- run_dq_checks(df, schema)
+  expect_equal(nrow(res$flags[res$flags$column == "target_pop", ]), 1L)
+  expect_equal(res$flags$row[res$flags$column == "target_pop"], 1L)
+})
+
+test_that("uga_oncho schema flags a district not in the real allowed_values list", {
+  schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  df <- tibble::tibble(
+    `#rbtrt_year` = "2026", `#rbtrt_adm2` = "Not A Real District", `#rbtrt_tot` = "50"
+  )
+  res <- run_dq_checks(df, schema)
+  expect_true(any(res$flags$column == "district"))
+})
+
+test_that("uga_sch_programmatic_treatment schema loads and resolves #schtrt_ codes", {
+  schema <- load_dq_schema("uga", "sch", "programmatic", "treatment", azcontainer = NULL)
+  expect_true("#schtrt_adm2" %in% schema$columns$district$aliases)
+  expect_true("Moyo" %in% schema$columns$district$allowed_values)
+})
+
+test_that("ssd_oncho_programmatic_treatment schema loads with the real district list", {
+  schema <- load_dq_schema("ssd", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  expect_true("Juba" %in% schema$columns$district$allowed_values)
+  expect_true("#rbtrt_adm2" %in% schema$columns$district$aliases)
+})
+
+test_that("sdn_oncho_programmatic_treatment schema loads and flags a zero target", {
+  schema <- load_dq_schema("sdn", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  df <- tibble::tibble(
+    `#rbtrt_year` = "2026", `#rbtrt_adm2` = "Barbar",
+    `#rbtrt_tot` = "10", `#rbtrt_trttarget` = "0"
+  )
+  res <- run_dq_checks(df, schema)
+  expect_true(any(res$flags$column == "target_pop"))
+})

--- a/tests/testthat/test-onboarding.R
+++ b/tests/testthat/test-onboarding.R
@@ -280,6 +280,9 @@ test_that("eri_onboard_disease errors on unsupported data_type", {
 new_schemas <- list(
   c("uga",    "oncho",   "programmatic", "treatment"),
   c("uga",    "oncho",   "research",     "prevalence"),
+  c("uga",    "sch",     "programmatic", "treatment"),
+  c("ssd",    "oncho",   "programmatic", "treatment"),
+  c("sdn",    "oncho",   "programmatic", "treatment"),
   c("global", "schisto", "programmatic", "treatment"),
   c("global", "schisto", "research",     "prevalence"),
   c("global", "sth",     "programmatic", "treatment"),


### PR DESCRIPTION
## What
Rewrites `uga_oncho_programmatic_treatment.yaml` and adds `uga_sch_programmatic_treatment.yaml`, `ssd_oncho_programmatic_treatment.yaml`, and `sdn_oncho_programmatic_treatment.yaml`, all built against the REAL CMR field codes (`eri_ingest_cmr()` output, `#rbtrt_*`/`#schtrt_*` prefixes).

## Why
Ahead of a live ingest of real South Sudan, Sudan, and Uganda CMR data, I checked whether the shipped DQ schema actually works against real submissions. It did not: `uga_oncho_programmatic_treatment.yaml` targeted a different, community-level format (`round`/`sub_county`/`community` all required) that the real monthly CMR does not have. Running it against a real Uganda file returned **7 "required column missing" flags and nothing else**, because none of its aliases resolved. South Sudan and Sudan had no DQ schema at all.

## What changed
- District, year, and treated are required; population and target are range-checked but not required (roughly half of real historical rows genuinely do not report a target, which is a normal submission pattern, not an error; the range floor (>= 1) still catches a present-but-invalid value).
- District `allowed_values` are the real historical district lists per country, pulled from the canonical `BI_inputs/all_treatment.parquet` (public administrative unit names, not case data).
- Uganda gets both RB and SCH schemas; South Sudan and Sudan get RB only (their real workbooks have no SCH Treatment sheet).

## Verified against real submitted CMR
Read-only recon: aggregate counts only, no records persisted or shared.
- All four schemas now resolve every real column, zero "missing required column" errors (down from 7).
- The `target_pop` range floor (`>= 1`) catches two real, confirmed anomalies: Sudan's most recent submission (202605) has `target = 0` for all 10 districts; Uganda's has `target = 0` for 45 of 52 districts.

## Known, not auto-corrected
The historical district lists carry near-duplicate entries (`Moyo` / `MOYO` in Uganda, `Aweil West` / `Awiel West` in South Sudan) and non-geographic values (`Passive`, `Refugees`, `Maban Refugees`). All are left in `allowed_values` as-is rather than merged or dropped, since it is not confirmed which are real duplicates versus distinct reporting categories. Flagging for the maintainer rather than deciding.

## A package-behavior note
A schema's `consistency:` block is **not** run automatically by `run_dq_checks()`; the aggregate-check pass only reads `derived:`, and `consistency` requires an explicit `add_anomaly_consistency(schema)` chain. These schemas rely on automatic `range` checks instead, which cover what matters for a first pass. Worth a decision later on whether to wire `consistency` into the default `run_dq_checks()` pipeline.

## Tests
14 new tests in `test-dq.R`, offline/synthetic fixtures only (no real data in the test suite). `test-dq.R`: **84 pass, 0 fail**. `test-cmr.R`: **749 pass, 0 fail** (unaffected).

## Version
Bumps to 0.9.5 + NEWS.
