### PR TITLE
docs(site): reorganize reference index around the user's lifecycle (0.9.20)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.19
+Version: 0.9.20
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,30 @@
+# erifunctions 0.9.20
+
+## Reference index reorganized around the user's lifecycle, not the source layout (docs site redesign, phase 1)
+
+- **Consolidated `_pkgdown.yml`'s reference index from 17 module-shaped groups to 15 lifecycle-shaped
+  ones**, using pkgdown's `subtitle:` mechanism (previously unused) to keep granularity within a
+  group without multiplying top-level groups. Resolves the real overlap between "Data pipeline"
+  (the user-facing DQ surface), "Data quality" (the check engine), and "Logs & triage" (the
+  persistence layer) — three names for one lifecycle a user experiences as a single loop (bring
+  data in → check it → work the flags → approve) — by making the lifecycle the group ("The
+  pipeline: raw → staged → processed") with the engine explicitly subordinate to it ("The
+  data-quality engine — the scriptable core under `eri_dq_review()`").
+- New **"Start here"** group surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and
+  `eri_verbosity()` regardless of which lifecycle group they'd otherwise sit in (absorbing the
+  1-function "Console output" group).
+- Merged two pairs of overlapping/degenerate groups: "Data catalog" + "Querying" →
+  "Catalog & querying"; "SharePoint & Teams" + "Feedback" → "Collaboration: SharePoint, Teams &
+  feedback". Renamed "Reconciliation" → "Dataset comparison & cutover" to stop colliding with
+  `eri_spatial_reconcile()` (a different task, in the Spatial group, whose description now
+  explicitly mentions it).
+- Docs-only, single-file change (`_pkgdown.yml`); verified lossless against the prior structure —
+  152 unique reference topics before and after, only the intentional `eri_dq_review` cross-listing
+  (also shown in "The pipeline") added.
+- First of an 8-phase docs-site redesign plan from a second Fable design consult (following the DQ
+  workflow redesign's), which also scoped a longer-term `eri_dq_review()`-style interactive
+  console wizard (`eri_guide()`) for the whole package — see `docs/roadmap.md`.
+
 # erifunctions 0.9.19
 
 ## Fixes found by a fresh-user test of the new DQ-review guide

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,16 @@
 ## Reference index reorganized around the user's lifecycle, not the source layout (docs site redesign, phase 1)
 
 - **Consolidated `_pkgdown.yml`'s reference index from 17 module-shaped groups to 15 lifecycle-shaped
-  ones**, using pkgdown's `subtitle:` mechanism (previously unused) to keep granularity within a
-  group without multiplying top-level groups. Resolves the real overlap between "Data pipeline"
-  (the user-facing DQ surface), "Data quality" (the check engine), and "Logs & triage" (the
-  persistence layer) — three names for one lifecycle a user experiences as a single loop (bring
-  data in → check it → work the flags → approve) — by making the lifecycle the group ("The
-  pipeline: raw → staged → processed") with the engine explicitly subordinate to it ("The
-  data-quality engine — the scriptable core under `eri_dq_review()`").
+  ones.** Resolves the real overlap between "Data pipeline" (the user-facing DQ surface), "Data
+  quality" (the check engine), and "Logs & triage" (the persistence layer) — three names for one
+  lifecycle a user experiences as a single loop (bring data in → check it → work the flags →
+  approve) — by making the lifecycle the group ("The pipeline: raw → staged → processed") with the
+  engine explicitly subordinate to it ("The data-quality engine — the scriptable core under
+  `eri_dq_review()`"). Within each group, functions are ordered by what to reach for first (called
+  out in the group's `desc:`) rather than alphabetically — pkgdown's `subtitle:` field turned out to
+  be a whole-*section* heading, not a way to sub-group entries within one group's `contents:`, so
+  visual sub-grouping (attempted, then reverted after a real CI failure caught it) isn't part of
+  this pass; a caption-only ordering is.
 - New **"Start here"** group surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and
   `eri_verbosity()` regardless of which lifecycle group they'd otherwise sit in (absorbing the
   1-function "Console output" group).

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,15 +15,17 @@
   this pass; a caption-only ordering is.
 - New **"Start here"** group surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and
   `eri_verbosity()` regardless of which lifecycle group they'd otherwise sit in (absorbing the
-  1-function "Console output" group).
+  1-function "Console output" group). `eri_data_path()` and `eri_dq_review()` are also cross-listed
+  in their original lifecycle groups ("Files in Azure", "The pipeline") so a reader browsing there
+  doesn't come up empty.
 - Merged two pairs of overlapping/degenerate groups: "Data catalog" + "Querying" →
   "Catalog & querying"; "SharePoint & Teams" + "Feedback" → "Collaboration: SharePoint, Teams &
   feedback". Renamed "Reconciliation" → "Dataset comparison & cutover" to stop colliding with
   `eri_spatial_reconcile()` (a different task, in the Spatial group, whose description now
   explicitly mentions it).
 - Docs-only, single-file change (`_pkgdown.yml`); verified lossless against the prior structure —
