### PR TITLE
docs(dq): add interactive DQ-review guide centered on eri_dq_review() (0.9.18)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.17
+Version: 0.9.18
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# erifunctions 0.9.18
+
+## New guide: interactively triaging and handing back DQ flags (`da-dq-review-guide`)
+
+- **New vignette `da-dq-review-guide.Rmd`**, a worked, run-it-live walkthrough of `eri_dq_review()`
+  end to end -- build a practice CMR workbook with two deliberate problems, split it, run the
+  review, work through both flags (one via "fix in source" + re-run, one via "mark noted" with an
+  explanation), print the handback file (`eri_dq_export()`), and approve. Practiced entirely against
+  the built-in `atlantis` training sandbox, so nothing touches a real country's data.
+- Framed around **`eri_dq_review()` as the single entry point**: the CMR and QC/feedback guides both
+  present the DQ pipeline as a sequence of functions a DA calls themselves (the scriptable core,
+  which still has to exist for automation); this guide leads with the interactive wrapper instead,
+  so a DA never has to remember that sequence or which function does which part of it.
+- Added to `_pkgdown.yml`'s "For data analysts" articles, `docs/guides.md`'s guide matrix, and
+  `README.md`'s guide table; cross-linked from both `da-cmr-guide.Rmd` and
+  `da-qc-feedback-guide.Rmd`.
+
 # erifunctions 0.9.17
 
 ## `eri_dq_export()`: a self-contained DQ handback file, and the QC/CMR guides converge on it (Phase 8, final phase of the DQ workflow redesign)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.17 · **Status:** Active development
