### PR TITLE
docs(news): restore missing 0.9.10/0.9.11 version headings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@ Also confirms Phase 2 (CMR re-run hygiene) was already shipped and validates it 
   promoted, with no leftover duplicate and no blocking log pileup; all test artifacts were cleaned
   up afterward. See `docs/roadmap.md`'s "DQ workflow redesign" entry.
 
+# erifunctions 0.9.11
+
 ## Raw retention and source hashing generalized to `eri_ingest()` (Phase 1 of the DQ workflow redesign)
 
 The first phase of the pilot-feedback-driven DQ workflow redesign (design consult with Fable;
@@ -55,6 +57,7 @@ to them.
   bytes and DQ review that approved them.
 - `da-ingest-guide.Rmd` updated to describe the new automatic raw-archival step.
 
+# erifunctions 0.9.10
 
 ## Per-flag DQ triage for CMR: one combined report, issue-by-issue resolution, traceable to approval
 


### PR DESCRIPTION
## Summary
Two prior NEWS.md edits this session each replaced the previous version's top-level heading
instead of inserting a new one above it, silently flattening the 0.9.10 and 0.9.11 changelog
sections under the 0.9.12 heading. Restores the correct `# erifunctions X.Y.Z` structure so each
release's notes are attributed to the right version.

## Test plan
- [x] Verified `# erifunctions` headings are now sequential (0.9.12, 0.9.11, 0.9.10, 0.9.9, ...)
- [x] No code changes; nothing to test beyond the diff itself