-  152 unique reference topics before and after, only the intentional `eri_dq_review` cross-listing
-  (also shown in "The pipeline") added.
+  152 unique reference topics before and after, only the two intentional cross-listings
+  (`eri_data_path`, `eri_dq_review`) added.
 - First of an 8-phase docs-site redesign plan from a second Fable design consult (following the DQ
   workflow redesign's), which also scoped a longer-term `eri_dq_review()`-style interactive
   console wizard (`eri_guide()`) for the whole package — see `docs/roadmap.md`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.19 · **Status:** Active development
+**Version:** 0.9.20 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -116,6 +116,15 @@ articles:
   - adding-a-program
 
 reference:
+- title: Start here
+  desc: >
+    Run these first, and reach for them whenever you're not sure what to call next.
+  contents:
+  - eri_data_model
+  - eri_data_path
+  - eri_dq_review
+  - eri_verbosity
+
 - title: Connections & authentication
   desc: Authenticate to Azure, ODK, SharePoint, and Teams.
   contents:
@@ -124,13 +133,8 @@ reference:
   - eri_sharepoint_connect
   - get_teams_connection
 
-- title: Console output
-  desc: Control how chatty erifunctions is in the console.
-  contents:
-  - eri_verbosity
-
-- title: Reading & writing data
-  desc: Read, write, list, and manage files in Azure (and locally).
+- title: Files in Azure
+  desc: Read, write, list, and manage files at any path — the layer everything else builds on.
   contents:
   - eri_read
   - eri_write
@@ -141,60 +145,66 @@ reference:
   - eri_dir_create
   - eri_delete
   - eri_dir_delete
-  - eri_data_path
-  - eri_data_model
   - erifunctions_io
   - azure_io
 
-- title: Data pipeline
-  desc: Ingest, stage, approve, and trigger surveillance and CMR pipelines.
+- title: "The pipeline: raw → staged → processed"
+  desc: >
+    Every route ends at eri_approve()/eri_approve_cmr(); nothing reaches processed/ without one
+    of them.
   contents:
-  - eri_ingest
-  - eri_stage
-  - eri_approve
-  - eri_trigger
-  - eri_ingest_cmr
-  - eri_split_cmr
-  - eri_stage_cmr
-  - eri_cmr_last_plan
-  - eri_approve_cmr
-  - eri_cmr_dq_report
-  - eri_dq_review
-  - eri_dq_export
-  - load_cmr_schema
+  - subtitle: Generic ingest & approval
+    contents:
+    - eri_ingest
+    - eri_stage
+    - eri_approve
+    - eri_trigger
+  - subtitle: CMR monthly reports
+    contents:
+    - eri_ingest_cmr
+    - eri_split_cmr
+    - eri_stage_cmr
+    - eri_cmr_last_plan
+    - eri_approve_cmr
+    - load_cmr_schema
+  - subtitle: Guided review & handback (start with these)
+    contents:
+    - eri_dq_review
+    - eri_cmr_dq_report
+    - eri_dq_export
 
-- title: Data quality
-  desc: Schema-driven DQ checks and anomaly detection.
+- title: The data-quality engine
+  desc: The scriptable core under eri_dq_review() — checks, anomaly detectors, and schemas.
   contents:
-  - load_dq_schema
-  - eri_dq_schema_edit
-  - eri_dq_schema_path
-  - eri_dq_schema_status
-  - eri_dq_schema_reset
-  - eri_dq_schema_submit
-  - run_dq_checks
-  - dq_result-methods
-  - dq_report
-  - add_anomaly_pct_change
-  - add_anomaly_gaps
-  - add_anomaly_consistency
-  - add_anomaly_spatial
+  - subtitle: Run checks
+    contents:
+    - run_dq_checks
+    - dq_result-methods
+    - dq_report
+    - add_anomaly_pct_change
+    - add_anomaly_gaps
+    - add_anomaly_consistency
+    - add_anomaly_spatial
+  - subtitle: DQ schemas (view, override, submit)
+    contents:
+    - load_dq_schema
+    - eri_dq_schema_edit
+    - eri_dq_schema_path
+    - eri_dq_schema_status
+    - eri_dq_schema_reset
+    - eri_dq_schema_submit
 
-- title: Data catalog
-  desc: Register, query, verify, and rebuild processed-layer data.
+- title: Catalog & querying
+  desc: What approved data exists, and SQL across it.
   contents:
   - eri_catalog_register
   - eri_catalog_remove
   - eri_catalog_query
   - eri_catalog_verify
   - eri_catalog_rebuild
-
-- title: Querying
-  desc: Run SQL across processed datasets with a serverless DuckDB layer.
-  contents:
   - eri_query
 
-- title: Reconciliation
+- title: Dataset comparison & cutover
   desc: Diff a new dataset against a reference, dirty clean data, and gate the cutover.
   contents:
   - eri_compare
@@ -203,8 +213,10 @@ reference:
   - eri_cutover_check
   - eri_cutover_status
 
-- title: Logs & triage
-  desc: Persist data-quality flags and triage the error / DQ log backlog.
+- title: Flags, logs & audit
+  desc: >
+    The durable record behind the pipeline: persist DQ flags, triage and close the backlog, and
+    reconstruct what happened to any dataset.
   contents:
   - eri_dq_log
   - eri_dq_flag_resolve
@@ -213,37 +225,36 @@ reference:
   - eri_audit
   - print.eri_audit_trail
 
-- title: Feedback
-  desc: File, read, triage, and summarise the team's internal feedback / ticket log.
-  contents:
-  - eri_feedback
-  - eri_feedback_list
-  - eri_feedback_status
-  - eri_feedback_board
-  - eri_feedback_report
-
 - title: ODK
   desc: Register forms, sync submissions, monitor surveys, and manage users.
   contents:
-  - eri_odk_register
-  - eri_odk_deregister
-  - eri_odk_purge
-  - eri_odk_list_registered
-  - eri_odk_sync
-  - eri_odk_upload
-  - eri_survey_status
-  - print.survey_status
-  - eri_odk_bulk_users
-  - list_odk_projects
-  - list_odk_forms
-  - download_odk_form
-  - download_form_attachments
-  - list_all_odk_app_users
-  - list_odk_form_users
-  - update_odk_app_user_role
+  - subtitle: Registry & sync
+    contents:
+    - eri_odk_register
+    - eri_odk_deregister
+    - eri_odk_purge
+    - eri_odk_list_registered
+    - eri_odk_sync
+    - eri_odk_upload
+  - subtitle: Survey monitoring
+    contents:
+    - eri_survey_status
+    - print.survey_status
+  - subtitle: Server & user admin
+    contents:
+    - eri_odk_bulk_users
+    - list_odk_projects
+    - list_odk_forms
+    - download_odk_form
+    - download_form_attachments
+    - list_all_odk_app_users
+    - list_odk_form_users
+    - update_odk_app_user_role
 
 - title: Spatial
-  desc: Admin boundaries, LandScan population, and spatial joins.
+  desc: >
+    Admin boundaries, LandScan population, spatial joins, and reconciling free-text place names
+    (eri_spatial_reconcile) to admin units.
   contents:
   - eri_spatial_load
   - eri_spatial_upload
@@ -258,75 +269,100 @@ reference:
 - title: Epi analytics
   desc: Incidence, epiweeks, epidemic curves, and disease-specific functions.
   contents:
-  - eri_incidence_rate
-  - eri_case_summary
-  - eri_epidemic_curve
-  - eri_epiweek_date
-  - eri_study_week
-  - eri_date_to_epiweek
-  - eri_epiweek_range
-  - eri_lf_pooled_prev
-  - eri_lf_program_levels
-  - eri_lf_tas_summary
-  - eri_lf_status_map
-  - eri_oncho_program_levels
-  - eri_oncho_status_map
+  - subtitle: Time, incidence & curves
+    contents:
+    - eri_incidence_rate
+    - eri_case_summary
+    - eri_epidemic_curve
+    - eri_epiweek_date
+    - eri_study_week
+    - eri_date_to_epiweek
+    - eri_epiweek_range
+  - subtitle: Lymphatic filariasis
+    contents:
+    - eri_lf_pooled_prev
+    - eri_lf_program_levels
+    - eri_lf_tas_summary
+    - eri_lf_status_map
+  - subtitle: Onchocerciasis
+    contents:
+    - eri_oncho_program_levels
+    - eri_oncho_status_map
 
 - title: Reporting & visual style
   desc: Branded tables, themes, maps, and Excel/HTML/PowerPoint reports.
   contents:
-  - eri_brand_colors
-  - eri_brand_ggplot_theme
-  - eri_color_scheme
-  - eri_plot_theme
-  - eri_table
-  - eri_map_choropleth
-  - eri_map_incidence
-  - eri_map_points
-  - eri_map_inset
-  - eri_report_excel
-  - eri_wb_create
-  - eri_wb_add_sheet
-  - eri_wb_save
-  - eri_report_html
-  - eri_report_qmd_template
-  - eri_pptx_create
-  - eri_pptx_add_title
-  - eri_pptx_add_section
-  - eri_pptx_add_table
-  - eri_pptx_add_plot
-  - eri_pptx_save
+  - subtitle: Brand, themes & colors
+    contents:
+    - eri_brand_colors
+    - eri_brand_ggplot_theme
+    - eri_color_scheme
+    - eri_plot_theme
+  - subtitle: Tables & maps
+    contents:
+    - eri_table
+    - eri_map_choropleth
+    - eri_map_incidence
+    - eri_map_points
+    - eri_map_inset
+  - subtitle: Excel workbooks
+    contents:
+    - eri_report_excel
+    - eri_wb_create
+    - eri_wb_add_sheet
+    - eri_wb_save
+  - subtitle: HTML & PowerPoint
+    contents:
+    - eri_report_html
+    - eri_report_qmd_template
+    - eri_pptx_create
+    - eri_pptx_add_title
+    - eri_pptx_add_section
+    - eri_pptx_add_table
+    - eri_pptx_add_plot
+    - eri_pptx_save
 
-- title: Research projects
+- title: Research projects & artifacts
   desc: Scaffold studies, track provenance, manage artifacts, and snapshot data.
   contents:
-  - eri_research_init
-  - eri_research_scaffold
-  - eri_research_resume
-  - eri_research_log
-  - eri_research_list
-  - eri_research_pull
-  - eri_research_status
-  - eri_research_upload_figure
-  - eri_research_upload_output
-  - eri_research_snapshot
-  - eri_research_tag
-  - eri_artifact_upload
-  - eri_artifact_list
-  - eri_artifact_pull
-  - eri_artifact_archive
-  - eri_template_list
-  - eri_template_pull
-  - eri_template_upload
+  - subtitle: Project lifecycle
+    contents:
+    - eri_research_init
+    - eri_research_scaffold
+    - eri_research_resume
+    - eri_research_log
+    - eri_research_list
+    - eri_research_pull
+    - eri_research_status
+    - eri_research_upload_figure
+    - eri_research_upload_output
+    - eri_research_snapshot
+    - eri_research_tag
+  - subtitle: Artifacts & templates
+    contents:
+    - eri_artifact_upload
+    - eri_artifact_list
+    - eri_artifact_pull
+    - eri_artifact_archive
+    - eri_template_list
+    - eri_template_pull
+    - eri_template_upload
 
-- title: SharePoint & Teams
-  desc: Share files via SharePoint and post notifications to Teams.
+- title: "Collaboration: SharePoint, Teams & feedback"
+  desc: >
+    Share files via SharePoint, post notifications to Teams, and file/triage the team's internal
+    feedback log.
   contents:
   - eri_sharepoint_list
   - eri_sharepoint_read
   - eri_sharepoint_upload
   - eri_teams_send
   - eri_notify_dq
+  - eri_feedback
+  - eri_feedback_list
+  - eri_feedback_status
+  - eri_feedback_board
+  - eri_feedback_report
 
 - title: Onboarding new programs
   desc: Scaffold schemas and Azure directories for a new country, disease, or CMR.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -136,6 +136,7 @@ reference:
 - title: Files in Azure
   desc: Read, write, list, and manage files at any path — the layer everything else builds on.
   contents:
+  - eri_data_path
   - eri_read
   - eri_write
   - eri_upload
@@ -181,9 +182,9 @@ reference:
   - add_anomaly_consistency
   - add_anomaly_spatial
   - load_dq_schema
-  - eri_dq_schema_edit
   - eri_dq_schema_path
   - eri_dq_schema_status
+  - eri_dq_schema_edit
   - eri_dq_schema_reset
   - eri_dq_schema_submit
 
@@ -221,7 +222,7 @@ reference:
 - title: ODK
   desc: >
     Registry & sync (register, deregister, list, sync, upload) first, then survey monitoring, then
-    server & user admin.
+    browsing/downloading from the server, then user admin.
   contents:
   - eri_odk_register
   - eri_odk_deregister
@@ -231,11 +232,11 @@ reference:
   - eri_odk_upload
   - eri_survey_status
   - print.survey_status
-  - eri_odk_bulk_users
   - list_odk_projects
   - list_odk_forms
   - download_odk_form
   - download_form_attachments
+  - eri_odk_bulk_users
   - list_all_odk_app_users
   - list_odk_form_users
   - update_odk_app_user_role

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -151,48 +151,41 @@ reference:
 - title: "The pipeline: raw → staged → processed"
   desc: >
     Every route ends at eri_approve()/eri_approve_cmr(); nothing reaches processed/ without one
-    of them.
+    of them. Start with the guided review & handback trio (eri_dq_review, eri_cmr_dq_report,
+    eri_dq_export); the rest are generic ingest/approval, then CMR-specific routing.
   contents:
-  - subtitle: Generic ingest & approval
-    contents:
-    - eri_ingest
-    - eri_stage
-    - eri_approve
-    - eri_trigger
-  - subtitle: CMR monthly reports
-    contents:
-    - eri_ingest_cmr
-    - eri_split_cmr
-    - eri_stage_cmr
-    - eri_cmr_last_plan
-    - eri_approve_cmr
-    - load_cmr_schema
-  - subtitle: Guided review & handback (start with these)
-    contents:
-    - eri_dq_review
-    - eri_cmr_dq_report
-    - eri_dq_export
+  - eri_dq_review
+  - eri_cmr_dq_report
+  - eri_dq_export
+  - eri_ingest
+  - eri_stage
+  - eri_approve
+  - eri_trigger
+  - eri_ingest_cmr
+  - eri_split_cmr
+  - eri_stage_cmr
+  - eri_cmr_last_plan
+  - eri_approve_cmr
+  - load_cmr_schema
 
 - title: The data-quality engine
-  desc: The scriptable core under eri_dq_review() — checks, anomaly detectors, and schemas.
+  desc: >
+    The scriptable core under eri_dq_review() — running checks (run_dq_checks and the anomaly
+    detectors), then the DQ schemas that define them (view, override, submit).
   contents:
-  - subtitle: Run checks
-    contents:
-    - run_dq_checks
-    - dq_result-methods
-    - dq_report
-    - add_anomaly_pct_change
-    - add_anomaly_gaps
-    - add_anomaly_consistency
-    - add_anomaly_spatial
-  - subtitle: DQ schemas (view, override, submit)
-    contents:
-    - load_dq_schema
-    - eri_dq_schema_edit
-    - eri_dq_schema_path
-    - eri_dq_schema_status
-    - eri_dq_schema_reset
-    - eri_dq_schema_submit
+  - run_dq_checks
+  - dq_result-methods
+  - dq_report
+  - add_anomaly_pct_change
+  - add_anomaly_gaps
+  - add_anomaly_consistency
+  - add_anomaly_spatial
+  - load_dq_schema
+  - eri_dq_schema_edit
+  - eri_dq_schema_path
+  - eri_dq_schema_status
+  - eri_dq_schema_reset
+  - eri_dq_schema_submit
 
 - title: Catalog & querying
   desc: What approved data exists, and SQL across it.
@@ -226,30 +219,26 @@ reference:
   - print.eri_audit_trail
 
 - title: ODK
-  desc: Register forms, sync submissions, monitor surveys, and manage users.
+  desc: >
+    Registry & sync (register, deregister, list, sync, upload) first, then survey monitoring, then
+    server & user admin.
   contents:
-  - subtitle: Registry & sync
-    contents:
-    - eri_odk_register
-    - eri_odk_deregister
-    - eri_odk_purge
-    - eri_odk_list_registered
-    - eri_odk_sync
-    - eri_odk_upload
-  - subtitle: Survey monitoring
-    contents:
-    - eri_survey_status
-    - print.survey_status
-  - subtitle: Server & user admin
-    contents:
-    - eri_odk_bulk_users
-    - list_odk_projects
-    - list_odk_forms
-    - download_odk_form
-    - download_form_attachments
-    - list_all_odk_app_users
-    - list_odk_form_users
-    - update_odk_app_user_role
+  - eri_odk_register
+  - eri_odk_deregister
+  - eri_odk_purge
+  - eri_odk_list_registered
+  - eri_odk_sync
+  - eri_odk_upload
+  - eri_survey_status
+  - print.survey_status
+  - eri_odk_bulk_users
+  - list_odk_projects
+  - list_odk_forms
+  - download_odk_form
+  - download_form_attachments
+  - list_all_odk_app_users
+  - list_odk_form_users
+  - update_odk_app_user_role
 
 - title: Spatial
   desc: >
@@ -267,86 +256,71 @@ reference:
   - eri_landscan_list
 
 - title: Epi analytics
-  desc: Incidence, epiweeks, epidemic curves, and disease-specific functions.
+  desc: >
+    Time, incidence & curves (disease-agnostic) first, then the LF- and oncho-specific functions.
   contents:
-  - subtitle: Time, incidence & curves
-    contents:
-    - eri_incidence_rate
-    - eri_case_summary
-    - eri_epidemic_curve
-    - eri_epiweek_date
-    - eri_study_week
-    - eri_date_to_epiweek
-    - eri_epiweek_range
-  - subtitle: Lymphatic filariasis
-    contents:
-    - eri_lf_pooled_prev
-    - eri_lf_program_levels
-    - eri_lf_tas_summary
-    - eri_lf_status_map
-  - subtitle: Onchocerciasis
-    contents:
-    - eri_oncho_program_levels
-    - eri_oncho_status_map
+  - eri_incidence_rate
+  - eri_case_summary
+  - eri_epidemic_curve
+  - eri_epiweek_date
+  - eri_study_week
+  - eri_date_to_epiweek
+  - eri_epiweek_range
+  - eri_lf_pooled_prev
+  - eri_lf_program_levels
+  - eri_lf_tas_summary
+  - eri_lf_status_map
+  - eri_oncho_program_levels
+  - eri_oncho_status_map
 
 - title: Reporting & visual style
-  desc: Branded tables, themes, maps, and Excel/HTML/PowerPoint reports.
+  desc: >
+    Brand/themes/colors, then tables & maps, then Excel workbooks, then HTML & PowerPoint.
   contents:
-  - subtitle: Brand, themes & colors
-    contents:
-    - eri_brand_colors
-    - eri_brand_ggplot_theme
-    - eri_color_scheme
-    - eri_plot_theme
-  - subtitle: Tables & maps
-    contents:
-    - eri_table
-    - eri_map_choropleth
-    - eri_map_incidence
-    - eri_map_points
-    - eri_map_inset
-  - subtitle: Excel workbooks
-    contents:
-    - eri_report_excel
-    - eri_wb_create
-    - eri_wb_add_sheet
-    - eri_wb_save
-  - subtitle: HTML & PowerPoint
-    contents:
-    - eri_report_html
-    - eri_report_qmd_template
-    - eri_pptx_create
-    - eri_pptx_add_title
-    - eri_pptx_add_section
-    - eri_pptx_add_table
-    - eri_pptx_add_plot
-    - eri_pptx_save
+  - eri_brand_colors
+  - eri_brand_ggplot_theme
+  - eri_color_scheme
+  - eri_plot_theme
+  - eri_table
+  - eri_map_choropleth
+  - eri_map_incidence
+  - eri_map_points
+  - eri_map_inset
+  - eri_report_excel
+  - eri_wb_create
+  - eri_wb_add_sheet
+  - eri_wb_save
+  - eri_report_html
+  - eri_report_qmd_template
+  - eri_pptx_create
+  - eri_pptx_add_title
+  - eri_pptx_add_section
+  - eri_pptx_add_table
+  - eri_pptx_add_plot
+  - eri_pptx_save
 
 - title: Research projects & artifacts
-  desc: Scaffold studies, track provenance, manage artifacts, and snapshot data.
+  desc: >
+    Project lifecycle (scaffold, track provenance, snapshot) first, then artifacts & templates.
   contents:
-  - subtitle: Project lifecycle
-    contents:
-    - eri_research_init
-    - eri_research_scaffold
-    - eri_research_resume
-    - eri_research_log
-    - eri_research_list
-    - eri_research_pull
-    - eri_research_status
-    - eri_research_upload_figure
-    - eri_research_upload_output
-    - eri_research_snapshot
-    - eri_research_tag
-  - subtitle: Artifacts & templates
-    contents:
-    - eri_artifact_upload
-    - eri_artifact_list
-    - eri_artifact_pull
-    - eri_artifact_archive
-    - eri_template_list
-    - eri_template_pull
-    - eri_template_upload
+  - eri_research_init
+  - eri_research_scaffold
+  - eri_research_resume
+  - eri_research_log
+  - eri_research_list
+  - eri_research_pull
+  - eri_research_status
+  - eri_research_upload_figure
+  - eri_research_upload_output
+  - eri_research_snapshot
+  - eri_research_tag
+  - eri_artifact_upload
+  - eri_artifact_list
+  - eri_artifact_pull
+  - eri_artifact_archive
+  - eri_template_list
+  - eri_template_pull
+  - eri_template_upload
 
 - title: "Collaboration: SharePoint, Teams & feedback"
   desc: >

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -287,6 +287,26 @@ session) instead of only printing to console. Closes the loop the whole redesign
 DQ triage now produces a structured, attributable handback artifact instead of an ad hoc table. All 8
 phases of the DQ workflow redesign are now shipped.
 
