### PR TITLE
docs(news): note the review-caught print-crash fix in 0.9.15

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,10 @@
   happened to insert events in already-correct order, masking the bug). Fixed the format string and
   rewrote the test to insert events out of order, so it can actually tell a working sort from one that
   silently does nothing.
+- Also fixes a print crash found in review: `print.eri_audit_trail()`'s red `[FORCED]` row built its
+  message as a plain string, then passed that finished string to `cli` as the glue *template* itself
+  rather than interpolating it as a variable -- a literal `{` in a DA-typed `justification` (exactly
+  the kind of free text this phase's design relies on) crashed the entire print, not just that row.
 
 # erifunctions 0.9.14
 


### PR DESCRIPTION
## Summary
Small changelog addition: PR #280 (force-approve) also fixed a real `print.eri_audit_trail()` crash
found in review (a literal brace in a DA's justification text crashed the entire print, not just
that row). Worth its own NEWS.md line since it's a genuine correctness fix, not just an
implementation detail of the feature it shipped alongside.

## Test plan
- [x] Verified NEWS.md heading sequence is still sequential (0.9.15, 0.9.14, 0.9.13, ...)
- [x] No code changes