### PR TITLE
docs: sync README version, note eri_split_cmr's mirror_pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ problems. Before adding a function or pattern:
 - `devtools::document()` if exports/docs changed; `devtools::check()` should pass clean.
 - `devtools::test()` — unit tests run offline; live integration tests in
   `tests/testthat/test-smoke.R` run only when `Sys.setenv(ERI_SMOKE_TESTS = "true")`.
-- Update `NEWS.md` under the current phase heading and bump `DESCRIPTION` `Version` if shipping.
+- Update `NEWS.md` and bump `DESCRIPTION` `Version` if shipping — and the `**Version:**` line near the
+  top of `README.md`, which does not track `DESCRIPTION` automatically and has drifted before.
 - Note: the cloud dev container has **no local R/quarto** — `R CMD check` and
   `pkgdown::build_site()` are verified in GitHub Actions CI, not locally.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.0 · **Status:** Active development
+**Version:** 0.9.8 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -251,7 +251,7 @@ eri_catalog_verify()
 | Function | What it does |
 |---|---|
 | `eri_ingest_cmr(path, sheet, country)` | Parse a CMR Excel sheet |
-| `eri_split_cmr(path, country)` | Route each CMR sheet to its disease/measure staged path |
+| `eri_split_cmr(path, country)` | Route each CMR sheet to its disease/measure staged path (opt-in `mirror_pipeline` also uploads the raw file to the legacy contractor pipeline) |
 | `load_cmr_schema(country)` | Load a bundled CMR country schema |
 | `eri_stage_cmr(country, period)` | Stage CMR files from the projects blob |
 


### PR DESCRIPTION
## Summary
- README's `**Version:**` line had drifted (still said 0.9.0 across 8 point releases) -- bumped to 0.9.8.
- `eri_split_cmr` row in README's function table now mentions the new `mirror_pipeline` option, matching how `eri_ingest`'s row already documents its own mirror option.
- Added README's Version line to CLAUDE.md's pre-PR checklist so this doesn't drift again.

Docs-only, no code change.