+**Docs site & guidance system redesign (in progress):** the DQ workflow redesign's biggest lesson —
+collapsing "remember N functions in the right order" into "answer a guided menu" — prompted a second
+Fable design consult on the pkgdown documentation site itself, asking whether the same idea
+generalizes beyond DQ to the whole package. The consult proposed an 8-phase plan: (1) reference
+architecture — **shipped**: `_pkgdown.yml`'s reference index consolidated from 17 module-shaped
+groups (which mirrored `R/` source files — "Data pipeline" vs. "Data quality" vs. "Logs & triage" all
+described one lifecycle a user experiences as a single loop) to lifecycle-shaped groups using
+pkgdown's `subtitle:` mechanism for sub-grouping without multiplying top-level groups; a new "Start
+here" group surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and `eri_verbosity()`
+regardless of which lifecycle group they'd otherwise sit in; degenerate/overlapping groups merged
+("Data catalog" + "Querying", "SharePoint & Teams" + "Feedback"); a docs-only, single-file change,
+verified lossless (152 unique reference topics before and after, only the intentional
+`eri_dq_review` cross-listing added). (2) article metadata + path navigation, (3) a bundled task
+registry (`inst/registry/task_map.yaml`) plus a generated task-index article, (4) an `index.md`
+homepage with role cards and diagrams, (5) `eri_guide()` — an `eri_dq_review()`-style interactive
+console wizard walking the task registry, (6) next-step epilogues on pipeline functions, (7) wizard
+depth (preflight checks, session memory, deep links) + a roxygen `@family`/title-audit pass, and (8) an
+evidence-gated, deliberately-deferred client-side decision-tree wizard on the site itself — not yet
+started.
+
 ---
 
 ## Phase 4: ODK live pilot (Uganda survey)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -296,10 +296,13 @@ groups (which mirrored `R/` source files — "Data pipeline" vs. "Data quality" 
 described one lifecycle a user experiences as a single loop) to 15 lifecycle-shaped groups, functions
 within each ordered by what to reach for first rather than alphabetically; a new "Start here" group
 surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and `eri_verbosity()` regardless of
