### PR TITLE
docs(cmr): explain why uga routing has no CDD/CS/STH sheets (0.9.6)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.5
+Version: 0.9.6
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# erifunctions 0.9.6
+
+## Docs: explain why Uganda's CMR routing has no CDD/CS/STH sheets
+
+- **`inst/schemas/cmr/uga.yaml` gets a comment explaining a real-world routing
+  question a Data Analyst raised** (a DA expected to see "CDD Training", "CS
+  Training", and "STH Treatment" sheets for Uganda). The routing was already
+  correct; the confusion was structural, not a bug. Per the real pipeline's
+  2026 template notes: Uganda's CDD count is now a downstream aggregate (VHT
+  Training + Local Leaders Training), CS Training was dropped for 2026, and
+  STH treatment is not part of Uganda's program (only Nigeria reports it).
+  Sudan and South Sudan's templates still carry CDD/CS as their own sheets, so
+  it is an easy assumption to carry across countries. No routing logic
+  changed; comment-only.
+
 # erifunctions 0.9.5
 
 ## Fix / add: data-quality schemas rebuilt against the real CMR field codes

--- a/inst/schemas/cmr/uga.yaml
+++ b/inst/schemas/cmr/uga.yaml
@@ -9,6 +9,15 @@ template: english_cmr
 # sheet; Training sheets -> combined `rblf`). Sheets without routing keys
 # (reference tabs with no field codes) are skipped; ToT routes with the trainings.
 # `required_fields` lists the stable (non-monthly) identifier columns.
+#
+# Uganda's 2026 template has NO separate "CDD Training", "CS Training", or
+# "STH Treatment" sheets, on purpose, not a gap in this routing list. Per the
+# real pipeline's 2026 template notes (health-rb-country-expansion,
+# config/versions/2026.yaml): CDD is now a downstream aggregate (VHT Training +
+# Local Leaders Training, both routed below), CS Training was dropped for 2026,
+# and STH treatment is not part of Uganda's disease program (only Nigeria
+# reports STH). Sudan/South Sudan's templates still have CDD/CS as raw sheets;
+# don't assume Uganda's structure matches theirs.
 
 sheets:
   "RB Treatment":


### PR DESCRIPTION
## What
Adds a comment to `inst/schemas/cmr/uga.yaml` explaining why it has no `CDD Training`, `CS Training`, or `STH Treatment` sheets. No routing logic changes.

## Why
Resolves a real ticket from a Data Analyst (via `eri_feedback`): they expected those sheets for Uganda's CMR and thought the routing list was incomplete. It is not. Verified against `health-rb-country-expansion`'s own `config/versions/2026.yaml` (the real pipeline's template spec): Uganda's CDD count is now a downstream aggregate (VHT Training + Local Leaders Training, both already routed), CS Training was dropped from the template for 2026, and STH treatment is not part of Uganda's disease program (only Nigeria reports it). Sudan and South Sudan's templates still carry CDD/CS as their own raw sheets, so the assumption is easy to carry across countries.

## Scope
Comment-only. `devtools::test()` full suite: **2080 pass, 0 fail, 0 error.**