### PR TITLE
feat(dal): raw retention + source hashing for eri_ingest (0.9.11)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.10
+Version: 0.9.11
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,10 @@
 
 ## Raw retention and source hashing generalized to `eri_ingest()` (Phase 1 of the DQ workflow redesign)
 
-The first phase of the pilot-feedback-driven DQ workflow redesign (design consult with Fable,
-see the plan referenced in the CMR workflow above): every ingest now keeps the exact bytes it was
-given, and every downstream copy can be traced back to them.
+The first phase of the pilot-feedback-driven DQ workflow redesign (design consult with Fable;
+see the "DQ workflow redesign" entry under Phase 3 of `docs/roadmap.md` for the full 8-phase plan):
+every ingest now keeps the exact bytes it was given, and every downstream copy can be traced back
+to them.
 
 - **`eri_ingest()` now archives the source file to `raw/` before doing anything else**, under a
   timestamp-suffixed filename so repeat ingests never collide, then runs DQ and stages as before.
@@ -14,9 +15,10 @@ given, and every downstream copy can be traced back to them.
   used for identity, not security): `eri_ingest()`, `eri_stage_cmr()`, `eri_split_cmr()`, and the
   `dq_flags` entries written by `eri_dq_log()`/`eri_cmr_dq_report()`. `eri_cmr_last_plan()` surfaces
   it (falling back to `NA` for log entries written before this change).
