### PR TITLE
docs(site): metadata strips + path navigation on every guide (0.9.21)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.20
+Version: 0.9.21
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,11 @@
   render correctly in the actual rendered HTML, not just that the source parses.
 - Found but out of scope here: `epi-analytics.Rmd`'s code chunks reference undefined objects and
   aren't actually runnable as shipped — logged as a nice-to-have, not fixed in this PR.
+- A review pass caught one strip that misapplied the sandbox-safe rule
+  (`da-qc-feedback-guide.Rmd`'s "Notify the team" aside illustrates a real country's Teams channel,
+  so it's `no`, not `yes`, even though the rest of the guide is offline) and wired up the
+  `.eri-sandbox-yes`/`.eri-sandbox-no` CSS classes that had been defined but never actually used in
+  any strip — both fixed.
 
 # erifunctions 0.9.20
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,29 @@
+# erifunctions 0.9.21
+
+## Every guide now says what it costs before you start (docs site redesign, phase 2)
+
+- **Added a metadata strip to all 25 vignettes**: type (Walkthrough / Desk reference / Deep-dive),
+  a time estimate, what it needs (nothing / Azure / Azure + ODK), and whether it's sandbox-safe
+  (runs on the built-in `atlantis` training country, or fully offline, vs. touches/illustrates a
+  real country's namespace) — answers "can I run this without breaking a real country" before
+  reading a word. Implemented as a pandoc fenced div (`::: {.eri-guide-meta}`), styled from a new
+  `pkgdown/extra.css` (pkgdown auto-copies and links any `pkgdown/extra.css`/`extra.js`).
+- **Added prev/next path footers to the 7 articles that are actually part of a strictly ordered
+  role path** — not the ~14 originally estimated. Reading the package's own "in order" text
+  (`getting-started.Rmd`, `docs/guides.md`) before implementing found the real strict sequence is
+  `connections-guide` (shared first step), then either the 3-step DA core (onboard → ingest →
+  logs) or the 3-step Epi core (research → reconcile → DQ). CMR, ODK, ad-hoc SQL, reporting,
+  QC-feedback, and survey-report guides are explicitly "feeds/tasks you reach for as needed," not
+  forced continuations — they get a metadata strip, not an invented "step N of 10."
+- **README's guide table gained Time / Needs / Sandbox columns**, matching the vignette strips.
+- Verified with a **full local `pkgdown::build_site()`** — not just `check_pkgdown()` — unlocked by
+  pointing `RSTUDIO_PANDOC` at RStudio's bundled Quarto Pandoc (a real capability gap from Phase 1,
+  where the equivalent invalid-config bug could only be caught by CI). Every reference page and all
+  25 articles built clean; confirmed `extra.css` is copied and linked and both fenced-div classes
+  render correctly in the actual rendered HTML, not just that the source parses.
+- Found but out of scope here: `epi-analytics.Rmd`'s code chunks reference undefined objects and
+  aren't actually runnable as shipped — logged as a nice-to-have, not fixed in this PR.
+
 # erifunctions 0.9.20
 
 ## Reference index reorganized around the user's lifecycle, not the source layout (docs site redesign, phase 1)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.20 · **Status:** Active development
+**Version:** 0.9.21 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -59,29 +59,30 @@ assumes.
   [Reconcile localities](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) →
   [Catch anomalies](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html).
 
-The full set:
+The full set (**Sandbox** = runs safely on the built-in `atlantis` training country or fully
+offline, with no real country ever touched):
 
-| Guide | For |
-|---|---|
-| [Connecting to Azure, ODK, SharePoint & Teams](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) | Everyone, how to authenticate to each service and confirm it works (start here) |
-| [A complete research workflow for epidemiologists](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | Epidemiologists running a study end-to-end, from a fresh project to a citable, reproducible result |
-| [Ingesting a surveillance dataset (raw → approved)](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | Data analysts taking a dataset through the raw → staged → approved pipeline, with a human approval gate |
-| [Uploading a monthly country report (CMR)](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | Data analysts uploading, staging, parsing, and approving the monthly CMR Excel reports countries file |
-| [Triaging DQ flags interactively](https://thecartercenter.github.io/erifunctions/articles/da-dq-review-guide.html) | Data analysts working a CMR's DQ flags through one guided menu (`eri_dq_review()`) instead of the underlying functions, ending in a handback file (`eri_dq_export()`) |
-| [Working with ODK Central](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | Data analysts connecting to ODK Central to monitor a form, manage collectors, and pull submissions into the pipeline |
-| [Onboarding a new country / disease / data type](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | Data analysts standing up the schema + folders for a new program before any data flows |
-| [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) |
-| [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer |
-| [Branded tables, figures & decks](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | Data analysts turning approved data into on-brand tables, plots, Excel workbooks, and PowerPoint decks |
-| [QC an extract & give a country feedback](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | Data analysts running DQ checks on a submission and turning the flags into clear country feedback |
-| [Final summaries & reports from an ODK survey](https://thecartercenter.github.io/erifunctions/articles/da-survey-report-guide.html) | Data analysts summarising an approved survey (e.g. LF TAS) with the disease helpers and packaging the result |
-| [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract |
-| [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers |
-| [Reconciling localities to admin units](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | Epidemiologists mapping messy free-text place names to canonical admin units (match → geocode → review) |
-| [Catching anomalies in a new extract](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html) | Epidemiologists QC-ing an extract for spikes, missing weeks, and cross-field/spatial anomalies before analysis |
-| [Spatial workflow](https://thecartercenter.github.io/erifunctions/articles/spatial-workflow.html) | Admin boundaries, population, and spatial joins/maps |
-| [SharePoint workflow](https://thecartercenter.github.io/erifunctions/articles/sharepoint-workflow.html) | Sharing files via SharePoint and posting to Teams |
-| [Adding a new program](https://thecartercenter.github.io/erifunctions/articles/adding-a-program.html) | Onboarding a new country, disease, or data type |
+| Guide | For | Time | Needs | Sandbox |
+|---|---|---|---|---|
+| [Connecting to Azure, ODK, SharePoint & Teams](https://thecartercenter.github.io/erifunctions/articles/connections-guide.html) | Everyone, how to authenticate to each service and confirm it works (start here) | ~20 min | Azure + ODK | No |
+| [A complete research workflow for epidemiologists](https://thecartercenter.github.io/erifunctions/articles/epi-research-guide.html) | Epidemiologists running a study end-to-end, from a fresh project to a citable, reproducible result | ~40 min | Azure | Yes |
+| [Ingesting a surveillance dataset (raw → approved)](https://thecartercenter.github.io/erifunctions/articles/da-ingest-guide.html) | Data analysts taking a dataset through the raw → staged → approved pipeline, with a human approval gate | ~35 min | Azure | Yes |
+| [Uploading a monthly country report (CMR)](https://thecartercenter.github.io/erifunctions/articles/da-cmr-guide.html) | Data analysts uploading, staging, parsing, and approving the monthly CMR Excel reports countries file | ~25 min | Azure | No |
+| [Triaging DQ flags interactively](https://thecartercenter.github.io/erifunctions/articles/da-dq-review-guide.html) | Data analysts working a CMR's DQ flags through one guided menu (`eri_dq_review()`) instead of the underlying functions, ending in a handback file (`eri_dq_export()`) | ~20 min | Azure | Yes |
+| [Working with ODK Central](https://thecartercenter.github.io/erifunctions/articles/da-odk-guide.html) | Data analysts connecting to ODK Central to monitor a form, manage collectors, and pull submissions into the pipeline | ~40 min | Azure + ODK | No |
+| [Onboarding a new country / disease / data type](https://thecartercenter.github.io/erifunctions/articles/da-onboard-guide.html) | Data analysts standing up the schema + folders for a new program before any data flows | ~20 min | Azure | Yes |
+| [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) | ~20 min | Azure | Yes |
+| [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer | ~15 min | Azure | No |
+| [Branded tables, figures & decks](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | Data analysts turning approved data into on-brand tables, plots, Excel workbooks, and PowerPoint decks | ~10 min | Nothing | Yes |
+| [QC an extract & give a country feedback](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | Data analysts running DQ checks on a submission and turning the flags into clear country feedback | ~10 min | Nothing | Yes |
+| [Final summaries & reports from an ODK survey](https://thecartercenter.github.io/erifunctions/articles/da-survey-report-guide.html) | Data analysts summarising an approved survey (e.g. LF TAS) with the disease helpers and packaging the result | ~10 min | Nothing | Yes |
+| [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract | ~15 min | Nothing | n/a |
+| [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers | ~10 min | n/a | n/a |
+| [Reconciling localities to admin units](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) | Epidemiologists mapping messy free-text place names to canonical admin units (match → geocode → review) | ~15 min | Nothing | Yes |
+| [Catching anomalies in a new extract](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html) | Epidemiologists QC-ing an extract for spikes, missing weeks, and cross-field/spatial anomalies before analysis | ~15 min | Nothing | Yes |
+| [Spatial workflow](https://thecartercenter.github.io/erifunctions/articles/spatial-workflow.html) | Admin boundaries, population, and spatial joins/maps | ~15 min | Azure | No |
+| [SharePoint workflow](https://thecartercenter.github.io/erifunctions/articles/sharepoint-workflow.html) | Sharing files via SharePoint and posting to Teams | ~15 min | Azure | No |
+| [Adding a new program](https://thecartercenter.github.io/erifunctions/articles/adding-a-program.html) | Onboarding a new country, disease, or data type | ~20 min | Nothing | Yes |
 
 The full, grouped **function reference** lives at
 <https://thecartercenter.github.io/erifunctions/reference/>.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ assumes.
   [Reconcile localities](https://thecartercenter.github.io/erifunctions/articles/epi-reconcile-guide.html) →
   [Catch anomalies](https://thecartercenter.github.io/erifunctions/articles/epi-dq-guide.html).
 
-The full set (**Sandbox** = runs safely on the built-in `atlantis` training country or fully
-offline, with no real country ever touched):
+The full set (**Sandbox** = runs safely with no real country ever touched — on the built-in
+`atlantis` training country, fully offline, or with public/placeholder data under a non-real
+country code):
 
 | Guide | For | Time | Needs | Sandbox |
 |---|---|---|---|---|
@@ -74,7 +75,7 @@ offline, with no real country ever touched):
 | [Triaging the error & DQ log backlog](https://thecartercenter.github.io/erifunctions/articles/da-logs-guide.html) | Data analysts finding what failed or needs review and closing it out (shared across the team) | ~20 min | Azure | Yes |
 | [Answering ad-hoc requests with SQL](https://thecartercenter.github.io/erifunctions/articles/da-adhoc-guide.html) | Data analysts running SQL across approved datasets (roll-ups, joins) with the `eri_query()` DuckDB layer | ~15 min | Azure | No |
 | [Branded tables, figures & decks](https://thecartercenter.github.io/erifunctions/articles/da-reporting-guide.html) | Data analysts turning approved data into on-brand tables, plots, Excel workbooks, and PowerPoint decks | ~10 min | Nothing | Yes |
-| [QC an extract & give a country feedback](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | Data analysts running DQ checks on a submission and turning the flags into clear country feedback | ~10 min | Nothing | Yes |
+| [QC an extract & give a country feedback](https://thecartercenter.github.io/erifunctions/articles/da-qc-feedback-guide.html) | Data analysts running DQ checks on a submission and turning the flags into clear country feedback | ~10 min | Nothing | No |
 | [Final summaries & reports from an ODK survey](https://thecartercenter.github.io/erifunctions/articles/da-survey-report-guide.html) | Data analysts summarising an approved survey (e.g. LF TAS) with the disease helpers and packaging the result | ~10 min | Nothing | Yes |
 | [Data quality pipeline](https://thecartercenter.github.io/erifunctions/articles/dq-pipeline.html) | Running schema-driven DQ checks and anomaly detection on an extract | ~15 min | Nothing | n/a |
 | [Epi analytics](https://thecartercenter.github.io/erifunctions/articles/epi-analytics.html) | Incidence, epiweeks, epidemic curves, and disease-specific helpers | ~10 min | n/a | n/a |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -320,8 +320,8 @@ originally estimated** — reading the package's own authoritative "in order" te
 QC-feedback/survey-report are explicitly "feeds/tasks you reach for as needed," not forced
 continuations, so they got a metadata strip but not an invented linear "step N of 10." Verified with
 a full local `pkgdown::build_site()` (unlocked via `RSTUDIO_PANDOC` pointing at RStudio's bundled
-Quarto Pandoc — see `docs/roadmap.md`'s Phase 1 note and [[reference_pkgdown_site]]), not just
-`check_pkgdown()`: every reference page and all 25 articles built clean, `extra.css` copied and
+Quarto Pandoc — see this redesign's own Phase 1 note above on the CI-only-catchable `subtitle:`
+bug), not just `check_pkgdown()`: every reference page and all 25 articles built clean, `extra.css` copied and
 linked, both fenced-div classes render correctly in the actual output. Found but out of scope to fix
 here: `epi-analytics.Rmd`'s code chunks reference undefined objects (`result`, `population_data`, …)
 and aren't actually runnable as shipped — logged as a nice-to-have. (3) a bundled task

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -306,7 +306,25 @@ proposal to use pkgdown's `subtitle:` field for sub-grouping *within* a
 group's `contents:` turned out not to be how pkgdown actually works — `subtitle` is a whole-section
 heading, like `title`, not a per-item nesting key — and was caught by a real CI failure
 (`build_reference_index()`: "contents[1] must be a string") before merge; reverted to flat,
-thoughtfully-ordered lists. (2) article metadata + path navigation, (3) a bundled task
+thoughtfully-ordered lists. (2) article metadata + path navigation — **shipped**: a metadata strip
+(`::: {.eri-guide-meta}`, a pandoc fenced div styled from a new `pkgdown/extra.css`) added to all 25
+vignettes, naming its type (Walkthrough/Desk reference/Deep-dive), a time estimate, what it needs
+(nothing/Azure/Azure+ODK), and whether it's sandbox-safe (runs on `atlantis` or fully offline vs.
+touches/illustrates a real country); the README's guide table gained matching Time/Needs/Sandbox
+columns. Prev/next path footers (`::: {.eri-path-nav}`) added, but to **7 articles, not the ~14
+originally estimated** — reading the package's own authoritative "in order" text
+(`getting-started.Rmd`, `docs/guides.md`) before implementing found the real strict sequence is only
+`connections-guide` (shared first step) → then either the 3-step DA core
+(`da-onboard-guide` → `da-ingest-guide` → `da-logs-guide`) or the 3-step Epi core
+(`epi-research-guide` → `epi-reconcile-guide` → `epi-dq-guide`); CMR/ODK/ad-hoc/reporting/
+QC-feedback/survey-report are explicitly "feeds/tasks you reach for as needed," not forced
+continuations, so they got a metadata strip but not an invented linear "step N of 10." Verified with
+a full local `pkgdown::build_site()` (unlocked via `RSTUDIO_PANDOC` pointing at RStudio's bundled
+Quarto Pandoc — see `docs/roadmap.md`'s Phase 1 note and [[reference_pkgdown_site]]), not just
+`check_pkgdown()`: every reference page and all 25 articles built clean, `extra.css` copied and
+linked, both fenced-div classes render correctly in the actual output. Found but out of scope to fix
+here: `epi-analytics.Rmd`'s code chunks reference undefined objects (`result`, `population_data`, …)
+and aren't actually runnable as shipped — logged as a nice-to-have. (3) a bundled task
 registry (`inst/registry/task_map.yaml`) plus a generated task-index article, (4) an `index.md`
 homepage with role cards and diagrams, (5) `eri_guide()` — an `eri_dq_review()`-style interactive
 console wizard walking the task registry, (6) next-step epilogues on pipeline functions, (7) wizard

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,38 @@
+/* Guide metadata strip: type / time / needs / sandbox-safe, shown at the top of every article.
+   Answers "can I run this without breaking a real country" before the reader reads a word. */
+.eri-guide-meta {
+  display: inline-block;
+  font-size: 0.92rem;
+  color: #5b6678;
+  background: #f3f6fa;
+  border: 1px solid #dde6ef;
+  border-radius: 6px;
+  padding: 0.5rem 0.9rem;
+  margin: 0.5rem 0 1.5rem;
+}
+.eri-guide-meta strong {
+  color: #001737;
+}
+.eri-guide-meta .eri-sandbox-yes {
+  color: #00873f;
+  font-weight: 600;
+}
+.eri-guide-meta .eri-sandbox-no {
+  color: #96302a;
+  font-weight: 600;
+}
+
+/* Prev/next path footer, shown at the bottom of articles that are part of a strictly ordered
+   role path (see docs/guides.md and getting-started.Rmd's "New here? Do these in order"). */
+.eri-path-nav {
+  margin-top: 2.5rem;
+  padding: 0.9rem 1.1rem;
+  background: #eaf3ee;
+  border: 1px solid #cfe6d6;
+  border-left: 4px solid #00873f;
+  border-radius: 6px;
+  font-size: 0.92rem;
+}
+.eri-path-nav strong {
+  color: #001737;
+}

--- a/vignettes/adding-a-program.Rmd
+++ b/vignettes/adding-a-program.Rmd
@@ -16,12 +16,13 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~20 min &middot; needs: nothing &middot; sandbox-safe: yes (local schema files, dry-run only)
+**Walkthrough** &middot; ~20 min for the shipped example below &middot; needs: nothing &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (local schema files, dry-run only)
 :::
 
 This vignette walks through the full process of adding a new disease program
 to `erifunctions` -- from generating skeleton schemas to opening a pull request.
-Estimated time: 1--2 hours for a new country/disease combination.
+Estimated time for a *real* new country/disease combination (not just running the
+example below): 1--2 hours.
 
 ## 1. Generate skeleton schemas
 

--- a/vignettes/adding-a-program.Rmd
+++ b/vignettes/adding-a-program.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~20 min &middot; needs: nothing &middot; sandbox-safe: yes (local schema files, dry-run only)
+:::
+
 This vignette walks through the full process of adding a new disease program
 to `erifunctions` -- from generating skeleton schemas to opening a pull request.
 Estimated time: 1--2 hours for a new country/disease combination.

--- a/vignettes/connections-guide.Rmd
+++ b/vignettes/connections-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~20 min &middot; needs: Azure + ODK &middot; sandbox-safe: no (illustrates real Azure/SharePoint/Teams destinations)
+:::
+
 `erifunctions` talks to four outside services on your behalf, **Azure** (where the data lives),
 **ODK Central** (where field submissions come from), **SharePoint** (shared files), and **Teams**
 (notifications). This is the one place that shows how to connect to each and **confirm it works**.
@@ -268,3 +272,9 @@ Now that you can connect, the role guides put these connections to work:
 
 For every connection function grouped together, see the **Connections & authentication** section of
 the [reference](../reference/index.html).
+
+::: {.eri-path-nav}
+**Step 1, shared by both role paths.** Next: [Onboarding a new program](da-onboard-guide.html)
+(Data Analyst path) &middot; or [A complete research workflow](epi-research-guide.html)
+(Epidemiologist path).
+:::

--- a/vignettes/connections-guide.Rmd
+++ b/vignettes/connections-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~20 min &middot; needs: Azure + ODK &middot; sandbox-safe: no (illustrates real Azure/SharePoint/Teams destinations)
+**Walkthrough** &middot; ~20 min &middot; needs: Azure + ODK &middot; sandbox-safe: [no]{.eri-sandbox-no} (illustrates real Azure/SharePoint/Teams destinations)
 :::
 
 `erifunctions` talks to four outside services on your behalf, **Azure** (where the data lives),
@@ -274,7 +274,7 @@ For every connection function grouped together, see the **Connections & authenti
 the [reference](../reference/index.html).
 
 ::: {.eri-path-nav}
-**Step 1, shared by both role paths.** Next: [Onboarding a new program](da-onboard-guide.html)
+**Step 1, shared by both role paths.** Next: [Onboarding a new country, disease, or data type](da-onboard-guide.html)
 (Data Analyst path) &middot; or [A complete research workflow](epi-research-guide.html)
 (Epidemiologist path).
 :::

--- a/vignettes/da-adhoc-guide.Rmd
+++ b/vignettes/da-adhoc-guide.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: no (illustrates a real catalog rollup)
+**Walkthrough** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: [no]{.eri-sandbox-no} (illustrates a real catalog rollup)
 :::
 
 "How many malaria cases by province this year?" "Pull treatment coverage for these three countries."

--- a/vignettes/da-adhoc-guide.Rmd
+++ b/vignettes/da-adhoc-guide.Rmd
@@ -11,6 +11,10 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: no (illustrates a real catalog rollup)
+:::
+
 "How many malaria cases by province this year?" "Pull treatment coverage for these three countries."
 Ad-hoc requests are a daily part of the job, and they usually mean the same thing: **combine a few
 approved datasets and compute a number.** [`eri_query()`](../reference/eri_query.html) does that with

--- a/vignettes/da-cheatsheet.Rmd
+++ b/vignettes/da-cheatsheet.Rmd
@@ -7,6 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~5 min &middot; needs: n/a &middot; sandbox-safe: n/a
+:::
+
 *One page. The functions you actually use, the path model, and which pipeline to reach for. Pair with
 [the data-model card](data-model-card.html) for the channel-vs-measure decision, and the role guides
 when you want the full walkthrough.*

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~25 min &middot; needs: Azure &middot; sandbox-safe: no (stage/approve need a real registered country)
+**Walkthrough** &middot; ~25 min &middot; needs: Azure &middot; sandbox-safe: [no]{.eri-sandbox-no} (stage/approve need a real registered country)
 :::
 
 Every month, country programmes file a **Case Management Report (CMR)**, a filled Excel template of

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~25 min &middot; needs: Azure &middot; sandbox-safe: no (stage/approve need a real registered country)
+:::
+
 Every month, country programmes file a **Case Management Report (CMR)**, a filled Excel template of
 treatment, training, and survey numbers. This guide, for a **Data Analyst**, walks the monthly job:
 take that incoming Excel, **upload** it to Azure, **stage** it, **parse** each sheet, and **approve** it

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
 The [CMR guide](da-cmr-guide.html) and the [QC/feedback guide](da-qc-feedback-guide.html) both walk

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+:::
+
 The [CMR guide](da-cmr-guide.html) and the [QC/feedback guide](da-qc-feedback-guide.html) both walk
 the DQ pipeline as a **sequence of functions you call yourself**: check, resolve each flag, close out
 the entry, re-run, approve. That's the scriptable core, and it has to exist for automation. But you

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~35 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+:::
+
 This is a hands-on, **start-to-finish walkthrough** of getting a surveillance dataset into the
 Carter Center data system, the daily work of a **Data Analyst (DA)**. It is written for domain
 experts who are *not* software developers. Work through it once, in order, and you will have done
@@ -519,3 +523,8 @@ This is one of a planned set of short, task-oriented guides, **one for each comm
 or epidemiologist does. See [the guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md)
 for what exists today and what is coming, and the [reference](../reference/index.html) for the full
 menu of functions grouped by purpose.
+
+::: {.eri-path-nav}
+**Data Analyst path, step 3 of 4.** &larr; [Onboarding a new program](da-onboard-guide.html)
+&middot; Next: [Triaging the error & DQ log backlog](da-logs-guide.html) &rarr;
+:::

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~35 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+**Walkthrough** &middot; ~35 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
 This is a hands-on, **start-to-finish walkthrough** of getting a surveillance dataset into the

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+:::
+
 Every operation `erifunctions` runs, an ingest, an approval, an ODK sync, **leaves a log** in
 Azure. When something fails, or a data-quality check raises issues, that log is the record. This guide
 is for a **Data Analyst** working the **backlog**: finding what failed or needs review with
@@ -252,3 +256,9 @@ teammate. The logs you are reading are written by the workflows in the other gui
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) and the
 **Logs & triage** group in the [reference](../reference/index.html).
+
+::: {.eri-path-nav}
+**Data Analyst path, step 4 of 4 (last).** &larr; [Ingesting a surveillance dataset](da-ingest-guide.html)
+&middot; Then, as those feeds arrive: [monthly CMR reports](da-cmr-guide.html) and
+[ODK Central forms](da-odk-guide.html).
+:::

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
 Every operation `erifunctions` runs, an ingest, an approval, an ODK sync, **leaves a log** in

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~40 min &middot; needs: Azure + ODK &middot; sandbox-safe: no (uses a real country's ODK project)
+**Walkthrough** &middot; ~40 min &middot; needs: Azure + ODK &middot; sandbox-safe: [no]{.eri-sandbox-no} (uses a real country's ODK project)
 :::
 
 **ODK Central** is where field data is born, survey teams collect submissions on phones, and they

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~40 min &middot; needs: Azure + ODK &middot; sandbox-safe: no (uses a real country's ODK project)
+:::
+
 **ODK Central** is where field data is born, survey teams collect submissions on phones, and they
 land on an ODK Central server. This is a hands-on walkthrough for a **Data Analyst (DA)** of the whole
 loop: connect to ODK Central, stand up a form, **monitor** it, **manage** who collects on it, and

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+:::
+
 Before any data can flow through `erifunctions`, the **space for it has to exist**: a data-quality
 schema that describes the data, and the `raw → staged → processed` folders it will move through. This
 guide is for a **Data Analyst** standing up that space for a new country, disease, or data type. It is
@@ -298,3 +302,8 @@ schemas. The data guides take it from here:
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) for
 the full set, and the [reference](../reference/index.html) for every function grouped by purpose.
+
+::: {.eri-path-nav}
+**Data Analyst path, step 2 of 4.** &larr; [Connecting to the services](connections-guide.html)
+&middot; Next: [Ingesting a surveillance dataset](da-ingest-guide.html) &rarr;
+:::

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: yes (runs on `atlantis`)
+**Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
 Before any data can flow through `erifunctions`, the **space for it has to exist**: a data-quality

--- a/vignettes/da-qc-feedback-guide.Rmd
+++ b/vignettes/da-qc-feedback-guide.Rmd
@@ -11,6 +11,10 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: yes (offline data.frame, no Azure)
+:::
+
 When a country sends a data extract, quality-checking it is only half the job, the other half is
 telling them, **specifically and clearly, what needs fixing**. `run_dq_checks()` does both: it
 **auto-corrects** the safe, unambiguous things (and records what it changed) and **flags** the rest for

--- a/vignettes/da-qc-feedback-guide.Rmd
+++ b/vignettes/da-qc-feedback-guide.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: yes (offline data.frame, no Azure)
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: [no]{.eri-sandbox-no} (the QC steps are offline, but the "Notify the team" aside illustrates a real country's Teams channel)
 :::
 
 When a country sends a data extract, quality-checking it is only half the job, the other half is

--- a/vignettes/da-reporting-guide.Rmd
+++ b/vignettes/da-reporting-guide.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: yes (no Azure touched)
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (no Azure touched)
 :::
 
 Once data is approved, a lot of the job is turning it into **outputs**, a table for a memo, a figure

--- a/vignettes/da-reporting-guide.Rmd
+++ b/vignettes/da-reporting-guide.Rmd
@@ -11,6 +11,10 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: yes (no Azure touched)
+:::
+
 Once data is approved, a lot of the job is turning it into **outputs**, a table for a memo, a figure
 for proceedings, a workbook for a partner, a slide deck for a meeting. `erifunctions` ships a small,
 consistent **reporting toolkit** so those come out on-brand without fiddling with styling each time.

--- a/vignettes/da-survey-report-guide.Rmd
+++ b/vignettes/da-survey-report-guide.Rmd
@@ -11,6 +11,10 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: yes (offline synthetic data, no Azure)
+:::
+
 Once a survey has been pulled from ODK, cleaned, and **approved**, the last step is the deliverable: a
 summary, a results table, a short report. This guide takes an approved survey dataset to a final
 summary using the disease helpers, then packages it for sharing.

--- a/vignettes/da-survey-report-guide.Rmd
+++ b/vignettes/da-survey-report-guide.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = FALSE)
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: yes (offline synthetic data, no Azure)
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (offline synthetic data, no Azure)
 :::
 
 Once a survey has been pulled from ODK, cleaned, and **approved**, the last step is the deliverable: a

--- a/vignettes/data-model-card.Rmd
+++ b/vignettes/data-model-card.Rmd
@@ -7,6 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~5 min &middot; needs: n/a &middot; sandbox-safe: n/a
+:::
+
 *The one concept everything else rests on. If you can answer the four questions below for a dataset,
 you can address it, ingest it, and approve it. Run `eri_data_model()` to see the live list of allowed
 values.*

--- a/vignettes/dq-pipeline.Rmd
+++ b/vignettes/dq-pipeline.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Deep-dive** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: n/a (bundled schema, offline)
+:::
+
 The DQ pipeline is a schema-driven system for cleaning and validating
 surveillance data before analysis. A single YAML schema file describes the
 expected columns, types, ranges, allowed values, translations, and

--- a/vignettes/epi-analytics.Rmd
+++ b/vignettes/epi-analytics.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~10 min &middot; needs: n/a &middot; sandbox-safe: n/a
+:::
+
 This vignette covers the epidemiological helper functions for malaria, lymphatic
 filariasis, and onchocerciasis analyses, from computing incidence rates and
 epiweek dates to LF pooled prevalence and onchocerciasis programme-status maps.

--- a/vignettes/epi-dq-guide.Rmd
+++ b/vignettes/epi-dq-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: yes (fully offline, no Azure, no real data)
+:::
+
 A fresh surveillance extract can be **valid cell-by-cell and still wrong epidemiologically**, a week
 that suddenly triples, a reporting week that never arrived, a count that exceeds what was tested. This
 guide, for **epidemiologists**, is about that second layer: after the basic
@@ -224,3 +228,8 @@ interrogated.
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) for the
 full set, and the [reference](../reference/index.html) for the anomaly-detector help pages.
+
+::: {.eri-path-nav}
+**Epidemiologist path, step 4 of 4 (last).** &larr; [Reconciling localities](epi-reconcile-guide.html)
+&middot; That's the core path — dip into [Epi analytics](epi-analytics.html) as needed.
+:::

--- a/vignettes/epi-dq-guide.Rmd
+++ b/vignettes/epi-dq-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: yes (fully offline, no Azure, no real data)
+**Walkthrough** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (fully offline, no Azure, no real data)
 :::
 
 A fresh surveillance extract can be **valid cell-by-cell and still wrong epidemiologically**, a week

--- a/vignettes/epi-reconcile-guide.Rmd
+++ b/vignettes/epi-reconcile-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: yes (offline string-match; writes nothing to Azure)
+:::
+
 Surveillance data arrives with **messy, free-text place names**, `"Jínova"`, `"JUAN DE HERRERA"`,
 `"S. Juan"`: that have to be matched to the **canonical admin units** in an authoritative boundary
 before you can aggregate cases, compute incidence, or map anything. Doing that by hand is slow and
@@ -232,3 +236,8 @@ uncertain ones flagged rather than hidden. From here:
 
 See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) and the
 [reference](../reference/index.html) for the full set.
+
+::: {.eri-path-nav}
+**Epidemiologist path, step 3 of 4.** &larr; [A complete research workflow](epi-research-guide.html)
+&middot; Next: [Catching anomalies in a new extract](epi-dq-guide.html) &rarr;
+:::

--- a/vignettes/epi-reconcile-guide.Rmd
+++ b/vignettes/epi-reconcile-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: yes (offline string-match; writes nothing to Azure)
+**Walkthrough** &middot; ~15 min &middot; needs: nothing &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (offline string-match; writes nothing to Azure)
 :::
 
 Surveillance data arrives with **messy, free-text place names**, `"Jínova"`, `"JUAN DE HERRERA"`,

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Walkthrough** &middot; ~40 min &middot; needs: Azure &middot; sandbox-safe: yes (public `mtcars` under a demo project)
+**Walkthrough** &middot; ~40 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (public `mtcars` under a demo project)
 :::
 
 This is a hands-on, **start-to-finish walkthrough** of running a research study with

--- a/vignettes/epi-research-guide.Rmd
+++ b/vignettes/epi-research-guide.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~40 min &middot; needs: Azure &middot; sandbox-safe: yes (public `mtcars` under a demo project)
+:::
+
 This is a hands-on, **start-to-finish walkthrough** of running a research study with
 `erifunctions`. It is written for **epidemiologists**, domain experts who are *not*
 software developers. You do not need to memorise anything: work through it once, in order,
@@ -520,3 +524,8 @@ for what exists today and what is coming.
 
 For the full menu of functions grouped by purpose, see the
 [reference](../reference/index.html).
+
+::: {.eri-path-nav}
+**Epidemiologist path, step 2 of 4.** &larr; [Connecting to the services](connections-guide.html)
+&middot; Next: [Reconciling localities to admin units](epi-reconcile-guide.html) &rarr;
+:::

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Walkthrough** &middot; ~10 min &middot; needs: nothing &middot; sandbox-safe: n/a (install + orientation only)
+:::
+
 `erifunctions` is the Carter Center ERI team's R package, the way **Data Analysts** and
 **Epidemiologists** work with TCC's Azure-centred data system across countries (Haiti, DR, Uganda,
 OEPA, …) and diseases (malaria, oncho, LF, SCH, STH). You install it, authenticate through your

--- a/vignettes/onboarding.Rmd
+++ b/vignettes/onboarding.Rmd
@@ -7,6 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~10 min &middot; needs: n/a &middot; sandbox-safe: n/a
+:::
+
 This is the **starting page** for a new ERI Data Analyst. It strings the reference and the run-it-live
 guides into a paced path with checkpoints, so onboarding is repeatable and self-serve rather than
 tribal knowledge. It ships with the package, so when a guide or function changes, this path changes

--- a/vignettes/orientation.Rmd
+++ b/vignettes/orientation.Rmd
@@ -7,6 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~5 min &middot; needs: n/a &middot; sandbox-safe: n/a
+:::
+
 The big picture for a new Data Analyst, the data system, the human-gated pipeline, and where your
 tasks live. Read this once before the hands-on guides; it's also the basis for a first training
 session. (For the step-by-step path, see [Onboarding](onboarding.html).)

--- a/vignettes/sharepoint-workflow.Rmd
+++ b/vignettes/sharepoint-workflow.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Deep-dive** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: no (connects to the real SharePoint site)
+:::
+
 This vignette covers the full SharePoint read/write pattern using the `eri_sharepoint_*`
 functions. These functions require the `Microsoft365R` package:
 

--- a/vignettes/sharepoint-workflow.Rmd
+++ b/vignettes/sharepoint-workflow.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Deep-dive** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: no (connects to the real SharePoint site)
+**Deep-dive** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: [no]{.eri-sandbox-no} (connects to the real SharePoint site)
 :::
 
 This vignette covers the full SharePoint read/write pattern using the `eri_sharepoint_*`

--- a/vignettes/spatial-workflow.Rmd
+++ b/vignettes/spatial-workflow.Rmd
@@ -15,6 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+::: {.eri-guide-meta}
+**Deep-dive** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: no (illustrates real country boundaries)
+:::
+
 The spatial workflow covers three use cases: loading canonical admin boundaries
 from Azure, joining GPS coordinates to those boundaries, and producing
 programmatic maps. All functions require the `sf` package.

--- a/vignettes/spatial-workflow.Rmd
+++ b/vignettes/spatial-workflow.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.eri-guide-meta}
-**Deep-dive** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: no (illustrates real country boundaries)
+**Deep-dive** &middot; ~15 min &middot; needs: Azure &middot; sandbox-safe: [no]{.eri-sandbox-no} (illustrates real country boundaries)
 :::
 
 The spatial workflow covers three use cases: loading canonical admin boundaries

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -7,6 +7,10 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~5 min &middot; needs: n/a &middot; sandbox-safe: n/a
+:::
+
 *The errors a DA actually hits, what they mean, and the fix. Then: how to work the shared error/DQ log
 backlog with `eri_logs()`.*
 


### PR DESCRIPTION
## Summary

Phase 2 of the docs-site redesign (following Phase 1's reference reorg, v0.9.20). Full 8-phase plan in `docs/roadmap.md`.

- **Metadata strip on all 25 vignettes** (`::: {.eri-guide-meta}`, a pandoc fenced div): type (Walkthrough / Desk reference / Deep-dive), time estimate, needs (nothing / Azure / Azure + ODK), and sandbox-safe (runs on `atlantis` / fully offline, vs. touches or illustrates a real country). Answers "can I run this without breaking a real country" before reading a word.
- **Prev/next path footers on 7 articles** — not the ~14 originally estimated. Before implementing, I checked the package's own authoritative "in order" text (`getting-started.Rmd`, `docs/guides.md`) rather than assuming the original estimate was right, and found the real strict sequence is only `connections-guide` (shared first step) → the 3-step DA core (onboard → ingest → logs) or the 3-step Epi core (research → reconcile → DQ). CMR/ODK/ad-hoc/reporting/QC-feedback/survey-report guides are explicitly "feeds you reach for as needed," not forced continuations — they get a metadata strip, not an invented "step N of 10."
- New `pkgdown/extra.css` (pkgdown auto-copies and links any `pkgdown/extra.css`/`extra.js` — verified against pkgdown's own source before relying on it, learning from Phase 1's `subtitle:` mistake).
- README's guide table gains matching Time/Needs/Sandbox columns.
- Found but out of scope here: `epi-analytics.Rmd`'s chunks reference undefined objects and aren't actually runnable as shipped — logged as a nice-to-have.

## Test plan
- [x] Verified pkgdown's `extra.css`/fenced-div mechanisms directly against its source (`copy_assets()`, `data_template()`) before building on them
- [x] `knitr::knit()` dry-run on all 25 vignettes — chunks parse
- [x] Real full render (`rmarkdown::render()`, actual `html_vignette` format) of a representative article confirms both the metadata strip and path footer render correctly as `<div>`s with working links
- [x] **Full local `pkgdown::build_site()`** (unlocked via `RSTUDIO_PANDOC` pointing at RStudio's bundled Quarto Pandoc, a real capability gap discovered fixing Phase 1's CI-only-catchable bug) — every reference page and all 25 articles built clean; confirmed `extra.css` copied to the site root and linked from an article page
- [x] Full local test suite — 0 failures (unaffected, docs-only change)
- [ ] CI (R-CMD-check, pkgdown)