### PR TITLE
docs(news): note the review-caught multi-measure re-run fix in 0.9.16

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,11 @@
   actually checks -- so marking every flag not-important/noted wouldn't by itself unblock approval.
   The wrapper now closes out each such entry via `eri_logs_resolve()` (auto-summarizing from the
   per-flag decisions) before offering to approve.
+- Also fixes a real bug found in review: "Re-run the DQ check" originally re-checked the **whole**
+  workbook, and `eri_cmr_dq_report()` always writes a brand-new "open" entry for every measure it's
+  given -- so re-checking after fixing just one measure silently discarded every *other* measure's
+  in-session not-important/noted decisions. Fixed by scoping the re-check to only the measure that
+  was actually resplit, merging just its fresh flags into the in-memory tibble.
 
 # erifunctions 0.9.15
 


### PR DESCRIPTION
## Summary
Small changelog addition: PR #282 (interactive DQ review wrapper) also fixed a real bug found in
review ("Re-run the DQ check" re-checked the whole workbook, silently discarding every other
measure's in-session triage decisions). Worth its own NEWS.md line, same treatment as the
print-crash fix noted for 0.9.15.

## Test plan
- [x] Verified NEWS.md heading sequence is still sequential (0.9.16, 0.9.15, 0.9.14, ...)
- [x] No code changes