-- This is the traceability groundwork for the planned `eri_audit()` timeline function (Phase 3):
-  being able to walk from a figure in a final table back through `processed` -> `staged` -> the
-  exact `raw/` bytes and DQ review that approved them.
+- This is the traceability groundwork for the planned `eri_audit()` timeline function (phase 3 of
+  the DQ workflow redesign, not to be confused with the V2 roadmap's own "Phase 3"): being able to
+  walk from a figure in a final table back through `processed` -> `staged` -> the exact `raw/`
+  bytes and DQ review that approved them.
 - `da-ingest-guide.Rmd` updated to describe the new automatic raw-archival step.
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,24 @@
-# erifunctions 0.9.10
+# erifunctions 0.9.11
+
+## Raw retention and source hashing generalized to `eri_ingest()` (Phase 1 of the DQ workflow redesign)
+
+The first phase of the pilot-feedback-driven DQ workflow redesign (design consult with Fable,
+see the plan referenced in the CMR workflow above): every ingest now keeps the exact bytes it was
+given, and every downstream copy can be traced back to them.
+
+- **`eri_ingest()` now archives the source file to `raw/` before doing anything else**, under a
+  timestamp-suffixed filename so repeat ingests never collide, then runs DQ and stages as before.
+  This was previously a manual step DAs did themselves (as in the `da-ingest-guide.Rmd` sandbox
+  walkthrough); it is now automatic on the fast path.
+- **Every op-log along the ingest/CMR path now carries a `source_hash`** (MD5 of the source file,
+  used for identity, not security): `eri_ingest()`, `eri_stage_cmr()`, `eri_split_cmr()`, and the
+  `dq_flags` entries written by `eri_dq_log()`/`eri_cmr_dq_report()`. `eri_cmr_last_plan()` surfaces
+  it (falling back to `NA` for log entries written before this change).
+- This is the traceability groundwork for the planned `eri_audit()` timeline function (Phase 3):
+  being able to walk from a figure in a final table back through `processed` -> `staged` -> the
+  exact `raw/` bytes and DQ review that approved them.
+- `da-ingest-guide.Rmd` updated to describe the new automatic raw-archival step.
+
 
 ## Per-flag DQ triage for CMR: one combined report, issue-by-issue resolution, traceable to approval
 

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -285,6 +285,12 @@ eri_split_cmr <- function(path, country, data_con = NULL,
     cli::cli_abort("File not found: {.path {path}}")
   }
 
+  # Identity for the workbook this run splits, not security -- carried into
+  # every measure's dq_flags entry (via the plan) so an audit trail can
+  # confirm exactly which submission a flag/approval traces back to. Computed
+  # once, up front, so it's identical whether this call is a dry run or real.
+  source_hash <- unname(tools::md5sum(path))
+
   # Resolve period generally (not just for the mirror): a leading YYYYMM_ in
   # the filename, same convention observed in real submissions. Used to tag
   # the op-log so eri_cmr_last_plan() can find this run again later. Failing
@@ -400,11 +406,12 @@ eri_split_cmr <- function(path, country, data_con = NULL,
   }
 
   plan_tbl <- tibble::tibble(
-    sheet     = vapply(plan, function(p) p$sheet,     character(1L)),
-    disease   = vapply(plan, function(p) p$disease,   character(1L)),
-    data_type = vapply(plan, function(p) p$data_type, character(1L)),
-    dest      = vapply(plan, function(p) p$dest,      character(1L)),
-    n_rows    = vapply(plan, function(p) p$n_rows,    integer(1L))
+    sheet       = vapply(plan, function(p) p$sheet,     character(1L)),
+    disease     = vapply(plan, function(p) p$disease,   character(1L)),
+    data_type   = vapply(plan, function(p) p$data_type, character(1L)),
+    dest        = vapply(plan, function(p) p$dest,      character(1L)),
+    n_rows      = vapply(plan, function(p) p$n_rows,    integer(1L)),
+    source_hash = source_hash
   )
 
   if (dry_run) {
@@ -483,14 +490,17 @@ eri_split_cmr <- function(path, country, data_con = NULL,
     analyst    = .eri_analyst_id(data_con),
     started_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     parameters = list(country = country, path = path, period = period),
+    source_file = basename(path),
+    source_hash = source_hash,
     status     = "in_progress", steps = list(), error = NULL, files = NULL,
     # Structured routing table (sheet/disease/data_type/dest/n_rows), not just
     # the flat `files` path list -- lets eri_cmr_last_plan() reconstruct the
     # plan tibble later without rerunning eri_split_cmr() or keeping the R
-    # object alive in-session.
+    # object alive in-session. source_hash travels with each row so
+    # eri_cmr_dq_report() can attribute a DQ check back to the exact workbook.
     plan = lapply(plan, function(p) {
       list(sheet = p$sheet, disease = p$disease, data_type = p$data_type,
-           dest = p$dest, n_rows = p$n_rows)
+           dest = p$dest, n_rows = p$n_rows, source_hash = source_hash)
     })
   )
 
@@ -683,11 +693,14 @@ eri_cmr_last_plan <- function(country, period, data_con = NULL) {
   }
 
   tibble::tibble(
-    sheet     = vapply(entry$plan, function(p) p$sheet,     character(1L)),
-    disease   = vapply(entry$plan, function(p) p$disease,   character(1L)),
-    data_type = vapply(entry$plan, function(p) p$data_type, character(1L)),
-    dest      = vapply(entry$plan, function(p) p$dest,      character(1L)),
-    n_rows    = vapply(entry$plan, function(p) p$n_rows,    integer(1L))
+    sheet       = vapply(entry$plan, function(p) p$sheet,     character(1L)),
+    disease     = vapply(entry$plan, function(p) p$disease,   character(1L)),
+    data_type   = vapply(entry$plan, function(p) p$data_type, character(1L)),
+    dest        = vapply(entry$plan, function(p) p$dest,      character(1L)),
+    n_rows      = vapply(entry$plan, function(p) p$n_rows,    integer(1L)),
+    # NA for a plan logged before source_hash was added -- older entries
+    # still reconstruct, just without that provenance field.
+    source_hash = vapply(entry$plan, function(p) p$source_hash %||% NA_character_, character(1L))
   )
 }
 
@@ -886,8 +899,10 @@ eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, da
     )
     if (is.null(schema)) next
 
-    result  <- run_dq_checks(staged, schema)
-    written <- .eri_dq_log_write(result, country, p$disease, "programmatic", p$data_type, period, data_con)
+    result       <- run_dq_checks(staged, schema)
+    p_source_hash <- if ("source_hash" %in% names(plan)) p$source_hash else NULL
+    written <- .eri_dq_log_write(result, country, p$disease, "programmatic", p$data_type, period, data_con,
+                                 source_hash = p_source_hash)
 
     if (isTRUE(supersede)) {
       prior <- tryCatch(
@@ -1082,11 +1097,12 @@ eri_stage_cmr <- function(country,
 
       tmp <- tempfile()
       .eri_blob_read(projects_con, src_path, tmp)
+      file_hash <- unname(tools::md5sum(tmp))  # identity, not security -- same convention as eri_ingest()
       .eri_blob_write(data_con, tmp, dest_path)
       unlink(tmp)
       staged       <- c(staged, dest_path)
       op_log$steps <- .eri_log_step(op_log$steps, "stage_file",
-                                     src = src_path, dest = dest_path)
+                                     src = src_path, dest = dest_path, source_hash = file_hash)
       .eri_say_done("Staged: {.path {fname}}")
     }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -1463,20 +1463,6 @@ eri_ingest <- function(path, country, disease,
     )
   }
 