+**Version:** 0.9.18 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -67,6 +67,7 @@ The full set:
 | [A complete research workflow for epidemiologists](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | Epidemiologists running a study end-to-end, from a fresh project to a citable, reproducible result |
 | [Ingesting a surveillance dataset (raw → approved)](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | Data analysts taking a dataset through the raw → staged → approved pipeline, with a human approval gate |
 | [Uploading a monthly country report (CMR)](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | Data analysts uploading, staging, parsing, and approving the monthly CMR Excel reports countries file |
+| [Triaging DQ flags interactively](https://thecartercenter.github.io/erifunctions/articles/da-dq-review-guide.html) | Data analysts working a CMR's DQ flags through one guided menu (`eri_dq_review()`) instead of the underlying functions, ending in a handback file (`eri_dq_export()`) |
 | [Working with ODK Central](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | Data analysts connecting to ODK Central to monitor a form, manage collectors, and pull submissions into the pipeline |
 | [Onboarding a new country / disease / data type](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | Data analysts standing up the schema + folders for a new program before any data flows |
 | [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -78,6 +78,7 @@ articles:
   - da-onboard-guide
   - da-ingest-guide
   - da-cmr-guide
+  - da-dq-review-guide
   - da-odk-guide
   - da-logs-guide
   - da-adhoc-guide

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -66,6 +66,7 @@ Grouped the same way as the [documentation site's Articles menu](https://thecart
 | Onboard a new country / disease / data type | [`da-onboard-guide`](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | ✅ Shipped |
 | Ingest → stage → approve a surveillance dataset | [`da-ingest-guide`](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | ✅ Shipped |
 | Upload, split & approve a monthly country report (CMR) | [`da-cmr-guide`](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | ✅ Shipped |
+| Triage and hand back DQ flags interactively (`eri_dq_review` + `eri_dq_export`) | [`da-dq-review-guide`](https://thecartercenter.github.io/erifunctions/articles/da-dq-review-guide.html) | ✅ Shipped |
 | Work with ODK Central (connect → monitor → manage → pull) | [`da-odk-guide`](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | ✅ Shipped |
 | Triage the error / DQ log backlog | [`da-logs-guide`](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | ✅ Shipped |
 | Answer ad-hoc data requests with SQL (`eri_query`) | [`da-adhoc-guide`](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | ✅ Shipped |

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -284,7 +284,7 @@ Leave it `FALSE` (the default) if you'd rather review the warning and remove the
 > It's built entirely on the functions below, so everything here still applies -- interactive-only
 > (it refuses to run in a script or CI, where these functions are what you use directly), and it
 > holds no state of its own: close it mid-review and running it again picks up exactly where the
-> logs say things are.
+> logs say things are. See the [DQ review guide](da-dq-review-guide.html) for a full worked session.
 
 CMR routing does **not** auto-run DQ checks -- CMR review is manual, on purpose.
 [`eri_cmr_dq_report()`](../reference/eri_cmr_dq_report.html) runs and logs DQ checks for every
@@ -345,7 +345,8 @@ Handing this back to a country or pasting it into a Teams thread? [`eri_dq_expor
 renders `flags` (with whatever `status`/`note` triage you've done above) to a self-contained
 HTML or markdown file, organised by sheet -- see the [QC/feedback guide](da-qc-feedback-guide.html)
 for the general pattern. [`eri_dq_review()`](../reference/eri_dq_review.html)'s "Print report" menu
-option calls this automatically.
+option calls this automatically -- see the [DQ review guide](da-dq-review-guide.html) for that whole
+session end to end.
 
 ```{r dq-export}
 eri_dq_export(flags, country = "uga", period = "202406")

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -71,11 +71,16 @@ there's nothing for a DQ check to catch. To have something to actually review, w
 introduce two realistic problems into a copy of it -- the same kind of thing a real submission might
 contain: an impossible value, and a locality the schema doesn't recognise yet.
 
+We also drop the `SCH Treatment` sheet: `atlantis` only ships a bundled DQ schema for
+`oncho/treatment`, and `eri_approve_cmr()` blocks on **any** routed measure that's never been
+DQ-checked (a schema-less measure never gets one) -- the same rule applies to a real, multi-sheet
+CMR, where every routed measure needs a schema before the whole workbook can be approved.
+
 ```{r build-workbook}
 library(openxlsx2)
 
 wb <- wb_load(system.file("extdata", "cmr-example.xlsx", package = "erifunctions"))
-wb$remove_worksheet("SCH Treatment")  # atlantis only ships a DQ schema for RB Treatment
+wb$remove_worksheet("SCH Treatment")
 wb <- wb_add_data(wb, sheet = "RB Treatment", x = -50,
                   start_col = 6, start_row = 6, col_names = FALSE)             # Kampala's treated count
 wb <- wb_add_data(wb, sheet = "RB Treatment", x = "Atlantis City",
@@ -130,12 +135,14 @@ between them are real, captured output.
          6  treated           -50 Value outside expected range [0, 10000000]
          8 district Atlantis City           Value not in allowed_values list
 
-2 open flag(s) across the workbook. What do you want to do?
+── 2 open flag(s) across the workbook. What do you want to do?
+
 1: Work through the open flags one at a time
 2: Re-run the DQ check
 3: Force-approve anyway
 4: Print report
 5: Exit
+
 ```
 
 Two open flags need two different responses, not the same one -- that's the whole reason to work
@@ -149,12 +156,14 @@ through them one at a time rather than bulk-resolving.
 ```
 ── Flag 1/2: RB Treatment row 6
 treated: "-50" -- Value outside expected range [0, 10000000]
-What do you want to do with this flag?
+── What do you want to do with this flag?
+
 1: Fix in source (open/copy the workbook)
 2: Adjust the schema (alias, allowed value, range...)
 3: Mark not important
 4: Mark noted
 5: Skip to the next flag
+
 Path to the local source workbook for this period (or a '_fixed' copy you've already started, if you have one): <you type the path here>
 ✔ Made a working copy: '202608_atlantis_demo_fixed.xlsx' (original preserved)
 ℹ Fix treated on Excel row 6 in the "RB Treatment" sheet.
@@ -187,9 +196,11 @@ Back at the main menu (still 2 open -- fixing the workbook doesn't retroactively
 flags), choose **"Re-run the DQ check"**:
 
 ```
-Re-split '202608_atlantis_demo_fixed.xlsx' and re-check just what it routes to?
+── Re-split '202608_atlantis_demo_fixed.xlsx' and re-check just what it routes to?
+
 1: Yes
 2: No -- cancel
+
 ```
 
 ```
@@ -231,11 +242,12 @@ with the flag from here on -- into the log, and into the handback file below.
 ```
 ── DQ review: atlantis / 202608 ────────────────────────────────────────────────
 ✔ 1 sheet checked -- all clean.
+── Nothing outstanding. What next?
 
-Nothing outstanding. What next?
 1: Approve
 2: Print report
 3: Exit
+
 ```
 
 "All clean" means every flag has been triaged, not that the data is now flawless -- one flag is just
@@ -257,12 +269,22 @@ Back at the same "Nothing outstanding" menu (print report loops back to it, it d
 **"Approve"**:
 
 ```
+✔ Catalog: registered '202608_atlantis_demo_fixed_rb_treatment.parquet'.
 ✔ Approved: '202608_atlantis_demo_fixed_rb_treatment.parquet'
+✔ Approval log: 'atlantis/oncho/programmatic/treatment/processed/202608_approval_log.yaml'
 ── ✔ Approved "202608" ─────────────────────────────────────────────────────────
 Dataset: atlantis / oncho / programmatic / treatment
 Files: 1 moved to processed
+Approver: NishantKishore (unverified)
+Location: atlantis/oncho/programmatic/treatment/processed
+ℹ Operation log: 'atlantis/oncho/programmatic/treatment/logs/20260712_014108_eri_approve_202608.yaml'
+ℹ Operation log: 'atlantis/rblf/cmr/logs/20260712_014108_eri_approve_cmr_202608.yaml'
 ✔ Approved 1 measure for "atlantis" / "202608".
 ```
+
+> `Approver` shows as "(unverified)" here because this sandbox session has no `ERI_ANALYST_ID` set --
+> on a normal analyst machine it carries your verified identity instead (see the
+> [onboarding guide](onboarding.html)).
 
 That's the whole session: two flags, two different resolutions, a handback file, one approval --
 without calling `eri_dq_flag_resolve()`, `eri_logs_resolve()`, or `eri_approve_cmr()` yourself even

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -1,0 +1,301 @@
+---
+title: "Triaging and handing back DQ flags, interactively (for data analysts)"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Triaging and handing back DQ flags, interactively (for data analysts)}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+The [CMR guide](da-cmr-guide.html) and the [QC/feedback guide](da-qc-feedback-guide.html) both walk
+the DQ pipeline as a **sequence of functions you call yourself**: check, resolve each flag, close out
+the entry, re-run, approve. That's the scriptable core, and it has to exist for automation. But you
+shouldn't have to remember that sequence, or which function does which part of it, just to triage a
+CMR workbook. **`eri_dq_review()`** is one function, one guided menu, that *is* the whole loop:
+
+```{=html}
+<div class="mermaid">
+flowchart TD
+    A["eri_dq_review(country, period)"] --> B{"Any open flags?"}
+    B -- "yes" --> C["Work through flags one at a time<br/>fix in source / adjust schema / mark not important / mark noted"]
+    C --> D["Re-run the DQ check"]
+    D --> B
+    B -- "no" --> E["Nothing outstanding"]
+    E --> F["Approve"]
+    E --> G["Print report -> eri_dq_export()"]
+    G --> E
+</div>
+```
+
+Everything under the hood is still `eri_cmr_dq_report()`, `eri_dq_flag_resolve()`,
+`eri_logs_resolve()`, `eri_split_cmr()`, `eri_approve_cmr()`, and `eri_dq_export()` -- but as a DA
+running this interactively, you never call any of them directly. You just answer the menu.
+
+> **The wrapper holds no state of its own.** Close your laptop mid-review and run `eri_dq_review()`
+> again later: it picks up exactly where the log YAMLs say things are, because every decision is
+> written through immediately, not batched. The one thing it doesn't remember between separate runs
+> is *which local file you were fixing* -- point it back at your working copy (or the original; see
+> [below](#fix-in-source)) if you come back to re-run a check.
+
+## Before you start {#before-you-start}
+
+- `remotes::install_github("thecartercenter/erifunctions")`.
+- **Azure access** to the `data` blob (zero-config browser sign-in, see the
+  [connections guide](connections-guide.html)).
+- `openxlsx2` (already a package dependency) to build the practice workbook below.
+- A CMR workbook already staged and split -- see the [CMR guide](da-cmr-guide.html) sections 1-4 for
+  a real country. Below, we practice on the built-in **`atlantis`** training sandbox instead, so
+  nothing here touches a real program's data.
+
+```{r library}
+library(erifunctions)
+```
+
+> **What's `atlantis`?** A fictional country the package ships a CMR routing schema and a DQ schema
+> for (`load_cmr_schema("atlantis")`, `load_dq_schema("atlantis", "oncho", "programmatic",
+> "treatment")`), purely so this exact loop -- split, flag, triage, approve -- can be practiced
+> against the real `data` Azure blob without ever touching a real country's namespace.
+
+## 1. Build a practice submission with two real problems {#build}
+
+The bundled `cmr-example.xlsx` (used throughout the [CMR guide](da-cmr-guide.html)) is clean data, so
+there's nothing for a DQ check to catch. To have something to actually review, we deliberately
+introduce two realistic problems into a copy of it -- the same kind of thing a real submission might
+contain: an impossible value, and a locality the schema doesn't recognise yet.
+
+```{r build-workbook}
+library(openxlsx2)
+
+wb <- wb_load(system.file("extdata", "cmr-example.xlsx", package = "erifunctions"))
+wb$remove_worksheet("SCH Treatment")  # atlantis only ships a DQ schema for RB Treatment
+wb <- wb_add_data(wb, sheet = "RB Treatment", x = -50,
+                  start_col = 6, start_row = 6, col_names = FALSE)             # Kampala's treated count
+wb <- wb_add_data(wb, sheet = "RB Treatment", x = "Atlantis City",
+                  start_col = 4, start_row = 8, col_names = FALSE)             # Soroti's district cell
+path <- file.path(tempdir(), "202608_atlantis_demo.xlsx")
+wb_save(wb, path, overwrite = TRUE)
+```
+
+## 2. Get a workbook with something to review {#split}
+
+`eri_split_cmr()` routes the workbook to `atlantis`'s `oncho/programmatic/treatment` measure;
+`eri_cmr_dq_report()` checks it against that measure's schema and combines every flag into one
+tibble -- both covered in depth in the [CMR guide](da-cmr-guide.html#dq-check).
+
+```{r split-and-check}
+plan  <- eri_split_cmr(path, "atlantis", period = "202608")
+flags <- eri_cmr_dq_report("atlantis", "202608", plan = plan)
+#> ✔ DQ checks complete: 0 corrections, 2 flags for review.
+#> ✔ Logged 2 DQ flags (needs_review).
+flags[, c("excel_row", "column", "value", "issue", "status")]
+#> # A tibble: 2 × 5
+#>   excel_row column   value         issue                                  status
+#>       <int> <chr>    <chr>         <chr>                                  <chr>
+#> 1         6 treated  -50           Value outside expected range [0, 1000… open
+#> 2         8 district Atlantis City Value not in allowed_values list       open
+```
+
+Two flags, one measure. Now forget that tibble exists -- from here on, one function.
+
+## 3. Run the review {#review}
+
+```{r review, eval=FALSE}
+eri_dq_review("atlantis", "202608")
+```
+
+`eri_dq_review()` is **interactive only** -- it refuses to run in a script or from `Rscript`, with a
+pointer back to the scriptable core (`eri_cmr_dq_report()`, `eri_dq_flag_resolve()`,
+`eri_logs_resolve()`, `eri_approve_cmr()`) for CI/automation. Run it from a live R console or RStudio
+session. Below is a real session against the workbook built above, one menu choice at a time -- the
+menu prompts themselves come straight from the function; the informational and success messages
+between them are real, captured output.
+
+### It opens on the flags {#opens}
+
+```
+── DQ review: atlantis / 202608 ────────────────────────────────────────────────
+✖ 1 of 1 sheet have open flags (2 flags total)
+
+── RB Treatment (oncho/treatment) -- 2 open ──
+
+ excel_row   column         value                                      issue
+         6  treated           -50 Value outside expected range [0, 10000000]
+         8 district Atlantis City           Value not in allowed_values list
+
+2 open flag(s) across the workbook. What do you want to do?
+1: Work through the open flags one at a time
+2: Re-run the DQ check
+3: Force-approve anyway
+4: Print report
+5: Exit
+```
+
+Two open flags need two different responses, not the same one -- that's the whole reason to work
+through them one at a time rather than bulk-resolving.
+
+### Flag 1: a real error -> fix in source {#fix-in-source}
+
+`treated = -50` is impossible -- a genuine data-entry mistake, not a judgement call. Choosing
+**"Work through the open flags"**, then **"Fix in source"** for this flag:
+
+```
+── Flag 1/2: RB Treatment row 6
+treated: "-50" -- Value outside expected range [0, 10000000]
+What do you want to do with this flag?
+1: Fix in source (open/copy the workbook)
+2: Adjust the schema (alias, allowed value, range...)
+3: Mark not important
+4: Mark noted
+5: Skip to the next flag
+Path to the local source workbook for this period (or a '_fixed' copy you've already started, if you have one): <you type the path here>
+✔ Made a working copy: '202608_atlantis_demo_fixed.xlsx' (original preserved)
+ℹ Fix treated on Excel row 6 in the "RB Treatment" sheet.
+ℹ Issue: Value outside expected range [0, 10000000]
+ℹ When you're done with this and any other fixes, choose "Re-run the DQ check" from the main menu -- it re-splits '202608_atlantis_demo_fixed.xlsx' and re-checks.
+```
+
+The first time you fix anything in a session, `eri_dq_review()` forks a `_fixed` working copy before
+touching it -- the file as submitted is never edited in place. Open that copy, correct the value,
+save it. (Picking this back up in a fresh R session? Point it at that same `_fixed` file, or the
+original again -- it detects the `_fixed` sibling and reuses it rather than forking a second one.)
+
+> In RStudio, the working copy opens directly in the editor instead of printing an "open this file"
+> message -- `eri_dq_review()` uses `rstudioapi` when it's available.
+
+### Flag 2: not wrong, just not catalogued yet -> defer it {#defer}
+
+`"Atlantis City"` isn't a typo -- it's a real locality the schema's `allowed_values` list hasn't
+caught up to yet. There's nothing to *fix*. Choose **"Skip to the next flag"** for now (we'll come
+back to it once the actual error above is out of the way):
+
+```
+── Flag 2/2: RB Treatment row 8
+district: "Atlantis City" -- Value not in allowed_values list
+```
+
+### Re-run: only what changed gets re-checked {#rerun}
+
+Back at the main menu (still 2 open -- fixing the workbook doesn't retroactively change the logged
+flags), choose **"Re-run the DQ check"**:
+
+```
+Re-split '202608_atlantis_demo_fixed.xlsx' and re-check just what it routes to?
+1: Yes
+2: No -- cancel
+```
+
+```
+ℹ Superseded a prior staged file for this period: '202608_atlantis_demo_rb_treatment.parquet'
+✔ "RB Treatment" -> 'atlantis/oncho/programmatic/treatment/staged/202608_atlantis_demo_fixed_rb_treatment.parquet'
+✔ DQ checks complete: 0 corrections, 1 flag for review.
+
+── DQ review: atlantis / 202608 ────────────────────────────────────────────────
+✖ 1 of 1 sheet have open flags (1 flag total)
+
+ excel_row   column         value                            issue
+         8 district Atlantis City Value not in allowed_values list
+```
+
+The `treated` flag is gone -- the underlying value is fixed, so it never comes back. The
+`"Atlantis City"` flag reappears exactly as it was, because it's genuinely still there. If your
+workbook routes several measures, only the ones you actually re-split get re-checked; every other
+measure's in-session decisions are left alone (see the [CMR guide](da-cmr-guide.html#dq-check) for a
+worked multi-measure example).
+
+### Flag 2, revisited: mark it noted {#mark-noted}
+
+One flag left. **"Work through the open flags"** again, then **"Mark noted"** this time, with an
+explanation:
+
+```
+── Flag 1/1: RB Treatment row 8
+district: "Atlantis City" -- Value not in allowed_values list
+Note (optional): <you type your explanation here>
+✔ Flag 1 in '...dq_flags_202608.yaml' marked "noted".
+```
+
+We typed: *"Confirmed with the country lead: Atlantis City is a real, if not-yet-catalogued,
+locality -- flagging for the schema maintainer to add it to the allowed list."* That note travels
+with the flag from here on -- into the log, and into the handback file below.
+
+### Nothing outstanding -> print the report {#print-report}
+
+```
+── DQ review: atlantis / 202608 ────────────────────────────────────────────────
+✔ 1 sheet checked -- all clean.
+
+Nothing outstanding. What next?
+1: Approve
+2: Print report
+3: Exit
+```
+
+"All clean" means every flag has been triaged, not that the data is now flawless -- one flag is just
+`noted` rather than `open`. Choose **"Print report"**:
+
+```
+✔ DQ report (1 flag · 0 open) written to '.../dq-report-atlantis-202608-2026-07-12.html'.
+```
+
+`eri_dq_review()` calls [`eri_dq_export()`](../reference/eri_dq_export.html) for you here -- see the
+[QC/feedback guide](da-qc-feedback-guide.html#export) for what that function does on its own. Open
+the file: a self-contained page, organised by sheet, with the `noted` status shown as a chip and the
+note text in its own column -- exactly what you'd forward to the country or paste into Teams, with
+zero reformatting.
+
+### Approve {#approve}
+
+Back at the same "Nothing outstanding" menu (print report loops back to it, it doesn't exit), choose
+**"Approve"**:
+
+```
+✔ Approved: '202608_atlantis_demo_fixed_rb_treatment.parquet'
+── ✔ Approved "202608" ─────────────────────────────────────────────────────────
+Dataset: atlantis / oncho / programmatic / treatment
+Files: 1 moved to processed
+✔ Approved 1 measure for "atlantis" / "202608".
+```
+
+That's the whole session: two flags, two different resolutions, a handback file, one approval --
+without calling `eri_dq_flag_resolve()`, `eri_logs_resolve()`, or `eri_approve_cmr()` yourself even
+once.
+
+## Cleaning up {#cleanup}
+
+Everything above lives under `atlantis`'s own namespace, so it's safe to leave -- but if you were
+following along and want to tidy up the sandbox behind you:
+
+```{r cleanup}
+con <- get_azure_storage_connection(storage_name = Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", "data"))
+eri_catalog_remove(
+  "atlantis/oncho/programmatic/treatment/processed/202608_atlantis_demo_fixed_rb_treatment.parquet",
+  data_con = con
+)
+all_files <- AzureStor::list_storage_files(con, "atlantis", recursive = TRUE)
+mine      <- all_files$name[!all_files$isdir & grepl("202608", all_files$name)]
+for (f in mine) AzureStor::delete_storage_file(con, f, confirm = FALSE)
+unlink(path)
+```
+
+Real submissions are not disposable like this practice run -- never delete a real country's staged,
+processed, or log files this way.
+
+## What's next
+
+- [`eri_dq_export()`](../reference/eri_dq_export.html) on its own, and its markdown output, in the
+  [QC/feedback guide](da-qc-feedback-guide.html#export).
+- The scriptable core this orchestrates, and a worked multi-measure example, in the
+  [CMR guide](da-cmr-guide.html#dq-check).
+- Scanning the *logged* state of the whole team's backlog (not just one session's tibble) with
+  `eri_logs()`, the [log-triage guide](da-logs-guide.html).
+- Submitting a schema fix for a maintainer to fold in permanently (rather than a one-off note) via
+  `eri_dq_schema_submit()` -- offered automatically at the end of a session if you used "Adjust the
+  schema" on any flag.

--- a/vignettes/da-qc-feedback-guide.Rmd
+++ b/vignettes/da-qc-feedback-guide.Rmd
@@ -150,6 +150,7 @@ token (the Graph-API path), see the [connections guide](connections-guide.html#t
   [log-triage guide](da-logs-guide.html).
 - For a CMR workbook specifically, `eri_dq_export()` also renders the richer, per-sheet flags
   tibble from [`eri_cmr_dq_report()`](../reference/eri_cmr_dq_report.html) -- see the
-  [CMR guide](da-cmr-guide.html) and [`eri_dq_review()`](../reference/eri_dq_review.html) for the
-  interactive triage wrapper that calls it automatically.
+  [CMR guide](da-cmr-guide.html) and the [DQ review guide](da-dq-review-guide.html) for
+  [`eri_dq_review()`](../reference/eri_dq_review.html), the interactive triage wrapper that calls it
+  automatically.
 ```


### PR DESCRIPTION
## Summary

Follow-up to the just-shipped 8-phase DQ workflow redesign (v0.9.11-0.9.17): a dedicated guide for `eri_dq_review()` + `eri_dq_export()` as the primary interface, so a DA relies on one guided menu instead of remembering the underlying function library.

- New `vignettes/da-dq-review-guide.Rmd`: builds a practice CMR workbook with two deliberate DQ problems, splits it, runs a full `eri_dq_review()` session (fix in source + re-run for a genuine data-entry error, mark noted with an explanation for a not-yet-catalogued locality), prints the `eri_dq_export()` handback file, and approves -- all against the built-in `atlantis` training sandbox, never touching real country data.
- All console output in the guide is either real, captured output from a live semi-scripted run against the sandbox, or verified directly against `R/dq_review.R`'s source where the interactive prompt itself can't be captured outside a real terminal (`utils::menu()` refuses to run non-interactively).
- Wired into `_pkgdown.yml`'s "For data analysts" articles, `docs/guides.md`'s matrix, and `README.md`'s guide table; cross-linked from `da-cmr-guide.Rmd` (two places) and `da-qc-feedback-guide.Rmd`.
- Version bump only, no code changes -- `R/` is untouched.

## Test plan
- [x] `knitr::knit()` dry-run on all three touched vignettes (chunks parse/run)
- [x] Full local test suite -- 0 failures (unaffected, docs-only change)
- [x] Live semi-scripted `eri_dq_review()` session run twice against the real `atlantis` Azure sandbox to verify every displayed message and filename; all artifacts (staged files, DQ/split/approve logs, processed file, catalog entry) cleaned up afterward, confirmed zero remaining
- [ ] CI (R-CMD-check, pkgdown)