### PR TITLE
feat(cmr): eri_approve_cmr() force-approve path (0.9.15)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.14
+Version: 0.9.15
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+# erifunctions 0.9.15
+
+## `eri_approve_cmr()` force-approve path (Phase 6 of the DQ workflow redesign)
+
+- **New `eri_approve_cmr(..., force = FALSE, justification = NULL)`**: for the rare case an
+  outstanding measure must be promoted anyway (e.g. a known template quirk confirmed with the
+  country, under a deadline). `force = TRUE` requires a non-empty `justification` -- no interactive
+  confirmation prompt here, since this scriptable core has to keep working unattended in scripts/CI;
+  that extra human friction belongs in the planned interactive `eri_dq_review()` wrapper (Phase 7),
+  not this function.
+- **Bypassed measures are annotated, never silently resolved.** Each bypassed `dq_flags` entry (when
+  one exists -- a "never DQ-checked" bypass has nothing to annotate) is marked `handled` via
+  `eri_logs_resolve(..., forced = TRUE)`, which now records `forced` in the triage block alongside a
+  note pointing back at the approval's own log. The open backlog stays clean without ever pretending
+  the flag was genuinely reviewed.
+- **The approval's own log records `forced`, `justification`, and exactly what it bypassed.**
+- **`eri_audit()` renders a forced approval and its bypass annotations in red with a `[FORCED]`
+  prefix**, rather than folding them in as ordinary events -- the one part of a trail that was *not*
+  a genuine review. New `forced` column on every event row.
+- Sequenced deliberately after Phase 5 (`eri_audit()`): the override is born fully auditable, never
+  before. Live-validated against a real `atlantis` forced approval end-to-end.
+- Also fixes a real bug found during this phase's validation: `eri_audit()`'s chronological sort used
+  a malformed date format string (missing `%M`) that silently failed to parse *every* timestamp,
+  degrading the sort to a no-op (original file-read order, not chronological order) with no error or
+  warning -- caught by re-running the live validation, not by the unit test written for it (which
+  happened to insert events in already-correct order, masking the bug). Fixed the format string and
+  rewrote the test to insert events out of order, so it can actually tell a working sort from one that
+  silently does nothing.
+
 # erifunctions 0.9.14
 
 ## `eri_audit()`: a chronological, event-level audit trail (Phase 5 of the DQ workflow redesign)

--- a/R/audit.R
+++ b/R/audit.R
@@ -25,12 +25,12 @@
   # via log_path -- the "walk a value back to its source bytes" half of the
   # audit story that source_hash was built for.
   source_hash <- entry$source_hash %||% NA_character_
-  mk <- function(timestamp, event, actor, detail) {
+  mk <- function(timestamp, event, actor, detail, forced = FALSE) {
     list(timestamp = .eri_na_chr(timestamp), event = event, actor = .eri_na_chr(actor),
          detail = if (is.null(detail)) NA_character_ else detail, log_path = log_path,
          country = axes$country, disease = axes$disease,
          data_source = axes$data_source, data_type = axes$data_type,
-         period = axes$period, source_hash = source_hash)
+         period = axes$period, source_hash = source_hash, forced = isTRUE(forced))
   }
 
   events <- list()
@@ -80,19 +80,41 @@
       dq_bit <- if (!is.null(entry$dq_reviewed) && length(entry$dq_reviewed) > 0L) {
         paste0("dq_reviewed: ", paste(basename(unlist(entry$dq_reviewed)), collapse = ", "))
       } else NULL
-      detail <- paste(Filter(Negate(is.null), list(measures_bit, dq_bit)), collapse = " -- ")
+      # A forced approval bypassed one or more outstanding measures -- surface
+      # exactly what and why, since this is the event eri_audit() renders
+      # prominently (see print.eri_audit_trail()).
+      forced_bit <- if (isTRUE(entry$forced)) {
+        bypassed_bit <- if (!is.null(entry$bypassed) && length(entry$bypassed) > 0L) {
+          paste0("bypassed: ", paste(
+            vapply(entry$bypassed, function(b) paste0(b$disease %||% "?", "/", b$data_type %||% "?",
+                                                       " (", b$issue %||% "?", ")"),
+                   character(1L)),
+            collapse = ", "
+          ))
+        } else NULL
+        paste(Filter(Negate(is.null), list(
+          paste0("justification: ", entry$justification %||% "?"), bypassed_bit
+        )), collapse = " -- ")
+      } else NULL
+      detail <- paste(Filter(Negate(is.null), list(measures_bit, dq_bit, forced_bit)), collapse = " -- ")
       if (!nzchar(detail)) detail <- NULL
     } else if (!is.null(entry$files) && length(entry$files) > 0L) {
       detail <- paste(basename(unlist(entry$files)), collapse = ", ")
     }
-    events[[length(events) + 1L]] <- mk(ts, op %||% "operation", entry$analyst, detail)
+    events[[length(events) + 1L]] <- mk(ts, op %||% "operation", entry$analyst, detail,
+                                        forced = isTRUE(entry$forced))
   }
 
   # A triage close-out (eri_logs_resolve()) can sit on ANY entry type above --
-  # one more event, regardless of what the entry itself was.
+  # one more event, regardless of what the entry itself was. A forced bypass
+  # (eri_logs_resolve(..., forced = TRUE), from eri_approve_cmr()'s force
+  # path) gets its own event name and the `forced` marker -- it closed the
+  # entry, but it was never actually reviewed, and that distinction matters.
   if (!is.null(entry$triage) && isTRUE(entry$triage$handled)) {
+    is_forced <- isTRUE(entry$triage$forced)
     events[[length(events) + 1L]] <- mk(
-      entry$triage$handled_at, "log_resolved", entry$triage$handled_by, entry$triage$note
+      entry$triage$handled_at, if (is_forced) "log_resolved (forced bypass)" else "log_resolved",
+      entry$triage$handled_by, entry$triage$note, forced = is_forced
     )
   }
 
@@ -105,7 +127,7 @@
     timestamp = character(), event = character(), actor = character(),
     detail = character(), log_path = character(), country = character(),
     disease = character(), data_source = character(), data_type = character(),
-    period = character(), source_hash = character()
+    period = character(), source_hash = character(), forced = logical()
   )
   class(out) <- c("eri_audit_trail", class(out))
   out
