### PR TITLE
docs(news): restore missing 0.9.12 version heading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
   by updating the Azure `schemas/*.yaml` blob directly (`load_dq_schema()` already prefers it over the
   bundled copy), which takes effect for every DA within minutes, not at the next package release.
 
+# erifunctions 0.9.12
+
 ## DQ schema local overrides: three-tier resolution, hash-based expiry (Phase 3 of the DQ workflow redesign)
 
 Also confirms Phase 2 (CMR re-run hygiene) was already shipped and validates it end-to-end. See


### PR DESCRIPTION
## Summary
Same root cause as #276: the edit adding the 0.9.13 changelog section replaced the
`# erifunctions 0.9.12` heading instead of inserting a new one above it, flattening 0.9.12's
content under 0.9.13. Restores the correct heading so `# erifunctions` reads 0.9.13, 0.9.12,
0.9.11, 0.9.10, ... in order.

## Test plan
- [x] Verified heading sequence is now sequential with no gaps/dupes
- [x] No code changes