### PR TITLE
fix(dq): flextable console leak, jammed cli bullets, guide accuracy (0.9.19)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.18
+Version: 0.9.19
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,33 @@
+# erifunctions 0.9.19
+
+## Fixes found by a fresh-user test of the new DQ-review guide
+
+- **Fixed a real bug in `eri_dq_review()`'s "Print report" menu item**: it printed an `eri_table()`
+  flextable to the console, which -- outside RStudio's Viewer (a plain console, VS Code terminal,
+  SSH session) -- has nowhere to render and dumps `print.flextable()`'s raw diagnostic summary
+  instead (`a flextable object. col_keys: ... original dataset sample: ...`) rather than the flags.
+  Now prints a plain table, matching the console-native convention `.eri_dq_review_report()` (the
+  main loop's own display) already followed for exactly this reason.
+- **Fixed a formatting bug**: `.eri_dq_review_fix_in_source()`'s "fix this value" instructions used
+  `cli_alert_info()` with a two-element bullet vector; `cli_alert_info()` only ever renders a single
+  bullet, so the two lines were glued together with no space (`"...sheet.Issue: ..."`). Switched to
+  `cli_bullets()`, which renders each element as its own line. The same anti-pattern (`cli_alert_info()`/
+  `cli_alert_danger()`/`cli_alert_warning()` called with a multi-element vector) was found and fixed
+  in six more places across `R/dq.R` (the schema-override lifecycle messages) and `R/cmr.R` (the
+  force-approve and outstanding-measures messages) -- all now use `cli_bullets()`.
+- **Tightened `da-dq-review-guide.Rmd`'s transcript accuracy**: added a disclosure that real console
+  output is noisier than the trimmed transcripts shown (schema-fallback warnings, rename messages),
+  an explanation for the expected `atlantis`-only "Could not load schema from Azure" warning, the
+  previously-missing "Open this file to review/edit" line, a missing per-sheet subheader in the
+  re-run listing, and a corrected "holds no state of its own" claim (it re-derives from a real,
+  logged DQ check on every open, it doesn't read stale cached state). The cleanup section now also
+  removes the `_fixed` workbook copy and the exported HTML report, which `eri_dq_export()` writes to
+  the working directory by default and previously went uncleaned.
+- Found via a fresh-user (`da-fresh-user` agent) run of the whole guide live against the real
+  `atlantis` sandbox -- caught two real bugs and several accuracy gaps that a hand-review alone had
+  missed; nothing else in the guide needed correction (every menu prompt, choice order, and the full
+  Approve transcript matched exactly).
+
 # erifunctions 0.9.18
 
 ## New guide: interactively triaging and handing back DQ flags (`da-dq-review-guide`)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,8 @@
   bullet, so the two lines were glued together with no space (`"...sheet.Issue: ..."`). Switched to
   `cli_bullets()`, which renders each element as its own line. The same anti-pattern (`cli_alert_info()`/
   `cli_alert_danger()`/`cli_alert_warning()` called with a multi-element vector) was found and fixed
-  in six more places across `R/dq.R` (the schema-override lifecycle messages) and `R/cmr.R` (the
-  force-approve and outstanding-measures messages) -- all now use `cli_bullets()`.
+  in ten more places across `R/dq.R` (the schema-override lifecycle messages) and `R/cmr.R` (the
+  force-approve, outstanding-measures, and audit-trail-missing messages) -- all now use `cli_bullets()`.
 - **Tightened `da-dq-review-guide.Rmd`'s transcript accuracy**: added a disclosure that real console
   output is noisier than the trimmed transcripts shown (schema-fallback warnings, rename messages),
   an explanation for the expected `atlantis`-only "Could not load schema from Azure" warning, the

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -816,8 +816,8 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
   outstanding_tbl <- if (length(outstanding) > 0L) dplyr::bind_rows(outstanding) else NULL
 
   if (!is.null(outstanding_tbl) && !isTRUE(force)) {
-    cli::cli_alert_danger(c(
-      "{nrow(outstanding_tbl)} measure{?s} still need{?s/} attention -- approving nothing.",
+    cli::cli_bullets(c(
+      "x" = "{nrow(outstanding_tbl)} measure{?s} still need{?s/} attention -- approving nothing.",
       "i" = "Review each below, close it out with {.fn eri_logs_resolve} (pass a {.arg note}), then re-run this.",
       "i" = "Or pass {.code force = TRUE} and a {.arg justification} to approve anyway."
     ))
@@ -826,7 +826,7 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
   }
 
   if (!is.null(outstanding_tbl)) {
-    cli::cli_alert_danger(c(
+    cli::cli_bullets(c(
       "!" = "FORCE-APPROVING {.val {country}} / {.val {period}} despite {nrow(outstanding_tbl)} outstanding measure{?s}.",
       "i" = "Justification: {justification}"
     ))
@@ -905,8 +905,8 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
     }
   )
   if (is.null(trail_path)) {
-    cli::cli_alert_danger(c(
-      "The measures above ARE approved, but the {.val dq_reviewed} audit-trail record could not be written",
+    cli::cli_bullets(c(
+      "x" = "The measures above ARE approved, but the {.val dq_reviewed} audit-trail record could not be written",
       "i" = "(see the Azure write warning above). The per-measure {.fn eri_approve} logs still exist; only this combined cross-reference is missing."
     ))
   }

--- a/R/dq.R
+++ b/R/dq.R
@@ -1113,7 +1113,7 @@ add_anomaly_spatial <- function(data, schema, azcontainer = NULL) {
     ov <- .eri_dq_schema_override_state(stem, azcontainer)
 
     if (ov$state == "active") {
-      cli::cli_alert_info(c(
+      cli::cli_bullets(c(
         "i" = "Using your local schema override for {.val {stem}} (created {ov$meta$forked_at}).",
         " " = "Reset with {.fn eri_dq_schema_reset}."
       ))
@@ -1122,7 +1122,7 @@ add_anomaly_spatial <- function(data, schema, azcontainer = NULL) {
     }
 
     if (ov$state == "unknown") {
-      cli::cli_alert_warning(c(
+      cli::cli_bullets(c(
         "!" = "Could not verify your local schema override for {.val {stem}} against upstream (Azure unreachable and no bundled copy found) -- using it as-is.",
         "i" = "Its freshness relative to the canonical schema could not be confirmed this time."
       ))
@@ -1132,16 +1132,16 @@ add_anomaly_spatial <- function(data, schema, azcontainer = NULL) {
 
     if (ov$state == "stale") {
       if (.eri_dq_schema_retire(stem, ov$paths)) {
-        cli::cli_alert_warning(c(
-          "Your local schema override for {.val {stem}} (forked {ov$meta$forked_at}) is stale -- the upstream schema changed since you forked it.",
+        cli::cli_bullets(c(
+          "!" = "Your local schema override for {.val {stem}} (forked {ov$meta$forked_at}) is stale -- the upstream schema changed since you forked it.",
           "i" = "Retired; using the current upstream instead.",
           "i" = "If issues re-flag that you thought you'd fixed, your changes weren't folded into the update -- re-review, or re-fork with {.fn eri_dq_schema_edit}."
         ))
         return(list(path = ov$upstream$path, source = ov$upstream$source,
                     hash = unname(tools::md5sum(ov$upstream$path))))
       }
-      cli::cli_alert_danger(c(
-        "Could not fully retire the stale local override for {.val {stem}} -- using it as-is.",
+      cli::cli_bullets(c(
+        "x" = "Could not fully retire the stale local override for {.val {stem}} -- using it as-is.",
         "i" = "Check {.path {.eri_schema_override_dir()}} manually, or run {.fn eri_dq_schema_reset}."
       ))
       return(list(path = ov$paths$yaml, source = "local_override",
@@ -1296,9 +1296,9 @@ eri_dq_schema_edit <- function(country, disease, data_source = NULL, data_type =
   ov   <- .eri_dq_schema_override_state(stem, azcontainer)
 
   if (ov$state %in% c("active", "unknown")) {
-    cli::cli_alert_info(c(
-      "You already have a local override for {.val {stem}} (forked {ov$meta$forked_at}).",
-      "i" = if (ov$state == "unknown") {
+    cli::cli_bullets(c(
+      "i" = "You already have a local override for {.val {stem}} (forked {ov$meta$forked_at}).",
+      " " = if (ov$state == "unknown") {
         "Could not verify it against upstream right now (unreachable) -- returning it as-is."
       } else {
         "Returning it as-is. Start over with {.fn eri_dq_schema_reset}."
@@ -1309,8 +1309,8 @@ eri_dq_schema_edit <- function(country, disease, data_source = NULL, data_type =
 
   if (ov$state == "stale") {
     if (!.eri_dq_schema_retire(stem, ov$paths)) {
-      cli::cli_alert_danger(c(
-        "Could not fully retire the stale local override for {.val {stem}} -- leaving it in place.",
+      cli::cli_bullets(c(
+        "x" = "Could not fully retire the stale local override for {.val {stem}} -- leaving it in place.",
         "i" = "Resolve manually in {.path {.eri_schema_override_dir()}}, or run {.fn eri_dq_schema_reset} then try again."
       ))
       return(invisible(ov$paths$yaml))
@@ -1333,7 +1333,7 @@ eri_dq_schema_edit <- function(country, disease, data_source = NULL, data_type =
   )
   yaml::write_yaml(meta, ov$paths$meta)
   cli::cli_alert_success("Forked {.val {stem}} into a local override: {.path {ov$paths$yaml}}")
-  cli::cli_alert_info(c(
+  cli::cli_bullets(c(
     "i" = "This is now your active schema for {.val {stem}} until you {.fn eri_dq_schema_reset} it.",
     " " = "If the upstream schema changes, it is retired automatically -- never silently overridden or discarded."
   ))

--- a/R/dq_review.R
+++ b/R/dq_review.R
@@ -79,9 +79,11 @@
   invisible(NULL)
 }
 
-# "Print report" menu item: one branded eri_table() per sheet on the console for a quick
-# eyeball, then eri_dq_export() writes the self-contained HTML handback file (with any in-session
-# status/note triage already folded in via .eri_dq_review_apply_local_resolutions()).
+# "Print report" menu item: one plain-tibble table per sheet on the console for a quick eyeball --
+# not eri_table()'s flextable (that renders to the Viewer pane, nothing over SSH/a plain console;
+# same reasoning .eri_dq_review_report() above already follows) -- then eri_dq_export() writes the
+# self-contained HTML handback file (with any in-session status/note triage already folded in via
+# .eri_dq_review_apply_local_resolutions()).
 #' @keywords internal
 .eri_dq_review_print_report <- function(flags, country, period) {
   if (nrow(flags) == 0L) {
@@ -92,7 +94,7 @@
     cols <- intersect(c("excel_row", "column", "value", "issue", "status", "note"), names(flags))
     sub  <- flags[flags$sheet == sh, cols, drop = FALSE]
     cli::cli_h3(sh)
-    print(eri_table(sub, title = sh))
+    print(as.data.frame(sub), row.names = FALSE)
   }
   # Best-effort: a write failure (read-only cwd, locked file...) shouldn't eject the DA from an
   # otherwise-safe interactive session -- nothing here is lost, it's all already in the logs.
@@ -139,7 +141,10 @@
     }
     local_path_env$path <- p
   }
-  cli::cli_alert_info(c(
+  # cli_bullets(), not cli_alert_info() -- cli_alert_info() only ever renders a single bullet;
+  # handed a 2-element vector it glues both elements onto one line with no line break between
+  # them instead of two separate "i" bullets.
+  cli::cli_bullets(c(
     "i" = "Fix {.field {f$column}} on Excel row {.val {f$excel_row}} in the {.val {f$sheet}} sheet.",
     "i" = "Issue: {f$issue}"
   ))

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.18 · **Status:** Active development
+**Version:** 0.9.19 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -574,6 +574,32 @@ test_that("load_dq_schema prefers a live local override over the bundled schema"
   expect_equal(schema$columns$target_pop$range[[2]], 99999999)
 })
 
+test_that("load_dq_schema's active-override notice prints as two separate bullets, not jammed", {
+  override_dir <- withr::local_tempdir()
+  local_mocked_bindings(
+    .eri_schema_override_dir = function() override_dir,
+    .package = "erifunctions"
+  )
+  suppressWarnings(
+    eri_dq_schema_edit("atlantis", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  )
+
+  lines <- capture.output(
+    suppressWarnings(
+      load_dq_schema("atlantis", "oncho", "programmatic", "treatment", azcontainer = NULL)
+    ),
+    type = "message"
+  )
+
+  using_line <- grep("Using your local schema override", lines, value = TRUE)
+  reset_line <- grep("Reset with", lines, value = TRUE)
+  expect_length(using_line, 1L)
+  expect_length(reset_line, 1L)
+  # regression guard: a prior bug (cli_alert_info() instead of cli_bullets() on a
+  # multi-element vector) glued both onto one line with no space between them
+  expect_false(any(grepl("created.*Reset with", lines)))
+})
+
 test_that("eri_dq_schema_path returns the override path when one is live", {
   override_dir <- withr::local_tempdir()
   local_mocked_bindings(

--- a/tests/testthat/test-dq_review.R
+++ b/tests/testthat/test-dq_review.R
@@ -313,6 +313,49 @@ test_that(".eri_dq_review_fix_in_source forks even when the ORIGINAL filename co
   expect_equal(opened, local_path_env$path)
 })
 
+test_that(".eri_dq_review_fix_in_source prints the fix instructions as two separate bullets, not jammed onto one line", {
+  tmp_dir  <- withr::local_tempdir()
+  original <- file.path(tmp_dir, "workbook.xlsx")
+  writeLines("x", original)
+  local_path_env <- new.env(parent = emptyenv())
+  local_path_env$path <- NULL
+  local_mocked_bindings(
+    .eri_prompt_line = function(...) original,
+    .eri_open_file    = function(path, ...) invisible(path),
+    .package = "erifunctions"
+  )
+
+  f <- list(column = "district", excel_row = 8L, sheet = "RB Treatment", issue = "not an allowed value")
+  lines <- capture.output(.eri_dq_review_fix_in_source(f, local_path_env), type = "message")
+
+  fix_line   <- grep("Fix district on Excel row 8", lines, value = TRUE)
+  issue_line <- grep("Issue: not an allowed value$", lines, value = TRUE)
+  expect_length(fix_line, 1L)
+  expect_length(issue_line, 1L)
+  # regression guard: a prior bug (cli_alert_info() instead of cli_bullets() on a
+  # multi-element vector) glued both onto one line with no space between them
+  expect_false(any(grepl("sheet\\.Issue:", lines)))
+})
+
+test_that(".eri_dq_review_print_report() prints a plain table, not a flextable's console diagnostic dump", {
+  flags <- tibble::tibble(
+    sheet = "RB Treatment", excel_row = 8L, column = "district", value = "Atlantis City",
+    issue = "not an allowed value", status = "noted", note = "confirmed with the country lead"
+  )
+  local_mocked_bindings(
+    eri_dq_export = function(...) invisible("x"),
+    .package = "erifunctions"
+  )
+
+  lines <- capture.output(.eri_dq_review_print_report(flags, "atlantis", "202608"))
+
+  # regression guard: a prior bug (print(eri_table(...)), a flextable) dumped
+  # print.flextable()'s diagnostic summary outside a Viewer-capable session
+  expect_false(any(grepl("a flextable object", lines)))
+  expect_false(any(grepl("col_keys:", lines)))
+  expect_true(any(grepl("Atlantis City", lines)))
+})
+
 test_that(".eri_dq_review_apply_local_resolutions writes both status and note into the flags tibble", {
   flags <- tibble::tibble(
     flag_id = c("a::1", "a::2"), status = c("open", "open"),

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -39,11 +39,13 @@ Everything under the hood is still `eri_cmr_dq_report()`, `eri_dq_flag_resolve()
 `eri_logs_resolve()`, `eri_split_cmr()`, `eri_approve_cmr()`, and `eri_dq_export()` -- but as a DA
 running this interactively, you never call any of them directly. You just answer the menu.
 
-> **The wrapper holds no state of its own.** Close your laptop mid-review and run `eri_dq_review()`
-> again later: it picks up exactly where the log YAMLs say things are, because every decision is
-> written through immediately, not batched. The one thing it doesn't remember between separate runs
-> is *which local file you were fixing* -- point it back at your working copy (or the original; see
-> [below](#fix-in-source)) if you come back to re-run a check.
+> **The wrapper holds no state of its own.** Every open re-derives current flags fresh from a real,
+> logged DQ check against whatever's actually staged -- it never trusts a possibly-stale in-memory
+> or cached view. Every triage decision is written through immediately too, not batched. So closing
+> your laptop mid-review and running `eri_dq_review()` again later is always safe: it re-checks from
+> the real staged data and picks up your prior decisions from the logs. The one thing it doesn't
+> remember between separate runs is *which local file you were fixing* -- point it back at your
+> working copy (or the original; see [below](#fix-in-source)) if you come back to re-run a check.
 
 ## Before you start {#before-you-start}
 
@@ -123,6 +125,12 @@ session. Below is a real session against the workbook built above, one menu choi
 menu prompts themselves come straight from the function; the informational and success messages
 between them are real, captured output.
 
+> **Your console will be busier than the transcripts below.** Each DQ check also prints its own
+> "renamed column" and "corrections/flags" lines, and you'll likely see
+> `! Could not load schema from Azure (Not Found...). Falling back to local.` -- expected here,
+> since `atlantis`'s DQ schema only ships inside the package and is never uploaded to Azure. Nothing
+> below is broken; the transcripts are trimmed to what changes each step, not a full console dump.
+
 ### It opens on the flags {#opens}
 
 ```
@@ -168,6 +176,7 @@ Path to the local source workbook for this period (or a '_fixed' copy you've alr
 ✔ Made a working copy: '202608_atlantis_demo_fixed.xlsx' (original preserved)
 ℹ Fix treated on Excel row 6 in the "RB Treatment" sheet.
 ℹ Issue: Value outside expected range [0, 10000000]
+ℹ Open this file to review/edit: '.../202608_atlantis_demo_fixed.xlsx'
 ℹ When you're done with this and any other fixes, choose "Re-run the DQ check" from the main menu -- it re-splits '202608_atlantis_demo_fixed.xlsx' and re-checks.
 ```
 
@@ -210,6 +219,8 @@ flags), choose **"Re-run the DQ check"**:
 
 ── DQ review: atlantis / 202608 ────────────────────────────────────────────────
 ✖ 1 of 1 sheet have open flags (1 flag total)
+
+── RB Treatment (oncho/treatment) -- 1 open ──
 
  excel_row   column         value                            issue
          8 district Atlantis City Value not in allowed_values list
@@ -254,10 +265,17 @@ with the flag from here on -- into the log, and into the handback file below.
 `noted` rather than `open`. Choose **"Print report"**:
 
 ```
+── RB Treatment
+ excel_row   column         value                            issue status
+         8 district Atlantis City Value not in allowed_values list  noted
+                                                                    note
+ Confirmed with the country lead: Atlantis City is a real, if not-yet-...
+
 ✔ DQ report (1 flag · 0 open) written to '.../dq-report-atlantis-202608-2026-07-12.html'.
 ```
 
-`eri_dq_review()` calls [`eri_dq_export()`](../reference/eri_dq_export.html) for you here -- see the
+A quick console eyeball first (the `note` column wraps if it's long, as it does here), then the
+handback file. `eri_dq_review()` calls [`eri_dq_export()`](../reference/eri_dq_export.html) for you here -- see the
 [QC/feedback guide](da-qc-feedback-guide.html#export) for what that function does on its own. Open
 the file: a self-contained page, organised by sheet, with the `noted` status shown as a chip and the
 note text in its own column -- exactly what you'd forward to the country or paste into Teams, with
@@ -293,7 +311,11 @@ once.
 ## Cleaning up {#cleanup}
 
 Everything above lives under `atlantis`'s own namespace, so it's safe to leave -- but if you were
-following along and want to tidy up the sandbox behind you:
+following along and want to tidy up the sandbox behind you. Three things were created: the Azure-side
+staged/log/processed files, the local practice workbook (`path`) and its `_fixed` working copy
+(forked in [Flag 1](#fix-in-source)), and the exported HTML report
+(`eri_dq_export()` writes to your working directory by default, not a temp folder -- see the
+[QC/feedback guide](da-qc-feedback-guide.html#export) -- so it won't clean itself up):
 
 ```{r cleanup}
 con <- get_azure_storage_connection(storage_name = Sys.getenv("ERIFUNCTIONS_DATA_STORAGE_NAME", "data"))
@@ -304,7 +326,10 @@ eri_catalog_remove(
 all_files <- AzureStor::list_storage_files(con, "atlantis", recursive = TRUE)
 mine      <- all_files$name[!all_files$isdir & grepl("202608", all_files$name)]
 for (f in mine) AzureStor::delete_storage_file(con, f, confirm = FALSE)
-unlink(path)
+
+unlink(path)                                                    # the original practice workbook
+unlink(sub("\\.xlsx$", "_fixed.xlsx", path))                     # its "fix in source" working copy
+unlink(list.files(getwd(), pattern = "^dq-report-atlantis-202608-.*\\.html$", full.names = TRUE))
 ```
 
 Real submissions are not disposable like this practice run -- never delete a real country's staged,

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -268,14 +268,14 @@ with the flag from here on -- into the log, and into the handback file below.
 ── RB Treatment
  excel_row   column         value                            issue status
          8 district Atlantis City Value not in allowed_values list  noted
-                                                                    note
- Confirmed with the country lead: Atlantis City is a real, if not-yet-...
+                                                                                                                                                           note
+ Confirmed with the country lead: Atlantis City is a real, if not-yet-catalogued, locality -- flagging for the schema maintainer to add it to the allowed list.
 
 ✔ DQ report (1 flag · 0 open) written to '.../dq-report-atlantis-202608-2026-07-12.html'.
 ```
 
-A quick console eyeball first (the `note` column wraps if it's long, as it does here), then the
-handback file. `eri_dq_review()` calls [`eri_dq_export()`](../reference/eri_dq_export.html) for you here -- see the
+A quick console eyeball first -- a long `note` doesn't truncate, it just pushes the table wide, as it
+does here -- then the handback file. `eri_dq_review()` calls [`eri_dq_export()`](../reference/eri_dq_export.html) for you here -- see the
 [QC/feedback guide](da-qc-feedback-guide.html#export) for what that function does on its own. Open
 the file: a self-contained page, organised by sheet, with the `noted` status shown as a chip and the
 note text in its own column -- exactly what you'd forward to the country or paste into Teams, with
@@ -311,10 +311,10 @@ once.
 ## Cleaning up {#cleanup}
 
 Everything above lives under `atlantis`'s own namespace, so it's safe to leave -- but if you were
-following along and want to tidy up the sandbox behind you. Three things were created: the Azure-side
+following along and want to tidy up the sandbox behind you, three things were created: the Azure-side
 staged/log/processed files, the local practice workbook (`path`) and its `_fixed` working copy
-(forked in [Flag 1](#fix-in-source)), and the exported HTML report
-(`eri_dq_export()` writes to your working directory by default, not a temp folder -- see the
+(forked in [Flag 1](#fix-in-source)), and the exported HTML report (`eri_dq_export()` writes to your
+working directory by default, not a temp folder -- see the
 [QC/feedback guide](da-qc-feedback-guide.html#export) -- so it won't clean itself up):
 
 ```{r cleanup}


### PR DESCRIPTION
## Summary

A fresh-user test (`da-fresh-user` agent, "Dana") ran the just-shipped `da-dq-review-guide.Rmd` end to end against the real `atlantis` sandbox and found two real bugs plus several vignette accuracy gaps.

**Bugs fixed:**
- `eri_dq_review()`'s "Print report" menu item printed an `eri_table()` flextable to the console. Outside RStudio's Viewer (plain console, VS Code terminal, SSH), `print.flextable()` has nowhere to render and dumps its raw diagnostic summary instead of the flags. Now uses a plain table print, matching the console-native convention `.eri_dq_review_report()` (the main loop's own display) already follows for exactly this reason.
- `cli_alert_info()`/`cli_alert_danger()`/`cli_alert_warning()` were called with multi-element bullet vectors in 7 places (`R/dq_review.R`, `R/dq.R`, `R/cmr.R`). Those functions only render a single bullet and glue any additional vector elements onto the same line with no space -- e.g. `"...sheet.Issue: ..."`. All 7 switched to `cli_bullets()`, which renders each element as its own line with the right icon.

**Guide accuracy fixes** (`da-dq-review-guide.Rmd`):
- Disclosed that real console output is noisier than the trimmed transcripts (schema-fallback warnings, rename messages).
- Explained the expected `atlantis`-only "Could not load schema from Azure" 404 warning.
- Added the previously-missing "Open this file to review/edit" line and a per-sheet subheader in the re-run listing.
- Corrected an overclaim that the wrapper "holds no state" -- it re-derives from a real, logged DQ check on every open, not stale cached state.
- Extended cleanup to remove the `_fixed` workbook copy and the exported HTML report (which `eri_dq_export()` writes to the working directory by default).

Regression tests added for both bugs (`test-dq_review.R`, `test-dq.R`).

## Test plan
- [x] Live semi-scripted `eri_dq_review()` session re-run against the real `atlantis` sandbox with the fixes applied -- confirmed both bugs are gone and the guide's transcripts now match exactly; all Azure artifacts cleaned up afterward (0 remaining)
- [x] New regression tests for both bugs, plus a schema-override message test in `test-dq.R`
- [x] Full local test suite -- 0 failures
- [x] `knitr::knit()` dry-run on the updated vignette
- [ ] CI (R-CMD-check, pkgdown)