@@ -121,7 +143,7 @@
 # this handles both forms; unparseable strings become NA and sort last.
 #' @keywords internal
 .eri_audit_parse_ts <- function(x) {
-  suppressWarnings(as.POSIXct(x, format = "%Y-%m-%dT%H:%OSZ", tz = "UTC"))
+  suppressWarnings(as.POSIXct(x, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC"))
 }
 
 #' Reconstruct a chronological audit trail for a dataset
@@ -142,6 +164,11 @@
 #' in — `log_path` stays on every row so a power user can still drill into the
 #' raw YAML, but nobody should *have* to follow paths by hand to answer "what
 #' happened to this dataset, and who signed off on it."
+#'
+#' A forced approval ([eri_approve_cmr()]'s `force = TRUE`) and the bypass
+#' annotations it leaves on the measures it overrode both render prominently
+#' here (`forced = TRUE`, printed in red) rather than folding in as an
+#' ordinary event — the one thing in a trail that was *not* a genuine review.
 #'
 #' No CMR-specific entry point is needed: leaving `disease`/`data_source`/
 #' `data_type` `NULL` (the default) already enumerates every disease/channel/
@@ -165,9 +192,10 @@
 #'   `data_type`, `period`, `source_hash` (an MD5 identity hash of the source
 #'   file the entry's operation ran against, when one was recorded — lets you
 #'   trace which exact bytes are behind a given step without opening the raw
-#'   YAML). Class `eri_audit_trail`; printing it renders a `cli`-formatted
-#'   timeline — the tibble itself is still the API (filter, join, whatever
-#'   you need).
+#'   YAML), `forced` (`lgl`; `TRUE` for a forced `eri_approve_cmr()` approval
+#'   or a bypass annotation it left behind). Class `eri_audit_trail`; printing
+#'   it renders a `cli`-formatted timeline — the tibble itself is still the
+#'   API (filter, join, whatever you need).
 #' @examples
 #' \dontrun{
 #' eri_audit("sdn", period = "202605")                      # a whole CMR period
@@ -224,7 +252,8 @@ eri_audit <- function(country, disease = NULL, data_source = NULL, data_type = N
     data_source = vapply(rows, function(r) .eri_na_chr(r$data_source), character(1L)),
     data_type   = vapply(rows, function(r) .eri_na_chr(r$data_type),   character(1L)),
     period      = vapply(rows, function(r) .eri_na_chr(r$period),      character(1L)),
-    source_hash = vapply(rows, function(r) .eri_na_chr(r$source_hash), character(1L))
+    source_hash = vapply(rows, function(r) .eri_na_chr(r$source_hash), character(1L)),
+    forced      = vapply(rows, function(r) isTRUE(r$forced),           logical(1L))
   )
 
   if (!is.null(period)) {
@@ -291,7 +320,15 @@ print.eri_audit_trail <- function(x, ...) {
     actor  <- if (!is.na(r$actor)) paste0(" (", r$actor, ")") else ""
     detail <- if (!is.na(r$detail) && nzchar(r$detail)) paste0(": ", r$detail) else ""
     event  <- r$event
-    cli::cli_bullets(c("*" = "{ts} -- {.strong {event}}{actor}{detail}"))
+    if (isTRUE(r$forced)) {
+      # A forced approval or a forced-bypass annotation -- render prominently
+      # (red, a "!" bullet) rather than folding it in as an ordinary event;
+      # this is the one thing in the trail that was NOT a genuine review.
+      line <- cli::col_red(paste0("[FORCED] ", ts, " -- ", event, actor, detail))
+      cli::cli_bullets(c("!" = line))
+    } else {
+      cli::cli_bullets(c("*" = "{ts} -- {.strong {event}}{actor}{detail}"))
+    }
   }
   invisible(x)
 }

--- a/R/audit.R
+++ b/R/audit.R
@@ -324,8 +324,12 @@ print.eri_audit_trail <- function(x, ...) {
       # A forced approval or a forced-bypass annotation -- render prominently
       # (red, a "!" bullet) rather than folding it in as an ordinary event;
       # this is the one thing in the trail that was NOT a genuine review.
+      # `detail` can embed free text a DA typed (the force-approve
+      # `justification`) -- interpolate the finished string as a glue
+      # VARIABLE ("{line}"), not as the template itself, or a stray literal
+      # "{" in someone's justification crashes the whole print.
       line <- cli::col_red(paste0("[FORCED] ", ts, " -- ", event, actor, detail))
-      cli::cli_bullets(c("!" = line))
+      cli::cli_bullets(c("!" = "{line}"))
     } else {
       cli::cli_bullets(c("*" = "{ts} -- {.strong {event}}{actor}{detail}"))
     }

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -733,21 +733,53 @@ eri_cmr_last_plan <- function(country, period, data_con = NULL) {
 #' truly stale/superseded flag needs an explicit note to clear, not just a
 #' clean recheck.
 #'
+#' **`force = TRUE` approves anyway**, for the rare case a DA needs to promote
+#' data despite an outstanding measure (e.g. a genuine template quirk that
+#' will never resolve cleanly, under a deadline). It requires a non-empty
+#' `justification` -- no confirmation prompt here, since this scriptable core
+#' has to work unattended in scripts/CI; an interactive wrapper is the right
+#' place for extra human friction (e.g. "type the period to confirm"), not
+#' this function. Every bypassed measure's `dq_flags` entry (when one exists)
+#' is annotated `handled` via [eri_logs_resolve()] with `forced = TRUE` and a
+#' note pointing back at this approval's own log -- so the open backlog stays
+#' clean without pretending the flag was ever actually reviewed, and
+#' [eri_audit()] renders the whole thing prominently rather than folding it in
+#' as an ordinary approval.
+#'
 #' @param country `str` Country code (e.g. `"sdn"`).
 #' @param period `str` Reporting period (e.g. `"202605"`).
 #' @param plan `tibble` or `NULL` The plan from [eri_split_cmr()] /
 #'   [eri_cmr_last_plan()]. `NULL` (default) looks it up via [eri_cmr_last_plan()].
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
-#' @returns Invisibly, a tibble: if everything was clean, one row per
-#'   `(disease, data_type)` that got approved; if anything was outstanding,
-#'   one row per `(disease, data_type)` still needing attention (with
-#'   `log_path`/`issue`) and **nothing was approved**.
+#' @param force `lgl` Approve even if some measures are outstanding. Default
+#'   `FALSE`. Requires `justification`.
+#' @param justification `chr` or `NULL` Required (non-empty) when `force = TRUE`:
+#'   why this approval is going through despite what's outstanding. Recorded
+#'   on the approval's own log and ignored when `force = FALSE`.
+#' @returns Invisibly, a tibble: if everything was clean (or `force = TRUE`),
+#'   one row per `(disease, data_type)` that got approved; if anything was
+#'   outstanding and `force = FALSE`, one row per `(disease, data_type)` still
+#'   needing attention (with `log_path`/`issue`) and **nothing was approved**.
 #' @examples
 #' \dontrun{
 #' eri_approve_cmr("sdn", "202605")
+#'
+#' # Only if you genuinely mean to promote past an outstanding measure:
+#' eri_approve_cmr("sdn", "202605", force = TRUE,
+#'                  justification = "Known template quirk in RB Treatment; confirmed with country lead.")
 #' }
 #' @export
-eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL) {
+eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
+                            force = FALSE, justification = NULL) {
+  if (isTRUE(force) &&
+      (is.null(justification) || length(justification) != 1L ||
+       is.na(justification) || !nzchar(trimws(justification)))) {
+    cli::cli_abort(c(
+      "{.arg justification} must be a single non-empty string when {.code force = TRUE}.",
+      "i" = "Explain why this approval should go through despite what's outstanding."
+    ))
+  }
+
   data_con <- .eri_logs_con(data_con)
 
   if (is.null(plan)) plan <- eri_cmr_last_plan(country, period, data_con = data_con)
@@ -781,15 +813,24 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL) {
       dq_reviewed <- c(dq_reviewed, dq_logs$log_path)
     }
   }
+  outstanding_tbl <- if (length(outstanding) > 0L) dplyr::bind_rows(outstanding) else NULL
 
-  if (length(outstanding) > 0L) {
-    outstanding_tbl <- dplyr::bind_rows(outstanding)
+  if (!is.null(outstanding_tbl) && !isTRUE(force)) {
     cli::cli_alert_danger(c(
       "{nrow(outstanding_tbl)} measure{?s} still need{?s/} attention -- approving nothing.",
-      "i" = "Review each below, close it out with {.fn eri_logs_resolve} (pass a {.arg note}), then re-run this."
+      "i" = "Review each below, close it out with {.fn eri_logs_resolve} (pass a {.arg note}), then re-run this.",
+      "i" = "Or pass {.code force = TRUE} and a {.arg justification} to approve anyway."
     ))
     print(outstanding_tbl)
     return(invisible(outstanding_tbl))
+  }
+
+  if (!is.null(outstanding_tbl)) {
+    cli::cli_alert_danger(c(
+      "!" = "FORCE-APPROVING {.val {country}} / {.val {period}} despite {nrow(outstanding_tbl)} outstanding measure{?s}.",
+      "i" = "Justification: {justification}"
+    ))
+    print(outstanding_tbl)
   }
 
   approved <- vector("list", nrow(measures))
@@ -808,20 +849,57 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL) {
   # reviewed and decided, and by whom" (each dq_flags log_path carries its own
   # per-flag notes via eri_dq_flag_resolve() and its whole-entry note via
   # eri_logs_resolve()).
+  trail_log <- list(
+    operation  = "eri_approve_cmr",
+    analyst    = .eri_analyst_id(data_con),
+    timestamp  = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    parameters = list(country = country, period = period),
+    status     = "success",
+    measures   = as.list(paste(approved_tbl$disease, approved_tbl$data_type, sep = "/")),
+    dq_reviewed = as.list(dq_reviewed)
+  )
+  if (!is.null(outstanding_tbl)) {
+    trail_log$forced        <- TRUE
+    trail_log$justification <- justification
+    trail_log$bypassed <- lapply(seq_len(nrow(outstanding_tbl)), function(i) {
+      b <- outstanding_tbl[i, ]
+      list(disease = b$disease, data_type = b$data_type, issue = b$issue,
+           log_path = if (is.na(b$log_path)) NA_character_ else b$log_path)
+    })
+  }
   trail_path <- .eri_write_log(
-    list(
-      operation  = "eri_approve_cmr",
-      analyst    = .eri_analyst_id(data_con),
-      timestamp  = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
-      parameters = list(country = country, period = period),
-      status     = "success",
-      measures   = as.list(paste(approved_tbl$disease, approved_tbl$data_type, sep = "/")),
-      dq_reviewed = as.list(dq_reviewed)
-    ),
-    data_con, paste(c(country, "rblf", "cmr", "logs"), collapse = "/")
+    trail_log, data_con, paste(c(country, "rblf", "cmr", "logs"), collapse = "/")
   )
 
-  cli::cli_alert_success("Approved {nrow(approved_tbl)} measure{?s} for {.val {country}} / {.val {period}}.")
+  # Annotate (never silently resolve) each bypassed dq_flags entry that
+  # actually exists, pointing back at this approval's own log -- the open
+  # backlog stays clean, but the record says exactly what happened and why,
+  # never that the flag was genuinely reviewed. A "never DQ-checked" bypass
+  # (no log_path) has nothing to annotate -- it's already captured in
+  # trail_log$bypassed above.
+  if (!is.null(outstanding_tbl)) {
+    bypass_note <- paste0(
+      "Bypassed by a forced eri_approve_cmr() approval",
+      if (!is.null(trail_path)) paste0(" (", basename(trail_path), ")") else "",
+      ": ", justification
+    )
+    for (lp in outstanding_tbl$log_path[!is.na(outstanding_tbl$log_path)]) {
+      tryCatch(
+        eri_logs_resolve(lp, note = bypass_note, forced = TRUE, data_con = data_con),
+        error = function(e) cli::cli_alert_warning(
+          "Could not annotate bypassed log {.path {lp}}: {conditionMessage(e)}"
+        )
+      )
+    }
+  }
+
+  cli::cli_alert_success(
+    if (!is.null(outstanding_tbl)) {
+      "Force-approved {nrow(approved_tbl)} measure{?s} for {.val {country}} / {.val {period}}."
+    } else {
+      "Approved {nrow(approved_tbl)} measure{?s} for {.val {country}} / {.val {period}}."
+    }
+  )
   if (is.null(trail_path)) {
     cli::cli_alert_danger(c(
       "The measures above ARE approved, but the {.val dq_reviewed} audit-trail record could not be written",

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -880,7 +880,11 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
   if (!is.null(outstanding_tbl)) {
     bypass_note <- paste0(
       "Bypassed by a forced eri_approve_cmr() approval",
-      if (!is.null(trail_path)) paste0(" (", basename(trail_path), ")") else "",
+      if (!is.null(trail_path)) {
+        paste0(" (", basename(trail_path), ")")
+      } else {
+        " (this approval's own log could not be written -- no back-reference available)"
+      },
       ": ", justification
     )
     for (lp in outstanding_tbl$log_path[!is.na(outstanding_tbl$log_path)]) {

--- a/R/logs.R
+++ b/R/logs.R
@@ -430,8 +430,8 @@ eri_logs <- function(country = NULL, disease = NULL, data_source = NULL,
 #'
 #' Records a triage note on a single log YAML (by its `log_path` from
 #' [eri_logs()]), flagging it handled so it drops out of the open backlog. Adds a
-#' `triage` block (`handled`, `handled_by`, `handled_at`, `note`) to the file in
-#' place; the original operation record is preserved.
+#' `triage` block (`handled`, `handled_by`, `handled_at`, `note`, `forced`) to
+#' the file in place; the original operation record is preserved.
 #'
 #' Same single-editor caveat as [eri_dq_flag_resolve()]: this is a read-modify-write
 #' with no optimistic-concurrency protection, so two people resolving the *same*
@@ -440,6 +440,11 @@ eri_logs <- function(country = NULL, disease = NULL, data_source = NULL,
 #' @param log_path `chr` Blob path of the log to resolve (the `log_path` column
 #'   from [eri_logs()]).
 #' @param note `chr` or `NULL` An optional note describing how it was handled.
+#' @param forced `lgl` Mark the entry `handled` because something else bypassed
+#'   it (e.g. [eri_approve_cmr()]'s `force = TRUE` path), not because it was
+#'   actually reviewed and resolved. Default `FALSE`. Distinguishes an
+#'   annotated bypass from a genuine resolution in the record --
+#'   [eri_audit()] renders the two differently.
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
 #' @returns Invisibly, `TRUE`.
 #' @examples
@@ -448,7 +453,7 @@ eri_logs <- function(country = NULL, disease = NULL, data_source = NULL,
 #' eri_logs_resolve(backlog$log_path[1], note = "Re-ran after the source fixed the file.")
 #' }
 #' @export
-eri_logs_resolve <- function(log_path, note = NULL, data_con = NULL) {
+eri_logs_resolve <- function(log_path, note = NULL, forced = FALSE, data_con = NULL) {
   data_con <- .eri_logs_con(data_con)
 
   tmp <- tempfile(fileext = ".yaml")
@@ -468,14 +473,21 @@ eri_logs_resolve <- function(log_path, note = NULL, data_con = NULL) {
     handled    = TRUE,
     handled_by = .eri_analyst_id(data_con),
     handled_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
-    note       = if (is.null(note)) NA_character_ else note
+    note       = if (is.null(note)) NA_character_ else note,
+    forced     = isTRUE(forced)
   )
 
   yaml::write_yaml(entry, tmp)
   .eri_blob_write(data_con, tmp, log_path)
   unlink(tmp)
 
-  cli::cli_alert_success("Marked {.path {basename(log_path)}} handled.")
+  cli::cli_alert_success(
+    if (isTRUE(forced)) {
+      "Marked {.path {basename(log_path)}} handled (bypassed by a forced approval)."
+    } else {
+      "Marked {.path {basename(log_path)}} handled."
+    }
+  )
   invisible(TRUE)
 }
 

--- a/R/logs.R
+++ b/R/logs.R
@@ -440,12 +440,12 @@ eri_logs <- function(country = NULL, disease = NULL, data_source = NULL,
 #' @param log_path `chr` Blob path of the log to resolve (the `log_path` column
 #'   from [eri_logs()]).
 #' @param note `chr` or `NULL` An optional note describing how it was handled.
+#' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
 #' @param forced `lgl` Mark the entry `handled` because something else bypassed
 #'   it (e.g. [eri_approve_cmr()]'s `force = TRUE` path), not because it was
 #'   actually reviewed and resolved. Default `FALSE`. Distinguishes an
 #'   annotated bypass from a genuine resolution in the record --
 #'   [eri_audit()] renders the two differently.
-#' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
 #' @returns Invisibly, `TRUE`.
 #' @examples
 #' \dontrun{
@@ -453,7 +453,7 @@ eri_logs <- function(country = NULL, disease = NULL, data_source = NULL,
 #' eri_logs_resolve(backlog$log_path[1], note = "Re-ran after the source fixed the file.")
 #' }
 #' @export
-eri_logs_resolve <- function(log_path, note = NULL, forced = FALSE, data_con = NULL) {
+eri_logs_resolve <- function(log_path, note = NULL, data_con = NULL, forced = FALSE) {
   data_con <- .eri_logs_con(data_con)
 
   tmp <- tempfile(fileext = ".yaml")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.14 · **Status:** Active development
+**Version:** 0.9.15 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -256,7 +256,7 @@ eri_catalog_verify()
 |---|---|
 | `eri_dq_log(result, country, disease, data_source, data_type)` | Persist `run_dq_checks()` flags to the durable log backlog |
 | `eri_logs(country, disease, data_source, data_type)` | Read the operation / DQ-flag triage backlog as one tibble |
-| `eri_logs_resolve(log_path, note)` | Close out a whole log entry (auto-summarizes from per-flag decisions if triaged) |
+| `eri_logs_resolve(log_path, note, forced)` | Close out a whole log entry (auto-summarizes from per-flag decisions if triaged); `forced` marks a bypass, not a genuine resolution |
 | `eri_dq_flag_resolve(flag_id, status, note)` | Triage one DQ flag at a time (`not_important`/`fixed`/`noted`) |
 | `eri_audit(country, disease, data_source, data_type, period)` | Reconstruct a chronological, event-level audit trail (staged/split/DQ-run/flag-resolved/approved) |
 
@@ -281,7 +281,7 @@ eri_catalog_verify()
 | `eri_stage_cmr(country, period)` | Stage CMR files from the projects blob |
 | `eri_cmr_last_plan(country, period)` | Recover a past `eri_split_cmr()` run's routing plan from the log, without rerunning |
 | `eri_cmr_dq_report(country, period)` | DQ-check every measure a CMR workbook routed to, one combined flags tibble |
-| `eri_approve_cmr(country, period)` | Approve every measure in one call, but only if none are outstanding |
+| `eri_approve_cmr(country, period, force, justification)` | Approve every measure in one call, but only if none are outstanding (opt-in `force = TRUE` + `justification` to approve anyway) |
 
 ### ODK
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -254,10 +254,18 @@ which exact bytes backed a step, not only which operation ran; returned as a sin
 (oldest-first) tibble with its own `cli`-rendered print method; no CMR-specific entry point needed
 (leaving the axes unscoped already enumerates the `rblf/cmr` split/approve coordinate alongside
 every fanned-out measure — validated live against a real atlantis split → dq → approve trail);
-(6) `eri_approve_cmr()` force-approve path; (7) an interactive `eri_dq_review()` wrapper over the
-existing scriptable per-flag triage (`eri_dq_flag_resolve()`/`eri_logs_resolve()`); (8)
-`eri_dq_export()` (PDF flag report) + guide convergence. Phases 6–8 are not yet started; each ships as
-its own PR against this plan, not a rewrite.
+(6) `eri_approve_cmr()` force-approve path — **shipped**: `force = TRUE` requires a non-empty
+`justification` (no interactive confirmation gate here — that's Phase 7's job, since this scriptable
+core has to work unattended in scripts/CI), approves despite an outstanding measure, annotates each
+bypassed `dq_flags` entry `handled` via `eri_logs_resolve(..., forced = TRUE)` (never silently
+resolved, never left rotting the open backlog forever) with a note pointing back at the approval's
+own log, and records `forced`/`justification`/`bypassed` on that log; `eri_audit()` renders both the
+forced approval and the bypass annotation in red with a `[FORCED]` prefix rather than folding them in
+as ordinary events — sequenced deliberately after Phase 5 so the override is born fully auditable,
+never before. Live-validated against a real atlantis force-approval end-to-end; (7) an interactive
+`eri_dq_review()` wrapper over the existing scriptable per-flag triage
+(`eri_dq_flag_resolve()`/`eri_logs_resolve()`); (8) `eri_dq_export()` (PDF flag report) + guide
+convergence. Phases 7–8 are not yet started; each ships as its own PR against this plan, not a rewrite.
 
 ---
 

--- a/man/eri_approve_cmr.Rd
+++ b/man/eri_approve_cmr.Rd
@@ -4,7 +4,14 @@
 \alias{eri_approve_cmr}
 \title{Approve every disease/measure one CMR workbook routed to, in one call}
 \usage{
-eri_approve_cmr(country, period, plan = NULL, data_con = NULL)
+eri_approve_cmr(
+  country,
+  period,
+  plan = NULL,
+  data_con = NULL,
+  force = FALSE,
+  justification = NULL
+)
 }
 \arguments{
 \item{country}{\code{str} Country code (e.g. \code{"sdn"}).}
@@ -15,12 +22,19 @@ eri_approve_cmr(country, period, plan = NULL, data_con = NULL)
 \code{\link[=eri_cmr_last_plan]{eri_cmr_last_plan()}}. \code{NULL} (default) looks it up via \code{\link[=eri_cmr_last_plan]{eri_cmr_last_plan()}}.}
 
 \item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.}
+
+\item{force}{\code{lgl} Approve even if some measures are outstanding. Default
+\code{FALSE}. Requires \code{justification}.}
+
+\item{justification}{\code{chr} or \code{NULL} Required (non-empty) when \code{force = TRUE}:
+why this approval is going through despite what's outstanding. Recorded
+on the approval's own log and ignored when \code{force = FALSE}.}
 }
 \value{
-Invisibly, a tibble: if everything was clean, one row per
-\verb{(disease, data_type)} that got approved; if anything was outstanding,
-one row per \verb{(disease, data_type)} still needing attention (with
-\code{log_path}/\code{issue}) and \strong{nothing was approved}.
+Invisibly, a tibble: if everything was clean (or \code{force = TRUE}),
+one row per \verb{(disease, data_type)} that got approved; if anything was
+outstanding and \code{force = FALSE}, one row per \verb{(disease, data_type)} still
+needing attention (with \code{log_path}/\code{issue}) and \strong{nothing was approved}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
@@ -48,9 +62,26 @@ until you \code{\link[=eri_logs_resolve]{eri_logs_resolve()}} it. This is delibe
 shouldn't be silently superseded by a fresh "clean" run), but it does mean a
 truly stale/superseded flag needs an explicit note to clear, not just a
 clean recheck.
+
+\strong{\code{force = TRUE} approves anyway}, for the rare case a DA needs to promote
+data despite an outstanding measure (e.g. a genuine template quirk that
+will never resolve cleanly, under a deadline). It requires a non-empty
+\code{justification} -- no confirmation prompt here, since this scriptable core
+has to work unattended in scripts/CI; an interactive wrapper is the right
+place for extra human friction (e.g. "type the period to confirm"), not
+this function. Every bypassed measure's \code{dq_flags} entry (when one exists)
+is annotated \code{handled} via \code{\link[=eri_logs_resolve]{eri_logs_resolve()}} with \code{forced = TRUE} and a
+note pointing back at this approval's own log -- so the open backlog stays
+clean without pretending the flag was ever actually reviewed, and
+\code{\link[=eri_audit]{eri_audit()}} renders the whole thing prominently rather than folding it in
+as an ordinary approval.
 }
 \examples{
 \dontrun{
 eri_approve_cmr("sdn", "202605")
+
+# Only if you genuinely mean to promote past an outstanding measure:
+eri_approve_cmr("sdn", "202605", force = TRUE,
+                 justification = "Known template quirk in RB Treatment; confirmed with country lead.")
 }
 }

--- a/man/eri_audit.Rd
+++ b/man/eri_audit.Rd
@@ -36,9 +36,10 @@ A tibble, \strong{oldest first}, with columns \code{timestamp}, \code{event},
 \code{data_type}, \code{period}, \code{source_hash} (an MD5 identity hash of the source
 file the entry's operation ran against, when one was recorded — lets you
 trace which exact bytes are behind a given step without opening the raw
-YAML). Class \code{eri_audit_trail}; printing it renders a \code{cli}-formatted
-timeline — the tibble itself is still the API (filter, join, whatever
-you need).
+YAML), \code{forced} (\code{lgl}; \code{TRUE} for a forced \code{eri_approve_cmr()} approval
+or a bypass annotation it left behind). Class \code{eri_audit_trail}; printing
+it renders a \code{cli}-formatted timeline — the tibble itself is still the
+API (filter, join, whatever you need).
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
@@ -56,6 +57,11 @@ approval (its \code{dq_reviewed} field); this is the function that cashes that
 in — \code{log_path} stays on every row so a power user can still drill into the
 raw YAML, but nobody should \emph{have} to follow paths by hand to answer "what
 happened to this dataset, and who signed off on it."
+
+A forced approval (\code{\link[=eri_approve_cmr]{eri_approve_cmr()}}'s \code{force = TRUE}) and the bypass
+annotations it leaves on the measures it overrode both render prominently
+here (\code{forced = TRUE}, printed in red) rather than folding in as an
+ordinary event — the one thing in a trail that was \emph{not} a genuine review.
 
 No CMR-specific entry point is needed: leaving \code{disease}/\code{data_source}/
 \code{data_type} \code{NULL} (the default) already enumerates every disease/channel/

--- a/man/eri_logs_resolve.Rd
+++ b/man/eri_logs_resolve.Rd
@@ -4,13 +4,19 @@
 \alias{eri_logs_resolve}
 \title{Mark a log entry as handled}
 \usage{
-eri_logs_resolve(log_path, note = NULL, data_con = NULL)
+eri_logs_resolve(log_path, note = NULL, forced = FALSE, data_con = NULL)
 }
 \arguments{
 \item{log_path}{\code{chr} Blob path of the log to resolve (the \code{log_path} column
 from \code{\link[=eri_logs]{eri_logs()}}).}
 
 \item{note}{\code{chr} or \code{NULL} An optional note describing how it was handled.}
+
+\item{forced}{\code{lgl} Mark the entry \code{handled} because something else bypassed
+it (e.g. \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}'s \code{force = TRUE} path), not because it was
+actually reviewed and resolved. Default \code{FALSE}. Distinguishes an
+annotated bypass from a genuine resolution in the record --
+\code{\link[=eri_audit]{eri_audit()}} renders the two differently.}
 
 \item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.}
 }
@@ -20,8 +26,8 @@ Invisibly, \code{TRUE}.
 \description{
 Records a triage note on a single log YAML (by its \code{log_path} from
 \code{\link[=eri_logs]{eri_logs()}}), flagging it handled so it drops out of the open backlog. Adds a
-\code{triage} block (\code{handled}, \code{handled_by}, \code{handled_at}, \code{note}) to the file in
-place; the original operation record is preserved.
+\code{triage} block (\code{handled}, \code{handled_by}, \code{handled_at}, \code{note}, \code{forced}) to
+the file in place; the original operation record is preserved.
 }
 \details{
 Same single-editor caveat as \code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}}: this is a read-modify-write

--- a/man/eri_logs_resolve.Rd
+++ b/man/eri_logs_resolve.Rd
@@ -4,7 +4,7 @@
 \alias{eri_logs_resolve}
 \title{Mark a log entry as handled}
 \usage{
-eri_logs_resolve(log_path, note = NULL, forced = FALSE, data_con = NULL)
+eri_logs_resolve(log_path, note = NULL, data_con = NULL, forced = FALSE)
 }
 \arguments{
 \item{log_path}{\code{chr} Blob path of the log to resolve (the \code{log_path} column
@@ -12,13 +12,13 @@ from \code{\link[=eri_logs]{eri_logs()}}).}
 
 \item{note}{\code{chr} or \code{NULL} An optional note describing how it was handled.}
 
+\item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.}
+
 \item{forced}{\code{lgl} Mark the entry \code{handled} because something else bypassed
 it (e.g. \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}'s \code{force = TRUE} path), not because it was
 actually reviewed and resolved. Default \code{FALSE}. Distinguishes an
 annotated bypass from a genuine resolution in the record --
 \code{\link[=eri_audit]{eri_audit()}} renders the two differently.}
-
-\item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.}
 }
 \value{
 Invisibly, \code{TRUE}.

--- a/tests/testthat/test-audit.R
+++ b/tests/testthat/test-audit.R
@@ -389,3 +389,25 @@ test_that("eri_audit carries the forced column through and print.eri_audit_trail
   expect_match(rendered, "FORCED")
   expect_match(rendered, "Deadline override.", fixed = TRUE)
 })
+
+test_that("print.eri_audit_trail does not crash on a forced justification containing literal braces", {
+  # A justification is free text a DA types -- e.g. quoting a template
+  # placeholder or a formula -- and could easily contain "{"/"}". The forced
+  # row is rendered by building the whole line as a plain string first; it
+  # must be interpolated as a glue VARIABLE, not passed as the glue template
+  # itself, or a stray brace crashes the entire print (not just that row).
+  store <- list()
+  store[["atlantis/oncho/programmatic/treatment/logs/a.yaml"]] <- list(
+    operation = "eri_approve_cmr", analyst = "u", timestamp = "2026-06-01T11:00:00Z",
+    parameters = list(country = "atlantis", period = "202607"), status = "success",
+    measures = list("oncho/treatment"), forced = TRUE,
+    justification = "Matches the {district} placeholder in last month's template.",
+    bypassed = list(list(disease = "oncho", data_type = "treatment", issue = "3 unresolved DQ flag(s)",
+                        log_path = NA_character_))
+  )
+  local_audit_store(store)
+
+  out <- eri_audit("atlantis", "oncho", "programmatic", "treatment")
+  expect_no_error(rendered <- paste(cli::cli_fmt(print(out)), collapse = " "))
+  expect_match(rendered, "district", fixed = TRUE)
+})

--- a/tests/testthat/test-audit.R
+++ b/tests/testthat/test-audit.R
@@ -59,6 +59,55 @@ test_that(".eri_audit_events shows eri_approve_cmr's measures and dq_reviewed cr
   expect_equal(out[[1]]$event, "eri_approve_cmr")
   expect_match(out[[1]]$detail, "oncho/treatment", fixed = TRUE)
   expect_match(out[[1]]$detail, "dq_reviewed: dq_flags_202607.yaml", fixed = TRUE)
+  expect_false(out[[1]]$forced)
+})
+
+test_that(".eri_audit_events marks a forced eri_approve_cmr entry and shows its justification/bypassed detail", {
+  entry <- list(
+    operation = "eri_approve_cmr", analyst = "u", timestamp = "2026-06-01T11:00:00Z",
+    parameters = list(country = "atlantis", period = "202607"),
+    status = "success", measures = list("oncho/treatment"),
+    forced = TRUE, justification = "Known template quirk.",
+    bypassed = list(list(disease = "oncho", data_type = "treatment",
+                        issue = "3 unresolved DQ flag(s)", log_path = "x/y/logs/dq.yaml"))
+  )
+  out <- .eri_audit_events(entry, "atlantis/rblf/cmr/logs/f.yaml")
+  expect_length(out, 1L)
+  expect_true(out[[1]]$forced)
+  expect_match(out[[1]]$detail, "justification: Known template quirk.", fixed = TRUE)
+  expect_match(out[[1]]$detail, "bypassed: oncho/treatment (3 unresolved DQ flag(s))", fixed = TRUE)
+})
+
+test_that(".eri_audit_events renders a forced-bypass triage block as 'log_resolved (forced bypass)'", {
+  entry <- list(
+    operation = "dq_flags", analyst = "u", timestamp = "2026-06-01T09:30:00Z",
+    parameters = list(country = "atlantis", disease = "oncho", data_source = "programmatic",
+                      data_type = "treatment", period = "202607"),
+    status = "needs_review", n_flags = 1L,
+    flags = list(list(index = 1, status = "open", resolved_at = NA_character_,
+                      resolved_by = NA_character_, note = NA_character_)),
+    triage = list(handled = TRUE, handled_by = "maintainer", handled_at = "2026-06-03T10:00:00Z",
+                 note = "Bypassed by a forced approval.", forced = TRUE)
+  )
+  out <- .eri_audit_events(entry, "atlantis/oncho/programmatic/treatment/logs/f.yaml")
+  events <- vapply(out, function(e) e$event, character(1L))
+  expect_true("log_resolved (forced bypass)" %in% events)
+  bypass_event <- out[[which(events == "log_resolved (forced bypass)")]]
+  expect_true(bypass_event$forced)
+})
+
+test_that(".eri_audit_events keeps a genuine (non-forced) triage block as plain 'log_resolved'", {
+  entry <- list(
+    operation = "eri_approve", analyst = "u", completed_at = "2026-06-01T10:00:00Z",
+    parameters = list(country = "uga", disease = "oncho", data_source = "surveillance"),
+    status = "success",
+    triage = list(handled = TRUE, handled_by = "u", handled_at = "2026-06-02T10:00:00Z",
+                 note = "genuinely resolved", forced = FALSE)
+  )
+  out <- .eri_audit_events(entry, "uga/oncho/surveillance/logs/f.yaml")
+  events <- vapply(out, function(e) e$event, character(1L))
+  expect_true("log_resolved" %in% events)
+  expect_false(any(grepl("forced", events)))
 })
 
 test_that(".eri_audit_events produces one dq_flags event and no flag_resolved rows for an unresolved entry", {
@@ -276,18 +325,29 @@ test_that("eri_audit carries source_hash from the entry onto every event row", {
   expect_true(all(out$source_hash == "abc123"))
 })
 
+test_that(".eri_audit_parse_ts parses both whole- and fractional-second ISO-8601 timestamps", {
+  parsed <- .eri_audit_parse_ts(c("2026-06-01T12:00:01Z", "2026-06-01T12:00:01.500Z"))
+  expect_false(anyNA(parsed))
+  expect_true(parsed[2] > parsed[1])
+})
+
 test_that("eri_audit sorts a fractional-second timestamp correctly relative to whole-second ones", {
-  # A raw string sort would put "...12:00:01.500Z" BEFORE "...12:00:01Z",
-  # even though it is chronologically AFTER -- "." sorts before "Z" in ASCII.
+  # A raw string sort would put "...12:00:01.500Z" BEFORE "...12:00:01Z", even
+  # though it is chronologically AFTER -- "." sorts before "Z" in ASCII. Keyed
+  # so the LATER event is listed/read FIRST (file "a.yaml" before "b.yaml"):
+  # if sorting silently no-ops (e.g. every timestamp fails to parse), the
+  # untouched read order would put the later event first, and this test would
+  # catch that -- unlike a store already in chronological order, which cannot
+  # tell a working sort from a sort that quietly does nothing.
   store <- list()
   store[["atlantis/oncho/programmatic/treatment/logs/a.yaml"]] <- list(
-    operation = "eri_split_cmr", analyst = "u", started_at = "2026-06-01T12:00:01Z",
-    parameters = list(country = "atlantis", period = "202607"), status = "success"
-  )
-  store[["atlantis/oncho/programmatic/treatment/logs/b.yaml"]] <- list(
     operation = "eri_approve", analyst = "u", completed_at = "2026-06-01T12:00:01.500Z",
     parameters = list(country = "atlantis", disease = "oncho", data_source = "programmatic",
                       data_type = "treatment", period = "202607"), status = "success"
+  )
+  store[["atlantis/oncho/programmatic/treatment/logs/b.yaml"]] <- list(
+    operation = "eri_split_cmr", analyst = "u", started_at = "2026-06-01T12:00:01Z",
+    parameters = list(country = "atlantis", period = "202607"), status = "success"
   )
   local_audit_store(store)
 
@@ -309,4 +369,23 @@ test_that("eri_audit informs which periods were actually found when the period f
     "202607"
   )
   expect_equal(nrow(out), 0L)
+})
+
+test_that("eri_audit carries the forced column through and print.eri_audit_trail renders it prominently", {
+  store <- list()
+  store[["atlantis/oncho/programmatic/treatment/logs/a.yaml"]] <- list(
+    operation = "eri_approve_cmr", analyst = "u", timestamp = "2026-06-01T11:00:00Z",
+    parameters = list(country = "atlantis", period = "202607"), status = "success",
+    measures = list("oncho/treatment"), forced = TRUE, justification = "Deadline override.",
+    bypassed = list(list(disease = "oncho", data_type = "treatment", issue = "3 unresolved DQ flag(s)",
+                        log_path = NA_character_))
+  )
+  local_audit_store(store)
+
+  out <- eri_audit("atlantis", "oncho", "programmatic", "treatment")
+  expect_true(out$forced[out$event == "eri_approve_cmr"])
+
+  rendered <- paste(cli::cli_fmt(print(out)), collapse = " ")
+  expect_match(rendered, "FORCED")
+  expect_match(rendered, "Deadline override.", fixed = TRUE)
 })

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -1040,6 +1040,127 @@ test_that("eri_approve_cmr records a dq_reviewed cross-reference in its own op-l
   expect_true("sdn/oncho/programmatic/treatment/logs/dq.yaml" %in% unlist(logged[[1]]$dq_reviewed))
 })
 
+#### Tests for eri_approve_cmr()'s force = TRUE path ####
+
+test_that("eri_approve_cmr errors when force = TRUE without a justification", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  expect_error(
+    eri_approve_cmr("sdn", "202605", plan = plan, force = TRUE,
+                    data_con = structure(list(), class = "mock")),
+    "justification"
+  )
+  expect_error(
+    eri_approve_cmr("sdn", "202605", plan = plan, force = TRUE, justification = "   ",
+                    data_con = structure(list(), class = "mock")),
+    "justification"
+  )
+})
+
+test_that("eri_approve_cmr force = TRUE approves despite unresolved flags, annotates the bypassed entry, and records forced/justification/bypassed", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  approved   <- list()
+  resolved   <- list()
+  logged     <- list()
+  local_mocked_bindings(
+    eri_logs = function(...) tibble::tibble(
+      log_path = "sdn/oncho/programmatic/treatment/logs/x.yaml", period = "202605",
+      status = "needs_review", handled = FALSE, n_issues = 3L
+    ),
+    eri_approve = function(country, disease, data_source, period, data_type = NULL, azcontainer = NULL) {
+      approved[[length(approved) + 1L]] <<- list(disease = disease, data_type = data_type)
+    },
+    eri_logs_resolve = function(log_path, note = NULL, forced = FALSE, data_con = NULL) {
+      resolved[[length(resolved) + 1L]] <<- list(log_path = log_path, note = note, forced = forced)
+      invisible(TRUE)
+    },
+    .eri_write_log = function(log_list, ...) {
+      logged[[length(logged) + 1L]] <<- log_list
+      "sdn/rblf/cmr/logs/fake_force_approve.yaml"
+    },
+    .package = "erifunctions"
+  )
+
+  result <- suppressMessages(eri_approve_cmr(
+    "sdn", "202605", plan = plan, force = TRUE,
+    justification = "Known template quirk, confirmed with country lead.",
+    data_con = structure(list(), class = "mock")
+  ))
+
+  expect_length(approved, 1L)  # still approved, despite the outstanding flag
+  expect_equal(nrow(result), 1L)
+
+  expect_length(logged, 1L)
+  expect_true(logged[[1]]$forced)
+  expect_equal(logged[[1]]$justification, "Known template quirk, confirmed with country lead.")
+  expect_length(logged[[1]]$bypassed, 1L)
+  expect_equal(logged[[1]]$bypassed[[1]]$log_path, "sdn/oncho/programmatic/treatment/logs/x.yaml")
+
+  # the bypassed entry was annotated, forced = TRUE, pointing back at this approval
+  expect_length(resolved, 1L)
+  expect_equal(resolved[[1]]$log_path, "sdn/oncho/programmatic/treatment/logs/x.yaml")
+  expect_true(resolved[[1]]$forced)
+  expect_match(resolved[[1]]$note, "forced", ignore.case = TRUE)
+  expect_match(resolved[[1]]$note, "fake_force_approve.yaml", fixed = TRUE)
+})
+
+test_that("eri_approve_cmr force = TRUE on a never-DQ-checked measure records the bypass but attempts no annotation", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  resolve_called <- FALSE
+  logged <- list()
+  local_mocked_bindings(
+    eri_logs = function(...) tibble::tibble(
+      log_path = character(0), period = character(0),
+      status = character(0), handled = logical(0), n_issues = integer(0)
+    ),
+    eri_approve = function(...) invisible(NULL),
+    eri_logs_resolve = function(...) { resolve_called <<- TRUE },
+    .eri_write_log = function(log_list, ...) {
+      logged[[length(logged) + 1L]] <<- log_list
+      "sdn/rblf/cmr/logs/fake_force_approve2.yaml"
+    },
+    .package = "erifunctions"
+  )
+
+  suppressMessages(eri_approve_cmr(
+    "sdn", "202605", plan = plan, force = TRUE, justification = "Deadline override.",
+    data_con = structure(list(), class = "mock")
+  ))
+
+  expect_false(resolve_called)  # nothing to annotate -- no log_path exists
+  expect_true(logged[[1]]$forced)
+  expect_true(is.na(logged[[1]]$bypassed[[1]]$log_path))
+  expect_match(logged[[1]]$bypassed[[1]]$issue, "never DQ-checked")
+})
+
+test_that("eri_approve_cmr force = TRUE with nothing outstanding behaves like a normal approval (no forced fields)", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  logged <- list()
+  local_mocked_bindings(
+    eri_logs = function(...) tibble::tibble(
+      log_path = "sdn/x/programmatic/treatment/logs/x.yaml", period = "202605",
+      status = "clean", handled = FALSE, n_issues = 0L
+    ),
+    eri_approve = function(...) invisible(NULL),
+    .eri_write_log = function(log_list, ...) {
+      logged[[length(logged) + 1L]] <<- log_list
+      "sdn/rblf/cmr/logs/fake_force_approve3.yaml"
+    },
+    .package = "erifunctions"
+  )
+
+  suppressMessages(eri_approve_cmr(
+    "sdn", "202605", plan = plan, force = TRUE, justification = "Not actually needed here.",
+    data_con = structure(list(), class = "mock")
+  ))
+
+  expect_null(logged[[1]]$forced)
+  expect_null(logged[[1]]$bypassed)
+})
+
 test_that("eri_cmr_dq_report combines every measure's flags into one tibble with usable flag_ids", {
   plan <- tibble::tibble(
     sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -1161,6 +1161,35 @@ test_that("eri_approve_cmr force = TRUE with nothing outstanding behaves like a 
   expect_null(logged[[1]]$bypassed)
 })
 
+test_that("eri_approve_cmr force = TRUE still annotates the bypass (without a back-reference) when its own trail log fails to write", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  resolved <- list()
+  local_mocked_bindings(
+    eri_logs = function(...) tibble::tibble(
+      log_path = "sdn/oncho/programmatic/treatment/logs/x.yaml", period = "202605",
+      status = "needs_review", handled = FALSE, n_issues = 3L
+    ),
+    eri_approve = function(...) invisible(NULL),
+    eri_logs_resolve = function(log_path, note = NULL, forced = FALSE, data_con = NULL) {
+      resolved[[length(resolved) + 1L]] <<- list(log_path = log_path, note = note, forced = forced)
+      invisible(TRUE)
+    },
+    .eri_write_log = function(...) NULL,  # simulates a failed Azure write (never throws, per .eri_write_log's own contract)
+    .package = "erifunctions"
+  )
+
+  expect_no_error(suppressMessages(eri_approve_cmr(
+    "sdn", "202605", plan = plan, force = TRUE, justification = "Deadline override.",
+    data_con = structure(list(), class = "mock")
+  )))
+
+  expect_length(resolved, 1L)
+  expect_true(resolved[[1]]$forced)
+  expect_match(resolved[[1]]$note, "could not be written", fixed = TRUE)
+  expect_match(resolved[[1]]$note, "Deadline override.", fixed = TRUE)
+})
+
 test_that("eri_cmr_dq_report combines every measure's flags into one tibble with usable flag_ids", {
   plan <- tibble::tibble(
     sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),

--- a/tests/testthat/test-logs.R
+++ b/tests/testthat/test-logs.R
@@ -594,4 +594,31 @@ test_that("eri_logs_resolve adds a triage block and preserves the record", {
   expect_equal(captured$triage$note, "Re-ran after the source fixed the file.")
   expect_equal(captured$operation, "eri_approve")   # original record preserved
   expect_equal(captured$status, "error")
+  expect_false(captured$triage$forced)   # default: a genuine resolution, not a bypass
+})
+
+test_that("eri_logs_resolve(forced = TRUE) marks the triage block as a bypass, not a genuine resolution", {
+  path  <- paste0(scoped_dir, "/20260604_120000_eri_approve_2024-01.yaml")
+  entry <- make_op_log()
+  captured <- NULL
+
+  local_mocked_bindings(
+    storage_download = function(container, src, dest, ...) {
+      yaml::write_yaml(entry, dest); invisible(dest)
+    },
+    storage_upload = function(container, src, dest, ...) {
+      captured <<- yaml::read_yaml(src); invisible(dest)
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  res <- eri_logs_resolve(path, note = "Bypassed by a forced approval.", forced = TRUE)
+  expect_true(res)
+  expect_true(captured$triage$handled)  # still drops out of the open backlog
+  expect_true(captured$triage$forced)
+  expect_equal(captured$triage$note, "Bypassed by a forced approval.")
 })

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -359,6 +359,25 @@ verified clean for this approval (`dq_reviewed`) -- so the audit trail from "thi
 processed" back to "here's every flag that was raised, and what was decided about each one" is
 traceable via `eri_logs()`, not just a bare approval stamp.
 
+### The rare escape hatch: force-approving anyway
+
+Every so often something is outstanding for a reason that will never resolve cleanly -- a known
+template quirk confirmed with the country, say -- and the data genuinely needs to go through. Pass
+`force = TRUE` and a `justification` explaining why:
+
+```{r approve-forced, eval=FALSE}
+eri_approve_cmr("uga", "202406", force = TRUE,
+                justification = "Known template quirk in RB Treatment; confirmed with country lead.")
+#> x FORCE-APPROVING "uga" / "202406" despite 1 outstanding measure.
+#> ✔ Force-approved 2 measures for "uga" / "202406".
+```
+
+This does **not** silently resolve the bypassed flag -- it's annotated (`handled`, but marked
+`forced`) so the open backlog stays clean without pretending it was ever actually reviewed, and the
+approval's own log records the justification and exactly what it bypassed. Reach for `eri_logs_resolve()`
+first; force-approving is for when the flag itself will never close, not a shortcut around reviewing
+it.
+
 ```{r catalog}
 eri_catalog_query(country = "uga", data_source = "programmatic")
 #> # A tibble: 2 × 13

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -369,6 +369,12 @@ template quirk confirmed with the country, say -- and the data genuinely needs t
 eri_approve_cmr("uga", "202406", force = TRUE,
                 justification = "Known template quirk in RB Treatment; confirmed with country lead.")
 #> x FORCE-APPROVING "uga" / "202406" despite 1 outstanding measure.
+#> i Justification: Known template quirk in RB Treatment; confirmed with country lead.
+#> # A tibble: 1 × 4
+#>   disease data_type log_path                                     issue
+#>   <chr>   <chr>     <chr>                                        <chr>
+#> 1 oncho   treatment uga/oncho/programmatic/treatment/logs/x.yaml 1 unresolved DQ flag(s)
+#> ✔ Marked 'x.yaml' handled (bypassed by a forced approval).
 #> ✔ Force-approved 2 measures for "uga" / "202406".
 ```
 

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -223,6 +223,11 @@ field); `eri_audit()` is what cashes that in — leave `disease`/`data_source`/`
 a CMR workbook and the trail spans the split/approve coordinate *and* every fanned-out measure
 automatically, no CMR-specific audit function needed.
 
+A forced approval (`eri_approve_cmr(..., force = TRUE)`, for the rare case something outstanding
+must be promoted anyway — see the [CMR guide](da-cmr-guide.html#approve)) and the bypass annotation
+it leaves on the measure it overrode both render in red with a `[FORCED]` prefix here, rather than
+folding in as an ordinary approval — the one part of a trail that was *not* a genuine review.
+
 ## 6. Clean up {#clean-up}
 
 If you ran this in the sandbox, remove the `atlantis` namespace (this deletes its logs too):


### PR DESCRIPTION
## Summary

Phase 6 of the pilot-feedback-driven DQ workflow redesign: a rare, explicit escape hatch for
promoting data despite an outstanding measure, sequenced deliberately after Phase 5 (`eri_audit()`)
so the override is born fully auditable, never before.

- `eri_approve_cmr(..., force = FALSE, justification = NULL)`: `force = TRUE` requires a non-empty
  `justification` and approves despite outstanding measures. No interactive confirmation gate here --
  the scriptable core must keep working unattended in scripts/CI; that human friction is Phase 7's job.
- Bypassed measures are **annotated, never silently resolved**: `eri_logs_resolve()` gains a `forced`
  parameter, recorded in the triage block, so a bypass is distinguishable from a genuine review while
  still dropping out of the open backlog.
- The approval's own log records `forced`, `justification`, and exactly what it bypassed.
- `eri_audit()` renders a forced approval and its bypass annotations in red with a `[FORCED]` prefix,
  new `forced` column on every event row.
- Live-validated against a real `atlantis` forced approval end-to-end (split → flag → block →
  force-approve → audit), then cleaned up.

**Also fixes a real bug the live validation caught**: `eri_audit()`'s chronological sort used a
malformed date format string (`%H:%OSZ`, missing `%M`) that silently failed to parse *every*
timestamp, degrading the sort to a no-op (original file-read order). The unit test written for this
in PR #279 didn't catch it because its fixture happened to insert events in already-correct order --
rewrote it to insert out of order so it can actually distinguish a working sort from one that
silently does nothing.

## Test plan
- [x] `devtools::document()` clean
- [x] Full local test suite -- zero failures, only expected CRAN-skip/pre-existing warnings
- [x] New tests: `force = TRUE` validation, force-approve with an unresolved-flag bypass (annotation
  + trail fields), force-approve with a never-DQ-checked bypass (no annotation attempted),
  force = TRUE with nothing outstanding (no forced fields written), `eri_logs_resolve(forced =)`,
  `.eri_audit_events()`'s forced dispatch (both the `eri_approve_cmr` event and the
  `log_resolved (forced bypass)` event), `print.eri_audit_trail()`'s red rendering, and a
  properly-scrambled fractional-second ordering test (the one that caught the format-string bug)
- [x] Live end-to-end validation against the `atlantis` sandbox (see commit message), cleaned up
- [ ] CI green