-  if (is.null(schema)) {
-    schema <- load_dq_schema(country, disease, data_source, data_type, azcontainer = data_con)
-  }
-
-  raw_data <- eri_read(path, azure = FALSE)
-  if (is.list(raw_data) && !is.data.frame(raw_data)) {
-    raw_data <- raw_data[[1]]
-    cli::cli_alert_info("Multi-sheet Excel detected: using first sheet for DQ.")
-  }
-
-  result <- run_dq_checks(raw_data, schema)
-  dq_report(result)
-
-  fname_parquet <- paste0(tools::file_path_sans_ext(basename(path)), ".parquet")
   # Five-axis staging (ADR-0012): the measure lands in the path, so a later
   # eri_approve(country, disease, data_source, period, data_type) promotes it.
   # c() drops a NULL data_type, so a measure-less ingest stays four-axis.
@@ -1513,13 +1499,16 @@ eri_ingest <- function(path, country, disease,
   written   <- character(0)
   had_error <- FALSE
   err_msg   <- NULL
+  result    <- NULL
 
   tryCatch({
     # Archive the original source file to the raw/ layer before anything else
-    # touches it -- ADR-0012's five-axis model already has this layer; this
-    # generalizes what eri_stage_cmr() already does for CMR into the general
-    # ingest path, so reproducing a submission later doesn't depend on
-    # whoever has a copy of the original email/upload.
+    # touches it -- including before the file is even read or DQ-checked --
+    # ADR-0012's five-axis model already has this layer; this generalizes what
+    # eri_stage_cmr() already does for CMR into the general ingest path, so
+    # reproducing a submission later, or debugging why a malformed file was
+    # rejected, doesn't depend on whoever still has a copy of the original
+    # email/upload.
     if (!AzureStor::storage_dir_exists(data_con, raw_dir)) {
       AzureStor::create_storage_dir(data_con, raw_dir)
       op_log$steps <- .eri_log_step(op_log$steps, "create_raw_dir", path = raw_dir)
@@ -1528,6 +1517,21 @@ eri_ingest <- function(path, country, disease,
     written      <- c(written, raw_dest)
     op_log$steps <- .eri_log_step(op_log$steps, "archive_raw", dest = raw_dest, source_hash = source_hash)
     .eri_say_done("Archived raw source: {.path {raw_dest}}")
+
+    if (is.null(schema)) {
+      schema <- load_dq_schema(country, disease, data_source, data_type, azcontainer = data_con)
+    }
+
+    raw_data <- eri_read(path, azure = FALSE)
+    if (is.list(raw_data) && !is.data.frame(raw_data)) {
+      raw_data <- raw_data[[1]]
+      cli::cli_alert_info("Multi-sheet Excel detected: using first sheet for DQ.")
+    }
+
+    result <- run_dq_checks(raw_data, schema)
+    dq_report(result)
+
+    fname_parquet <- paste0(tools::file_path_sans_ext(basename(path)), ".parquet")
 
     if (!AzureStor::storage_dir_exists(data_con, staged_dir)) {
       AzureStor::create_storage_dir(data_con, staged_dir)

--- a/R/dal.R
+++ b/R/dal.R
@@ -1370,11 +1370,19 @@ eri_stage <- function(pipeline, country, disease,
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' The general analyst ingest entry point. Reads a raw local file, runs all DQ
-#' checks via [run_dq_checks()], prints the flags, and writes the cleaned parquet
-#' to `data/{country}/{disease}/{data_source}/{data_type}/staged/` — feeding
+#' The general analyst ingest entry point. Reads a raw local file, archives the
+#' original file as-is to `data/{country}/{disease}/{data_source}/{data_type}/raw/`
+#' (timestamp-suffixed, so re-ingesting the same filename never collides with an
+#' earlier archive of it), runs all DQ checks via [run_dq_checks()], prints the
+#' flags, and writes the cleaned parquet to
+#' `data/{country}/{disease}/{data_source}/{data_type}/staged/` — feeding
 #' [eri_approve()] with the matching measure. It runs on **any** data, including a
 #' throwaway sandbox: there is no pipeline-registry or country gate by default.
+#'
+#' The raw archive and the logged DQ flags both carry an MD5 hash of the source
+#' file (identity, not security) — reproducing an old submission, or answering
+#' "which exact bytes did this review look at", doesn't depend on whoever still
+#' has a copy of the original email/upload.
 #'
 #' The legacy `projects`-blob dual-write (the hsp-mal cutover comparison) is an
 #' **opt-in** mirror: pass `mirror_pipeline = "hsp-mal"` to additionally mirror the
@@ -1473,7 +1481,19 @@ eri_ingest <- function(path, country, disease,
   # eri_approve(country, disease, data_source, period, data_type) promotes it.
   # c() drops a NULL data_type, so a measure-less ingest stays four-axis.
   staged_dir    <- eri_data_path(country, disease, data_source, data_type, "staged")
+  raw_dir       <- eri_data_path(country, disease, data_source, data_type, "raw")
   log_dir       <- paste(c(country, disease, data_source, data_type, "logs"), collapse = "/")
+
+  # Identity for the source file, not security -- lets a later audit trail
+  # answer "which exact bytes were reviewed/approved" even across a rename.
+  source_hash <- unname(tools::md5sum(path))
+  # Timestamp-suffixed so re-ingesting the same filename (a corrected re-send,
+  # a different period) never collides with an earlier raw archive of it.
+  raw_ts    <- format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC")
+  raw_ext   <- tools::file_ext(path)
+  raw_fname <- paste0(tools::file_path_sans_ext(basename(path)), "_", raw_ts,
+                      if (nzchar(raw_ext)) paste0(".", raw_ext) else "")
+  raw_dest  <- paste0(raw_dir, "/", raw_fname)
 
   op_log <- list(
     operation  = "eri_ingest",
@@ -1482,6 +1502,8 @@ eri_ingest <- function(path, country, disease,
     parameters = list(path = path, country = country, disease = disease,
                       data_source = data_source, data_type = data_type,
                       mirror_pipeline = mirror_pipeline),
+    source_file = basename(path),
+    source_hash = source_hash,
     status     = "in_progress",
     steps      = list(),
     error      = NULL,
@@ -1493,6 +1515,20 @@ eri_ingest <- function(path, country, disease,
   err_msg   <- NULL
 
   tryCatch({
+    # Archive the original source file to the raw/ layer before anything else
+    # touches it -- ADR-0012's five-axis model already has this layer; this
+    # generalizes what eri_stage_cmr() already does for CMR into the general
+    # ingest path, so reproducing a submission later doesn't depend on
+    # whoever has a copy of the original email/upload.
+    if (!AzureStor::storage_dir_exists(data_con, raw_dir)) {
+      AzureStor::create_storage_dir(data_con, raw_dir)
+      op_log$steps <- .eri_log_step(op_log$steps, "create_raw_dir", path = raw_dir)
+    }
+    .eri_blob_write(data_con, path, raw_dest)
+    written      <- c(written, raw_dest)
+    op_log$steps <- .eri_log_step(op_log$steps, "archive_raw", dest = raw_dest, source_hash = source_hash)
+    .eri_say_done("Archived raw source: {.path {raw_dest}}")
+
     if (!AzureStor::storage_dir_exists(data_con, staged_dir)) {
       AzureStor::create_storage_dir(data_con, staged_dir)
       op_log$steps <- .eri_log_step(op_log$steps, "create_staged_dir", path = staged_dir)
@@ -1531,7 +1567,8 @@ eri_ingest <- function(path, country, disease,
     # Persist the DQ flags to the log backlog so they are durable and triageable
     # via eri_logs() / eri_logs_resolve(). Never let a logging hiccup break ingest.
     tryCatch(
-      eri_dq_log(result, country, disease, data_source, data_type, data_con = data_con),
+      eri_dq_log(result, country, disease, data_source, data_type, data_con = data_con,
+                source_hash = source_hash),
       error = function(e) cli::cli_alert_warning("Could not log DQ flags: {conditionMessage(e)}")
     )
 

--- a/R/logs.R
+++ b/R/logs.R
@@ -206,6 +206,10 @@
 #'   `NULL` (default) writes to the four-axis channel-level `logs/` directory.
 #' @param period `chr` or `NULL` Reporting period the data covers (e.g. `"2024-01"`).
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
+#' @param source_hash `chr` or `NULL` MD5 hash of the source file this check ran
+#'   against (identity, not security), if you have one -- lets a later audit
+#'   trail confirm exactly which bytes were reviewed. `NULL` (default) when
+#'   there's no local file to hash (e.g. checking data already staged in Azure).
 #' @returns Invisibly, the number of flags logged.
 #' @examples
 #' \dontrun{
@@ -214,15 +218,17 @@
 #' }
 #' @export
 eri_dq_log <- function(result, country, disease, data_source,
-                       data_type = NULL, period = NULL, data_con = NULL) {
+                       data_type = NULL, period = NULL, data_con = NULL,
+                       source_hash = NULL) {
   written <- .eri_dq_log_write(result, country, disease, data_source,
-                               data_type, period, data_con)
+                               data_type, period, data_con, source_hash)
   invisible(written$n_flags)
 }
 
 #' @keywords internal
 .eri_dq_log_write <- function(result, country, disease, data_source,
-                              data_type = NULL, period = NULL, data_con = NULL) {
+                              data_type = NULL, period = NULL, data_con = NULL,
+                              source_hash = NULL) {
   if (!inherits(result, "dq_result")) {
     cli::cli_abort("{.arg result} must be a {.cls dq_result} from {.fn run_dq_checks}.")
   }
@@ -255,6 +261,11 @@ eri_dq_log <- function(result, country, disease, data_source,
     parameters    = list(country = country, disease = disease,
                          data_source = data_source, data_type = data_type,
                          period = period),
+    # Identity for the file this check actually ran against -- lets an audit
+    # trail answer "which exact bytes were reviewed here", not just "some
+    # file was". NULL (default) when the caller has no local file to hash
+    # (e.g. checking data already staged in Azure).
+    source_hash   = if (is.null(source_hash)) NA_character_ else source_hash,
     status        = status,
     n_flags       = n_flags,
     n_corrections = nrow(result$log),

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.10 · **Status:** Active development
+**Version:** 0.9.11 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -214,6 +214,17 @@ periods as they arrive; `eri_cutover_check()` each one; watch `eri_cutover_statu
 streak; only then retire the adapters for that stream. The toolchain is ready and end-to-end tested
 offline. It needs real uploads, not more code.
 
+**DQ workflow redesign (in progress, pilot-feedback-driven):** the SDN/SSD CMR pilot surfaced a
+recurring pain point — a DA fixing DQ flags had no structured way to note *what* they fixed or *why*,
+and no way to trace a `processed/` figure back to the exact source bytes it came from. A design consult
+scoped an 8-phase plan to close this: (1) raw retention + source hashing on every ingest path — **shipped**
+(this doc's entry, NEWS 0.9.11); (2) DQ schema override lifecycle; (3) `eri_audit()` — walk a canonical
+value back through `processed → staged → raw` and the DQ review that approved it; (4) `eri_feedback()` +
+`eri_dq_schema_submit()` for DA-authored schema-edit tickets; (5) `eri_approve_cmr()` force-approve path;
+(6) an interactive `eri_dq_review()` wrapper over the existing scriptable per-flag triage
+(`eri_dq_flag_resolve()`/`eri_logs_resolve()`); (7) `eri_dq_export()` (PDF flag report); (8) guide
+convergence. Phases 2–8 are not yet started; each ships as its own PR against this plan, not a rewrite.
+
 ---
 
 ## Phase 4: ODK live pilot (Uganda survey)

--- a/man/eri_dq_log.Rd
+++ b/man/eri_dq_log.Rd
@@ -11,7 +11,8 @@ eri_dq_log(
   data_source,
   data_type = NULL,
   period = NULL,
-  data_con = NULL
+  data_con = NULL,
+  source_hash = NULL
 )
 }
 \arguments{
@@ -30,6 +31,11 @@ eri_dq_log(
 \item{period}{\code{chr} or \code{NULL} Reporting period the data covers (e.g. \code{"2024-01"}).}
 
 \item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.}
+
+\item{source_hash}{\code{chr} or \code{NULL} MD5 hash of the source file this check ran
+against (identity, not security), if you have one -- lets a later audit
+trail confirm exactly which bytes were reviewed. \code{NULL} (default) when
+there's no local file to hash (e.g. checking data already staged in Azure).}
 }
 \value{
 Invisibly, the number of flags logged.

--- a/man/eri_ingest.Rd
+++ b/man/eri_ingest.Rd
@@ -53,11 +53,19 @@ Invisibly, the \code{dq_result} object (\verb{$data}, \verb{$log}, \verb{$flags}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-The general analyst ingest entry point. Reads a raw local file, runs all DQ
-checks via \code{\link[=run_dq_checks]{run_dq_checks()}}, prints the flags, and writes the cleaned parquet
-to \verb{data/\{country\}/\{disease\}/\{data_source\}/\{data_type\}/staged/} — feeding
+The general analyst ingest entry point. Reads a raw local file, archives the
+original file as-is to \verb{data/\{country\}/\{disease\}/\{data_source\}/\{data_type\}/raw/}
+(timestamp-suffixed, so re-ingesting the same filename never collides with an
+earlier archive of it), runs all DQ checks via \code{\link[=run_dq_checks]{run_dq_checks()}}, prints the
+flags, and writes the cleaned parquet to
+\verb{data/\{country\}/\{disease\}/\{data_source\}/\{data_type\}/staged/} — feeding
 \code{\link[=eri_approve]{eri_approve()}} with the matching measure. It runs on \strong{any} data, including a
 throwaway sandbox: there is no pipeline-registry or country gate by default.
+
+The raw archive and the logged DQ flags both carry an MD5 hash of the source
+file (identity, not security) — reproducing an old submission, or answering
+"which exact bytes did this review look at", doesn't depend on whoever still
+has a copy of the original email/upload.
 
 The legacy \code{projects}-blob dual-write (the hsp-mal cutover comparison) is an
 \strong{opt-in} mirror: pass \code{mirror_pipeline = "hsp-mal"} to additionally mirror the

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -524,6 +524,36 @@ test_that("eri_stage_cmr(period = NULL) auto-selects the most recent period", {
   expect_match(read_src, "202406")   # staged from the 202406 source dir
 })
 
+test_that("eri_stage_cmr records a source_hash on each staged file's op-log step", {
+  mock_con <- structure(list(), class = "mock")
+
+  local_mocked_bindings(
+    storage_dir_exists  = function(...) TRUE,
+    storage_file_exists = function(...) FALSE,
+    list_storage_files  = function(container, dir, ...) {
+      tibble::tibble(name = paste0(dir, "/uga_cmr_202406.xlsx"), isdir = FALSE)
+    },
+    .package = "AzureStor"
+  )
+  logged_op <- NULL
+  local_mocked_bindings(
+    .eri_blob_read   = function(con, src, dest, ...) { writeLines("fixed content", dest); invisible(dest) },
+    .eri_blob_write  = function(...) invisible(NULL),
+    .eri_write_log   = function(op_log, ...) { logged_op <<- op_log; invisible(NULL) },
+    .eri_log_session = function(...) invisible(NULL),
+    .eri_analyst_id  = function(...) "tester",
+    get_azure_storage_connection = function(...) mock_con,
+    .package = "erifunctions"
+  )
+
+  eri_stage_cmr("uga", "202406", data_con = mock_con)
+
+  stage_steps <- Filter(function(s) identical(s$step, "stage_file"), logged_op$steps)
+  expect_length(stage_steps, 1L)
+  expect_false(is.null(stage_steps[[1]]$source_hash))
+  expect_true(nzchar(stage_steps[[1]]$source_hash))
+})
+
 test_that("eri_split_cmr writes one parquet per routed sheet to the data blob", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   make_uga_cmr(tmp)
@@ -851,6 +881,60 @@ test_that("eri_cmr_last_plan reconstructs a plan from the persisted op-log", {
   expect_s3_class(plan, "tbl_df")
   expect_equal(nrow(plan), 2L)
   expect_setequal(plan$disease, c("oncho", "lf"))
+  # fake_entry predates source_hash -- should default to NA, not error
+  expect_true(all(is.na(plan$source_hash)))
+})
+
+test_that("eri_cmr_last_plan carries source_hash through when the logged plan has it", {
+  fake_entry <- list(
+    operation = "eri_split_cmr", status = "success",
+    plan = list(
+      list(sheet = "RB Treatment", disease = "oncho", data_type = "treatment",
+          dest = "sdn/oncho/programmatic/treatment/staged/x.parquet", n_rows = 10L,
+          source_hash = "abc123")
+    )
+  )
+  local_mocked_bindings(
+    eri_logs = function(...) tibble::tibble(
+      log_path = "sdn/rblf/cmr/logs/fake.yaml", period = "202605",
+      operation = "eri_split_cmr", status = "success"
+    ),
+    .eri_blob_read = function(con, src, dest, ...) {
+      yaml::write_yaml(fake_entry, dest); invisible(dest)
+    },
+    .package = "erifunctions"
+  )
+
+  plan <- eri_cmr_last_plan("sdn", "202605", data_con = structure(list(), class = "mock"))
+  expect_equal(plan$source_hash, "abc123")
+})
+
+test_that("eri_split_cmr's real op-log and returned plan both carry source_hash", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_uga_cmr(tmp)
+
+  logged <- NULL
+  local_mocked_bindings(
+    storage_dir_exists  = function(...) TRUE,
+    storage_file_exists = function(...) FALSE,
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    .eri_blob_write  = function(...) invisible(NULL),
+    .eri_write_log   = function(op_log, ...) { logged <<- op_log; invisible(NULL) },
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+
+  plan <- suppressWarnings(
+    eri_split_cmr(tmp, "uga", data_con = structure(list(), class = "mock"))
+  )
+
+  expected_hash <- unname(tools::md5sum(tmp))
+  expect_true(all(plan$source_hash == expected_hash))
+  expect_equal(logged$source_hash, expected_hash)
+  expect_equal(logged$source_file, basename(tmp))
+  expect_true(all(vapply(logged$plan, function(p) p$source_hash, character(1L)) == expected_hash))
 })
 
 test_that("eri_cmr_last_plan errors clearly when nothing is logged for that period", {
@@ -974,7 +1058,7 @@ test_that("eri_cmr_dq_report combines every measure's flags into one tibble with
     eri_read = function(...) tibble::tibble(x = 1),
     load_dq_schema = function(...) list(columns = list()),
     run_dq_checks = function(...) fake_result,
-    .eri_dq_log_write = function(result, country, disease, data_source, data_type, period, data_con) {
+    .eri_dq_log_write = function(result, country, disease, data_source, data_type, period, data_con, ...) {
       list(n_flags = 1L, status = "needs_review",
           log_path = paste0(country, "/", disease, "/", data_source, "/", data_type, "/logs/x.yaml"),
           flags = list(list(index = 1, row = 1L, column = "district", value = "Bad",

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -420,6 +420,53 @@ test_that("eri_ingest archives the original source file to raw/ before staging",
   expect_equal(logged_op$source_hash, unname(tools::md5sum(raw_csv)))
 })
 
+test_that("eri_ingest still archives to raw/ and logs the failure when reading the file errors", {
+  raw_csv <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(Year = 2024L, EpiWeek = 1L), raw_csv, row.names = FALSE)
+
+  schema <- list(
+    country = "uga", disease = "oncho",
+    data_source = "programmatic", data_type = "treatment",
+    temporal = list(year_col = "Year", period_col = "EpiWeek"),
+    columns  = list(
+      Year    = list(required = TRUE, type = "numeric"),
+      EpiWeek = list(required = TRUE, type = "numeric")
+    )
+  )
+
+  written_dests <- character(0)
+  logged_op     <- NULL
+
+  local_mocked_bindings(
+    .eri_blob_write  = function(con, src, dest, ...) { written_dests <<- c(written_dests, dest); invisible(NULL) },
+    .eri_write_log   = function(op_log, con, dir, ...) { logged_op <<- op_log; invisible(NULL) },
+    eri_read         = function(...) stop("corrupt or unreadable file"),
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    storage_dir_exists = function(...) TRUE,
+    .package = "AzureStor"
+  )
+
+  expect_error(
+    eri_ingest(raw_csv, "uga", "oncho",
+               data_source = "programmatic", data_type = "treatment",
+               schema = schema, data_con = structure(list(), class = "mock")),
+    "corrupt or unreadable file"
+  )
+
+  # the raw archive still happened even though the read that follows it failed
+  raw_write <- written_dests[grepl("^uga/oncho/programmatic/treatment/raw/", written_dests)]
+  expect_length(raw_write, 1L)
+
+  # ...and the failure is visible in the op-log, not silently lost
+  expect_equal(logged_op$status, "error")
+  expect_match(logged_op$error, "corrupt or unreadable file")
+  step_names <- vapply(logged_op$steps, function(s) s$step, character(1L))
+  expect_true("archive_raw" %in% step_names)
+})
+
 #### Tests for eri_approve error paths (no Azure needed) ####
 
 test_that("eri_approve errors informatively when staged dir does not exist", {

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -376,6 +376,50 @@ test_that("eri_ingest with data_type = NULL stays four-axis (no measure level)",
   expect_equal(logged_dir, "uga/oncho/surveillance/logs")
 })
 
+test_that("eri_ingest archives the original source file to raw/ before staging", {
+  raw_csv <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(Year = 2024L, EpiWeek = 1L), raw_csv, row.names = FALSE)
+
+  schema <- list(
+    country = "uga", disease = "oncho",
+    data_source = "programmatic", data_type = "treatment",
+    temporal = list(year_col = "Year", period_col = "EpiWeek"),
+    columns  = list(
+      Year    = list(required = TRUE, type = "numeric"),
+      EpiWeek = list(required = TRUE, type = "numeric")
+    )
+  )
+
+  written_dests  <- character(0)
+  logged_op      <- NULL
+
+  local_mocked_bindings(
+    .eri_blob_write  = function(con, src, dest, ...) { written_dests <<- c(written_dests, dest); invisible(NULL) },
+    .eri_write_log   = function(op_log, con, dir, ...) { logged_op <<- op_log; invisible(NULL) },
+    eri_dq_log       = function(...) invisible(NULL),
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    storage_dir_exists = function(...) TRUE,
+    .package = "AzureStor"
+  )
+
+  eri_ingest(raw_csv, "uga", "oncho",
+             data_source = "programmatic", data_type = "treatment",
+             schema = schema, data_con = structure(list(), class = "mock"))
+
+  raw_write <- written_dests[grepl("^uga/oncho/programmatic/treatment/raw/", written_dests)]
+  expect_length(raw_write, 1L)
+  # timestamp-suffixed, not the bare original filename, so re-ingesting the
+  # same filename later doesn't collide with this archive
+  expect_match(basename(raw_write), paste0("^", tools::file_path_sans_ext(basename(raw_csv)), "_\\d{8}T\\d{6}Z"))
+
+  expect_false(is.null(logged_op$source_hash))
+  expect_equal(logged_op$source_file, basename(raw_csv))
+  expect_equal(logged_op$source_hash, unname(tools::md5sum(raw_csv)))
+})
+
 #### Tests for eri_approve error paths (no Azure needed) ####
 
 test_that("eri_approve errors informatively when staged dir does not exist", {

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -504,9 +504,12 @@ unlink("atlantis_malaria_surveillance_case.yaml")   # the local schema file
 You have now done the full DA ingest loop: store raw, quality-check against a schema, fix what only a
 human can, stage, and **approve** into the canonical layer, twice, including a messy extract.
 
-One call, [`eri_ingest()`](../reference/eri_ingest.html), does the read-and-DQ-and-stage steps
+One call, [`eri_ingest()`](../reference/eri_ingest.html), does the archive-DQ-and-stage steps
 (§2, §4, §5) in a single shot, on **any** data including the sandbox you just built (it takes the same
-`country` / `disease` / `data_source` / `data_type` you have been using). We did each step by hand here
+`country` / `disease` / `data_source` / `data_type` you have been using). It archives the file you hand
+it to `raw/` under a timestamped name before doing anything else, records an MD5 hash of that source
+file in the operation log (so any later `staged`/`processed` copy can be traced back to the exact bytes
+that were reviewed), then runs the DQ checks and stages the result. We did each step by hand here
 so you could *see* every layer; once you are comfortable, `eri_ingest()` is the fast path, and
 `eri_approve()`: your sign-off, is always the same human gate at the end. *(For the legacy `hsp-mal`
 cutover, passing `mirror_pipeline = "hsp-mal"` also mirrors the output to the old `projects` blob, off


### PR DESCRIPTION
## Summary

Phase 1 of the pilot-feedback-driven DQ workflow redesign (Fable consult): raw-file retention,
previously a manual step DAs did by hand in the sandbox guide, is now automatic on the
`eri_ingest()` fast path, and every op-log along the ingest/CMR chain now carries a source hash
so a `processed/` file can eventually be traced back to the exact bytes that were reviewed.

- `eri_ingest()` archives the source file to `raw/` (timestamp-suffixed filename) before running
  DQ and staging.
- `source_hash` (MD5, identity not security) threaded through `eri_ingest()`, `eri_stage_cmr()`,
  `eri_split_cmr()`, `eri_cmr_last_plan()`, and the `dq_flags` envelope written by
  `eri_dq_log()`/`eri_cmr_dq_report()`. Backward compatible -- old log entries surface `NA`.
  `eri_dq_log()`'s existing return contract (`invisible(n_flags)`) is unchanged.
- `da-ingest-guide.Rmd` updated to describe the automatic raw-archival step.
- NEWS.md entry added, DESCRIPTION and README version bumped to 0.9.11.

This is groundwork for the planned `eri_audit()` timeline function later in the same plan (walking
a final figure back through `processed` -> `staged` -> `raw` -> the DQ review that approved it).

## Test plan
- [x] `devtools::document()` clean
- [x] Full local test suite (`testthat::test_dir()`) -- zero failures, only expected CRAN-skip and
      pre-existing warnings
- [ ] CI green