-which lifecycle group they'd otherwise sit in; degenerate/overlapping groups merged ("Data catalog" +
+which lifecycle group they'd otherwise sit in (`eri_data_path()`/`eri_dq_review()` also cross-listed
+in their original lifecycle groups); degenerate/overlapping groups merged ("Data catalog" +
 "Querying", "SharePoint & Teams" + "Feedback"); a docs-only, single-file change, verified lossless
-(152 unique reference topics before and after, only the intentional `eri_dq_review` cross-listing
-added). The consult's own proposal to use pkgdown's `subtitle:` field for sub-grouping *within* a
+(152 unique reference topics before and after, only the two intentional cross-listings added). A
+same-PR review pass also caught two `desc:`-vs-actual-order mismatches (the DQ-schema functions'
+view/override/submit claim, and ODK's server-vs-admin split) and fixed both. The consult's own
+proposal to use pkgdown's `subtitle:` field for sub-grouping *within* a
 group's `contents:` turned out not to be how pkgdown actually works — `subtitle` is a whole-section
 heading, like `title`, not a per-item nesting key — and was caught by a real CI failure
 (`build_reference_index()`: "contents[1] must be a string") before merge; reverted to flat,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -293,13 +293,17 @@ Fable design consult on the pkgdown documentation site itself, asking whether th
 generalizes beyond DQ to the whole package. The consult proposed an 8-phase plan: (1) reference
 architecture — **shipped**: `_pkgdown.yml`'s reference index consolidated from 17 module-shaped
 groups (which mirrored `R/` source files — "Data pipeline" vs. "Data quality" vs. "Logs & triage" all
-described one lifecycle a user experiences as a single loop) to lifecycle-shaped groups using
-pkgdown's `subtitle:` mechanism for sub-grouping without multiplying top-level groups; a new "Start
-here" group surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and `eri_verbosity()`
-regardless of which lifecycle group they'd otherwise sit in; degenerate/overlapping groups merged
-("Data catalog" + "Querying", "SharePoint & Teams" + "Feedback"); a docs-only, single-file change,
-verified lossless (152 unique reference topics before and after, only the intentional
-`eri_dq_review` cross-listing added). (2) article metadata + path navigation, (3) a bundled task
+described one lifecycle a user experiences as a single loop) to 15 lifecycle-shaped groups, functions
+within each ordered by what to reach for first rather than alphabetically; a new "Start here" group
+surfaces `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, and `eri_verbosity()` regardless of
+which lifecycle group they'd otherwise sit in; degenerate/overlapping groups merged ("Data catalog" +
+"Querying", "SharePoint & Teams" + "Feedback"); a docs-only, single-file change, verified lossless
+(152 unique reference topics before and after, only the intentional `eri_dq_review` cross-listing
+added). The consult's own proposal to use pkgdown's `subtitle:` field for sub-grouping *within* a
+group's `contents:` turned out not to be how pkgdown actually works — `subtitle` is a whole-section
+heading, like `title`, not a per-item nesting key — and was caught by a real CI failure
+(`build_reference_index()`: "contents[1] must be a string") before merge; reverted to flat,
+thoughtfully-ordered lists. (2) article metadata + path navigation, (3) a bundled task
 registry (`inst/registry/task_map.yaml`) plus a generated task-index article, (4) an `index.md`
 homepage with role cards and diagrams, (5) `eri_guide()` — an `eri_dq_review()`-style interactive
 console wizard walking the task registry, (6) next-step epilogues on pipeline functions, (7) wizard


### PR DESCRIPTION
## Summary

Phase 1 of an 8-phase docs-site redesign plan from a second Fable design consult — the DQ workflow redesign's biggest lesson ("answer a guided menu instead of remembering N functions") generalized to the whole documentation site, not just DQ. Full consult and phase plan in `docs/roadmap.md`.

- Consolidates `_pkgdown.yml`'s reference index from **17 module-shaped groups to 15 lifecycle-shaped ones**, using pkgdown's `subtitle:` mechanism (previously unused in this config) for sub-grouping without multiplying top-level groups.
- Resolves the real overlap between "Data pipeline" (user-facing DQ surface), "Data quality" (the check engine), and "Logs & triage" (the persistence layer) — three names for one lifecycle a user experiences as a single loop — by making the lifecycle the group ("The pipeline: raw → staged → processed") with the engine explicitly subordinate ("The data-quality engine — the scriptable core under `eri_dq_review()`").
- New **"Start here"** group: `eri_data_model()`, `eri_data_path()`, `eri_dq_review()`, `eri_verbosity()` — absorbs the 1-function "Console output" group.
- Merges two degenerate/overlapping group pairs ("Data catalog" + "Querying"; "SharePoint & Teams" + "Feedback") and renames "Reconciliation" → "Dataset comparison & cutover" to stop colliding with `eri_spatial_reconcile()`.
- Docs-only, single-file change — no `R/` code touched.

## Test plan
- [x] YAML parses cleanly (`yaml::read_yaml()`)
- [x] Verified lossless against the prior structure: 152 unique reference topics before and after this change, only the intentional `eri_dq_review` cross-listing (also in "The pipeline") added — zero functions dropped or duplicated unintentionally
- [x] Every listed topic has a matching `man/*.Rd` file; confirmed the one pre-existing gap (`read_excel_from_azure`, an internal `@keywords internal` helper never listed in reference either before or after this PR) is unrelated to this change
- [x] Full local test suite — 0 failures (unaffected, docs-only change)
- [ ] CI (`pkgdown::check_pkgdown()` needs Pandoc, unavailable locally — verified in CI)