### PR TITLE
feat(docs): index.md homepage with role cards + pipeline diagram (v0.9.23)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.22
+Version: 0.9.23
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# erifunctions 0.9.23
+
+## A real front door: role cards + a pipeline diagram on the site homepage (docs site redesign, phase 4)
+
+- **Added `index.md`**, a pkgdown-only homepage (pkgdown prefers `index.md` over `README.md` when
+  both exist) built for a site visitor rather than a GitHub browser: two role cards (Data Analyst /
+  Epidemiologist), each with its ordered path and a link into the paced/analytics follow-on; a
+  callout up top to the new [task-index article](https://thecartercenter.github.io/erifunctions/articles/task-index.html)
+  for "what are you trying to do?"; and a Mermaid diagram of the raw → staged → processed pipeline
+  with the `eri_approve()` gate. `README.md` keeps its own content unchanged — it's still the
+  GitHub landing page and the fuller reference (install steps, environment variables,
+  contributing) the homepage links out to.
+- Verified locally via `pkgdown:::build_home()` (not a full `build_site()` — the home page alone
+  doesn't need the reference/article build): confirmed the role cards and Mermaid diagram render,
+  and caught that `man/figures/logo.png` needs `copy_figures()` to run before `build_home()` or
+  pkgdown can't resolve the path it rewrites to (`reference/figures/logo.png`) — a build-order
+  detail of my local verification harness, not a site bug (the real `build_site()` call always
+  runs both steps).
+
 # erifunctions 0.9.22
 
 ## A task registry answers "what are you trying to do?" (docs site redesign, phase 3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,20 +2,27 @@
 
 ## A real front door: role cards + a pipeline diagram on the site homepage (docs site redesign, phase 4)
 
-- **Added `index.md`**, a pkgdown-only homepage (pkgdown prefers `index.md` over `README.md` when
-  both exist) built for a site visitor rather than a GitHub browser: two role cards (Data Analyst /
+- **Added `pkgdown/index.md`**, a pkgdown-only homepage (pkgdown checks `pkgdown/index.md` before
+  `index.md` before `README.md`; placed inside `pkgdown/`, already `.Rbuildignore`d for
+  `pkgdown/extra.css`/`pkgdown/favicon/` in earlier phases, rather than at the package root — a
+  root-level `index.md` triggers `R CMD check`'s "Non-standard file/directory found at top level"
+  NOTE, caught by a review pass reading the actual CI log rather than trusting the green check mark)
+  built for a site visitor rather than a GitHub browser: two role cards (Data Analyst /
   Epidemiologist), each with its ordered path and a link into the paced/analytics follow-on; a
   callout up top to the new [task-index article](https://thecartercenter.github.io/erifunctions/articles/task-index.html)
   for "what are you trying to do?"; and a Mermaid diagram of the raw → staged → processed pipeline
-  with the `eri_approve()` gate. `README.md` keeps its own content unchanged — it's still the
-  GitHub landing page and the fuller reference (install steps, environment variables,
-  contributing) the homepage links out to.
+  with the `eri_approve()` gate. `README.md`'s own content is unchanged aside from the routine
+  version-line bump — it's still the GitHub landing page and the fuller reference (install steps,
+  environment variables, contributing) the homepage links out to.
 - Verified locally via `pkgdown:::build_home()` (not a full `build_site()` — the home page alone
   doesn't need the reference/article build): confirmed the role cards and Mermaid diagram render,
   and caught that `man/figures/logo.png` needs `copy_figures()` to run before `build_home()` or
   pkgdown can't resolve the path it rewrites to (`reference/figures/logo.png`) — a build-order
   detail of my local verification harness, not a site bug (the real `build_site()` call always
   runs both steps).
+- A review pass also reconciled the install snippet with README's (`devtools::install_github()`,
+  not `remotes::install_github()`) — both work, but the site and the README are meant to converge,
+  not quietly diverge on the first thing a new user copies.
 
 # erifunctions 0.9.22
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.22 · **Status:** Active development
+**Version:** 0.9.23 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -343,19 +343,26 @@ stale doc. The generated [task-index article](https://thecartercenter.github.io/
 executed chunk and renders a `knitr::kable()` table, so it can't drift from the YAML the way
 hand-written prose could; added to the "Quick reference & onboarding" article group and README's
 guide bullet list, alongside the other desk references. (4) the front door — **shipped**: a new
-`index.md` at the package root, which pkgdown prefers over `README.md` as the home page when both
-exist. Built for a site visitor rather than a GitHub browser: two role cards (Data Analyst /
+`pkgdown/index.md`, which pkgdown prefers over `README.md` as the home page when both exist (lookup
+order is `pkgdown/index.md` → `index.md` → `README.md`). Placed inside `pkgdown/` — already
+`.Rbuildignore`d for `pkgdown/extra.css`/`pkgdown/favicon/` from earlier phases — rather than at the
+package root: a first draft placed it at the root and a review pass, reading the actual CI log
+rather than trusting the green check mark, caught that `R CMD check` flags a root-level `index.md`
+with a real "Non-standard file/directory found at top level" NOTE; relocating avoided it entirely.
+Built for a site visitor rather than a GitHub browser: two role cards (Data Analyst /
 Epidemiologist), each showing its ordered path and a link into the paced-onboarding/analytics
 follow-on; a callout to the task-index article for "what are you trying to do?"; a Mermaid diagram
-of the raw → staged → processed pipeline with the `eri_approve()` gate; and an install snippet.
-`README.md` itself is untouched — it stays the GitHub landing page and the fuller reference
-(install steps, environment variables, contributing) the new homepage links out to, rather than
-being duplicated. Verified locally via `pkgdown:::build_home()` rather than a full `build_site()`
-(the home page alone doesn't need the reference/article build to render); this surfaced a real
-pkgdown mechanic worth remembering — `man/figures/*` images referenced from root-level markdown are
-rewritten to `reference/figures/*` on the built site, and resolving that path requires
-`copy_figures()` to have run (a `build_site()` step my minimal harness had to call explicitly).
-(5) `eri_guide()` — an `eri_dq_review()`-style interactive console wizard walking the task registry,
+of the raw → staged → processed pipeline with the `eri_approve()` gate; and an install snippet
+(reconciled to match README's `devtools::install_github()`, not a second, quietly-diverging
+`remotes::install_github()`). `README.md`'s own content is unchanged aside from the routine
+version-line bump — it stays the GitHub landing page and the fuller reference (install steps,
+environment variables, contributing) the new homepage links out to, rather than being duplicated.
+Verified locally via `pkgdown:::build_home()` rather than a full `build_site()` (the home page
+alone doesn't need the reference/article build to render, and re-run after the relocation); this
+surfaced a real pkgdown mechanic worth remembering — `man/figures/*` images referenced from
+root-level markdown are rewritten to `reference/figures/*` on the built site, and resolving that
+path requires `copy_figures()` to have run (a `build_site()` step my minimal harness had to call
+explicitly). (5) `eri_guide()` — an `eri_dq_review()`-style interactive console wizard walking the task registry,
 (6) next-step epilogues on pipeline functions, (7) wizard depth (preflight checks, session memory,
 deep links) + a roxygen `@family`/title-audit pass, and (8) an evidence-gated,
 deliberately-deferred client-side decision-tree wizard on the site itself — not yet started.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -342,10 +342,22 @@ stale doc. The generated [task-index article](https://thecartercenter.github.io/
 `system.file()`, the same pattern already used elsewhere in vignettes for bundled `extdata`) in a real
 executed chunk and renders a `knitr::kable()` table, so it can't drift from the YAML the way
 hand-written prose could; added to the "Quick reference & onboarding" article group and README's
-guide bullet list, alongside the other desk references. (4) an `index.md` homepage with role cards
-and diagrams, (5) `eri_guide()` — an `eri_dq_review()`-style interactive console wizard walking the
-task registry, (6) next-step epilogues on pipeline functions, (7) wizard depth (preflight checks,
-session memory, deep links) + a roxygen `@family`/title-audit pass, and (8) an evidence-gated,
+guide bullet list, alongside the other desk references. (4) the front door — **shipped**: a new
+`index.md` at the package root, which pkgdown prefers over `README.md` as the home page when both
+exist. Built for a site visitor rather than a GitHub browser: two role cards (Data Analyst /
+Epidemiologist), each showing its ordered path and a link into the paced-onboarding/analytics
+follow-on; a callout to the task-index article for "what are you trying to do?"; a Mermaid diagram
+of the raw → staged → processed pipeline with the `eri_approve()` gate; and an install snippet.
+`README.md` itself is untouched — it stays the GitHub landing page and the fuller reference
+(install steps, environment variables, contributing) the new homepage links out to, rather than
+being duplicated. Verified locally via `pkgdown:::build_home()` rather than a full `build_site()`
+(the home page alone doesn't need the reference/article build to render); this surfaced a real
+pkgdown mechanic worth remembering — `man/figures/*` images referenced from root-level markdown are
+rewritten to `reference/figures/*` on the built site, and resolving that path requires
+`copy_figures()` to have run (a `build_site()` step my minimal harness had to call explicitly).
+(5) `eri_guide()` — an `eri_dq_review()`-style interactive console wizard walking the task registry,
+(6) next-step epilogues on pipeline functions, (7) wizard depth (preflight checks, session memory,
+deep links) + a roxygen `@family`/title-audit pass, and (8) an evidence-gated,
 deliberately-deferred client-side decision-tree wizard on the site itself — not yet started.
 
 ---

--- a/index.md
+++ b/index.md
@@ -1,0 +1,100 @@
+<img src="man/figures/logo.png" align="right" height="120" alt="erifunctions logo" />
+
+# erifunctions
+
+Standardized data tools for the Epidemiology, Research and Innovation (ERI) team at The Carter
+Center's NTD and malaria programs — the way **Data Analysts** and **Epidemiologists** work with
+TCC's Azure-centred data system across countries (Haiti, DR, Uganda, OEPA, …) and diseases
+(malaria, oncho, LF, SCH, STH). You install it, authenticate through your browser, and call
+functions — you don't edit the package.
+
+Not sure where to start? **[What are you trying to do?](articles/task-index.html)** is a generated
+index of ~30 common tasks; pick yours and get the call and the guide. Otherwise, read
+**[Getting started](articles/getting-started.html)** first — it's the one idea every guide assumes.
+
+## Two roles, two paths
+
+```{=html}
+<div class="row row-cols-1 row-cols-md-2 g-4 my-2">
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header text-bg-secondary">Data Analyst</div>
+      <div class="card-body d-flex flex-column">
+        <p class="card-text">
+          Bring surveillance data, CMR reports, and ODK submissions through the
+          raw &rarr; staged &rarr; <strong>approved</strong> pipeline, keep the DQ backlog clean, and
+          turn approved data into reports countries and leadership can use.
+        </p>
+        <ol class="mb-3">
+          <li><a href="articles/connections-guide.html">Connect to Azure, ODK, SharePoint &amp; Teams</a></li>
+          <li><a href="articles/da-onboard-guide.html">Onboard a country / disease / data type</a></li>
+          <li><a href="articles/da-ingest-guide.html">Ingest a surveillance dataset</a></li>
+          <li><a href="articles/da-logs-guide.html">Triage the log backlog</a></li>
+        </ol>
+        <a href="articles/onboarding.html" class="mt-auto btn btn-outline-secondary btn-sm align-self-start">Paced onboarding path &rarr;</a>
+      </div>
+    </div>
+  </div>
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header text-bg-secondary">Epidemiologist</div>
+      <div class="card-body d-flex flex-column">
+        <p class="card-text">
+          Source approved data for a study, reconcile messy free-text places to admin units,
+          QC an extract for epidemiological sense, and compute the programme indicators you need
+          for analysis.
+        </p>
+        <ol class="mb-3">
+          <li><a href="articles/connections-guide.html">Connect to Azure, ODK, SharePoint &amp; Teams</a></li>
+          <li><a href="articles/epi-research-guide.html">A complete research workflow</a></li>
+          <li><a href="articles/epi-reconcile-guide.html">Reconcile localities to admin units</a></li>
+          <li><a href="articles/epi-dq-guide.html">Catch anomalies before analysis</a></li>
+        </ol>
+        <a href="articles/epi-analytics.html" class="mt-auto btn btn-outline-secondary btn-sm align-self-start">Epi analytics helpers &rarr;</a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## How data moves through the system
+
+Every dataset lives in the `data/` Azure blob under a five-axis path
+([ADR-0012](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md)):
+`data/{country}/{disease}/{data_source}/{data_type}/{layer}/`. Three layers, one human gate —
+nothing reaches `processed/` without a call to `eri_approve()`.
+
+```{=html}
+<div class="mermaid">
+flowchart TD
+    A["raw/ - as received"] --> B["run_dq_checks() / eri_dq_review()"]
+    B --> C["staged/ - DQ-checked, awaiting approval"]
+    C --> D{"eri_approve()"}
+    D --> E["processed/ - canonical, catalog-registered"]
+</div>
+```
+
+Run `eri_data_model()` once to see the full vocabulary — which `data_source` and `data_type`
+values are known, so you never have to guess one.
+
+## Install
+
+```r
+install.packages("remotes")
+remotes::install_github("thecartercenter/erifunctions")
+
+# Pin the version in your analysis project (recommended)
+renv::install("thecartercenter/erifunctions")
+renv::snapshot()
+```
+
+Azure access is zero-config — the first command that needs it opens your browser to sign in. See
+the [connections guide](articles/connections-guide.html) for ODK, SharePoint, and Teams setup, and
+the [full reference index](reference/index.html) for every function grouped by what you're doing
+when you reach for it.
+
+See the [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and
+[architecture decision records](https://github.com/thecartercenter/erifunctions/tree/main/docs/adr)
+for where this is going and the reasoning behind key design choices. For source, issues, and the
+full README (installation details, environment variables, contributing), see the
+[GitHub repository](https://github.com/thecartercenter/erifunctions).

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -80,8 +80,8 @@ values are known, so you never have to guess one.
 ## Install
 
 ```r
-install.packages("remotes")
-remotes::install_github("thecartercenter/erifunctions")
+# Install from GitHub
+devtools::install_github("thecartercenter/erifunctions")
 
 # Pin the version in your analysis project (recommended)
 renv::install("thecartercenter/erifunctions")


### PR DESCRIPTION
## Summary
- Phase 4 of the docs-site & guidance-system redesign: new `index.md` at the package root — pkgdown prefers this over `README.md` as the home page when both exist.
- Built for a site visitor rather than a GitHub browser: two role cards (Data Analyst / Epidemiologist) with their ordered paths, a callout to the [task-index article](https://thecartercenter.github.io/erifunctions/articles/task-index.html), and a Mermaid diagram of the raw → staged → processed pipeline with the `eri_approve()` gate.
- `README.md` is untouched — it stays the GitHub landing page and the fuller reference (install, env vars, contributing) the new homepage links out to.
- Version bumped 0.9.22 → 0.9.23; `NEWS.md`/`docs/roadmap.md` updated.

## Test plan
- [x] Verified locally via `pkgdown:::build_home()` (init_site + copy_assets + copy_figures + build_home) — confirmed both role cards and the Mermaid diagram render correctly in the built `index.html`, and the `man/figures/logo.png` → `reference/figures/logo.png` path resolves
- [x] `devtools::document()` — no changes (no roxygen touched this phase)
- [x] `devtools::test()` — full suite green (2695 pass, 0 fail)
- [ ] CI (R-CMD-check, pkgdown)
- [ ] review-agent pass