### PR TITLE
feat(guide): next-step epilogues on 5 pipeline functions (v0.9.25)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.24
+Version: 0.9.25
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,29 @@
+# erifunctions 0.9.25
+
+## Pipeline functions now hint at the next step, sourced from the task registry (docs site redesign, phase 6)
+
+- **Five pipeline functions now print a one-line "Next:" hint on success**, naming the natural
+  next task and its representative call: `eri_spatial_reconcile()` (→ join points to admin units
+  and map them), `eri_split_cmr()` (→ review and approve the CMR interactively),
+  `eri_ingest()` (→ triage the log backlog), `eri_approve_cmr()` (→ triage the log backlog), and
+  `eri_research_init()` (→ log progress and manage artifacts as you go). Gated at "full" verbosity
+  like every other narration (`.eri_say_info()`, `eri_verbosity("quiet")` silences it same as
+  anything else).
+- **The hook is a new optional `epilogue_after:` field in `inst/registry/task_map.yaml`**, not new
+  logic scattered across five files: each hooked leaf names one of its own `reference:` functions
+  as the unambiguous completion point, and `.eri_task_epilogue()` (`R/task_registry.R`) does the
+  actual lookup + printing generically from the leaf's own `next:` field. Only 5 of the ~32 tasks
+  got a hook — most multi-reference leaves (e.g. "log progress and manage artifacts," which covers
+  six functions called routinely throughout a study) have no single call that means "done with
+  this task," and guessing one would fire the hint at the wrong moment; those are deliberately left
+  unhooked rather than forced.
+- **`tests/testthat/test-task-map.R` gained 3 new integrity checks**: every `epilogue_after:`
+  value is in that leaf's own `reference:` list (so the hook can't name a function the task
+  doesn't even claim to touch), every leaf with `epilogue_after:` also has a `next:` to point to,
+  and no two leaves hook the same function — plus 3 runtime tests exercising
+  `.eri_task_epilogue()` directly (a real hook fires the right message, an unregistered function
+  name is silent, and quiet verbosity suppresses it).
+
 # erifunctions 0.9.24
 
 ## `eri_guide()`: an interactive console wizard over the task registry (docs site redesign, phase 5)

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,15 @@
   and no two leaves hook the same function — plus 3 runtime tests exercising
   `.eri_task_epilogue()` directly (a real hook fires the right message, an unregistered function
   name is silent, and quiet verbosity suppresses it).
+- A review pass caught that nothing exercised the real call sites in situ — every existing test
+  covering the 5 hooked functions' success paths, plus the new `.eri_task_epilogue()` unit tests,
+  but nothing that would fail if the `.eri_task_epilogue(...)` call at a real call site were ever
+  deleted or broken (it's wrapped in `tryCatch`, so a broken lookup fails silently, not loudly).
+  Added one `expect_message(..., "Next:")` per hooked function to `test-cmr.R` (×2), `test-dal.R`,
+  `test-research.R`, and `test-spatial.R`. Also tidied `eri_spatial_reconcile()`'s hook placement
+  to match the other four (assign, then epilogue, then return a bare variable — nothing after the
+  hook can fail) and added a one-line comment at `.eri_task_epilogue()`'s `[[1]]` explaining the
+  single-match assumption it relies on.
 
 # erifunctions 0.9.24
 

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -628,6 +628,7 @@ eri_split_cmr <- function(path, country, data_con = NULL,
   .eri_write_log(op_log, data_con, log_dir)
   if (had_error) cli::cli_abort(err_msg, call = NULL)
 
+  .eri_task_epilogue("eri_split_cmr")
   invisible(plan_tbl)
 }
 
@@ -910,6 +911,7 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
       "i" = "(see the Azure write warning above). The per-measure {.fn eri_approve} logs still exist; only this combined cross-reference is missing."
     ))
   }
+  .eri_task_epilogue("eri_approve_cmr")
   invisible(approved_tbl)
 }
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -1593,6 +1593,7 @@ eri_ingest <- function(path, country, disease,
   }
   .eri_write_log(op_log, data_con, log_dir)
   if (had_error) cli::cli_abort(err_msg, call = NULL)
+  .eri_task_epilogue("eri_ingest")
   invisible(result)
 }
 

--- a/R/research.R
+++ b/R/research.R
@@ -123,6 +123,7 @@ eri_research_init <- function(
     " " = "Manifest:   {.path research.yaml}",
     " " = "Azure:      {.path {azure_path}}"
   ))
+  .eri_task_epilogue("eri_research_init")
   invisible(yaml_path)
 }
 

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -837,6 +837,7 @@ eri_spatial_reconcile <- function(data,
       "{n_r} geocode{?s} flagged {.val geocoded_review} (low-confidence or parent mismatch) -- verify before use."
     )
   }
+  .eri_task_epilogue("eri_spatial_reconcile")
   tibble::as_tibble(out)
 }
 

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -837,8 +837,9 @@ eri_spatial_reconcile <- function(data,
       "{n_r} geocode{?s} flagged {.val geocoded_review} (low-confidence or parent mismatch) -- verify before use."
     )
   }
+  out <- tibble::as_tibble(out)
   .eri_task_epilogue("eri_spatial_reconcile")
-  tibble::as_tibble(out)
+  out
 }
 
 #### eri_landscan_upload ####

--- a/R/task_registry.R
+++ b/R/task_registry.R
@@ -29,11 +29,36 @@
         guide     = if (is.null(leaf$guide)) NA_character_ else leaf$guide,
         reference = I(list(leaf$reference)),
         next_ids  = I(list(leaf[["next"]])),
+        epilogue_after = if (is.null(leaf$epilogue_after)) NA_character_ else leaf$epilogue_after,
         stringsAsFactors = FALSE
       )
     }))
   })
   do.call(rbind, rows)
+}
+
+# Prints a one-line "what's next" hint sourced from the registry's own `next:` field, for the
+# handful of tasks where a single call is the unambiguous completion point (a leaf's
+# `epilogue_after:`, R/guide.R's phase-5 zero-arg check has no bearing here -- this fires
+# regardless of a task's argument shape, since the CALLER already ran it successfully).
+# Gated at "full" verbosity like any other narration (.eri_say_info(), R/console.R) and never
+# lets a lookup problem surface as an error -- this is pure narration, not part of the actual
+# operation that just succeeded.
+#' @keywords internal
+.eri_task_epilogue <- function(fn_name) {
+  tryCatch({
+    flat <- .eri_task_flatten()
+    hit  <- flat[!is.na(flat$epilogue_after) & flat$epilogue_after == fn_name, , drop = FALSE]
+    if (nrow(hit) == 0L) return(invisible(NULL))
+
+    next_ids <- hit$next_ids[[1]]
+    for (nid in next_ids) {
+      nxt <- flat[flat$id == nid, , drop = FALSE]
+      if (nrow(nxt) == 0L) next
+      .eri_say_info("Next: {.strong {nxt$title[[1]]}} -- {.code {nxt$call[[1]]}}")
+    }
+    invisible(NULL)
+  }, error = function(e) invisible(NULL))
 }
 
 #' Show the task registry: what are you trying to do?

--- a/R/task_registry.R
+++ b/R/task_registry.R
@@ -51,6 +51,9 @@
     hit  <- flat[!is.na(flat$epilogue_after) & flat$epilogue_after == fn_name, , drop = FALSE]
     if (nrow(hit) == 0L) return(invisible(NULL))
 
+    # [[1]] assumes exactly one match -- enforced by test-task-map.R's "no two leaves hook the
+    # same epilogue_after" check, since a second match's next_ids would otherwise be silently
+    # ignored rather than merged or erred.
     next_ids <- hit$next_ids[[1]]
     for (nid in next_ids) {
       nxt <- flat[flat$id == nid, , drop = FALSE]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.24 · **Status:** Active development
+**Version:** 0.9.25 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -379,7 +379,21 @@ requirement" call already made in Phase 3. `tests/testthat/test-guide.R` mirrors
 cross-checks `.eri_guide_zero_arg()`'s classification against every call actually in the bundled
 registry, not just synthetic examples. Cross-linked from `pkgdown/index.md`, `README.md`, and
 `_pkgdown.yml`'s "Start here" reference group.
-(6) next-step epilogues on pipeline functions, (7) wizard depth (preflight checks, session memory,
+(6) next-step epilogues on pipeline functions — **shipped**: 5 pipeline functions
+(`eri_spatial_reconcile()`, `eri_split_cmr()`, `eri_ingest()`, `eri_approve_cmr()`,
+`eri_research_init()`) now print a one-line "Next:" hint on success, sourced from the task
+registry's own `next:` field via a new internal `.eri_task_epilogue()` (`R/task_registry.R`) —
+gated at "full" verbosity like every other narration, never new logic duplicated across five
+files. The hook point itself is a new optional per-leaf `epilogue_after:` field naming one of the
+leaf's own `reference:` functions as the unambiguous completion point; only 5 of the ~32 tasks got
+one, because most multi-reference leaves (e.g. "log progress and manage artifacts," six functions
+called routinely throughout a study, not once at a clean "done" moment) have no single call that
+means "finished this task," and hooking one anyway would guess wrong and fire at the wrong time —
+those are deliberately left unhooked rather than forced, matching the same "don't force a fit"
+call already made for `eri_guide()`'s run guardrail in Phase 5. `test-task-map.R` gained 3 new
+integrity checks (`epilogue_after:` must be in the leaf's own `reference:` list, must have a
+`next:` to point to, and must be unique across the tree) plus 3 runtime tests exercising
+`.eri_task_epilogue()` directly. (7) wizard depth (preflight checks, session memory,
 deep links) + a roxygen `@family`/title-audit pass, and (8) an evidence-gated,
 deliberately-deferred client-side decision-tree wizard on the site itself — not yet started.
 

--- a/inst/registry/task_map.yaml
+++ b/inst/registry/task_map.yaml
@@ -23,6 +23,13 @@
 #   guide     a vignettes/*.Rmd slug (optional -- not every task has its own guide)
 #   reference exported function names this task touches (checked against NAMESPACE)
 #   next      ids of the natural next task(s) (optional)
+#   epilogue_after
+#             an exported function name from this leaf's own `reference:` list (optional).
+#             When set, that function prints a one-line "next step" hint (sourced from
+#             `next:`) after it succeeds -- see .eri_task_epilogue() in R/task_registry.R.
+#             Only set where a single call is genuinely the unambiguous completion point of
+#             the task; most multi-reference leaves have no one true "done" call and are
+#             deliberately left unhooked rather than guessing.
 
 - id: get_set_up
   title: "Get set up"
@@ -56,6 +63,7 @@
     guide: da-cmr-guide
     reference: [eri_stage_cmr, eri_split_cmr, eri_ingest_cmr, eri_cmr_last_plan]
     next: [check_cmr]
+    epilogue_after: eri_split_cmr
   - id: surveillance_file
     title: "A surveillance dataset (csv/xlsx from a country)"
     role: da
@@ -63,6 +71,7 @@
     guide: da-ingest-guide
     reference: [eri_ingest, eri_stage, eri_approve]
     next: [triage_logs]
+    epilogue_after: eri_ingest
   - id: odk_submissions
     title: "ODK Central survey submissions"
     role: da
@@ -97,6 +106,7 @@
     guide: da-dq-review-guide
     reference: [eri_dq_review, eri_cmr_dq_report, eri_dq_export, eri_approve_cmr]
     next: [triage_logs]
+    epilogue_after: eri_approve_cmr
   - id: qc_feedback
     title: "QC a submission and give a country feedback"
     role: da
@@ -186,6 +196,7 @@
     guide: epi-research-guide
     reference: [eri_research_init, eri_research_scaffold, eri_research_resume, eri_research_status]
     next: [track_provenance]
+    epilogue_after: eri_research_init
   - id: track_provenance
     title: "Log progress and manage artifacts as you go"
     role: epi
@@ -213,6 +224,7 @@
     guide: epi-reconcile-guide
     reference: [eri_spatial_reconcile]
     next: [join_map]
+    epilogue_after: eri_spatial_reconcile
   - id: join_map
     title: "Join points to admin units and map them"
     role: both

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -581,6 +581,28 @@ test_that("eri_split_cmr writes one parquet per routed sheet to the data blob", 
   expect_true(any(grepl("^uga/lf/programmatic/mmdp/staged/", written)))
 })
 
+test_that("eri_split_cmr prints the registered next-step hint on a real (non-dry-run) success (task-registry epilogue)", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_uga_cmr(tmp)
+
+  local_mocked_bindings(
+    storage_dir_exists  = function(...) TRUE,
+    storage_file_exists = function(...) FALSE,
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    .eri_blob_write  = function(...) invisible(NULL),
+    .eri_write_log   = function(...) invisible(NULL),
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+
+  expect_message(
+    suppressWarnings(eri_split_cmr(tmp, "uga", data_con = structure(list(), class = "mock"))),
+    "Next:"
+  )
+})
+
 test_that("eri_split_cmr defaults to warning about superseded files, not deleting them", {
   tmp <- withr::local_tempfile(pattern = "202406_fixed", fileext = ".xlsx")
   make_uga_cmr(tmp)
@@ -1012,6 +1034,25 @@ test_that("eri_approve_cmr approves every measure once all are clean", {
   result <- eri_approve_cmr("sdn", "202605", plan = plan, data_con = structure(list(), class = "mock"))
   expect_length(approved, 2L)
   expect_equal(nrow(result), 2L)
+})
+
+test_that("eri_approve_cmr prints the registered next-step hint on success (task-registry epilogue)", {
+  plan <- tibble::tibble(
+    sheet = "RB Treatment", disease = "oncho", data_type = "treatment", dest = "a", n_rows = 1L
+  )
+  local_mocked_bindings(
+    eri_logs = function(...) tibble::tibble(
+      log_path = "sdn/x/programmatic/treatment/logs/x.yaml", period = "202605",
+      status = "clean", handled = FALSE, n_issues = 0L
+    ),
+    eri_approve = function(...) NULL,
+    .package = "erifunctions"
+  )
+
+  expect_message(
+    eri_approve_cmr("sdn", "202605", plan = plan, data_con = structure(list(), class = "mock")),
+    "Next:"
+  )
 })
 
 test_that("eri_approve_cmr records a dq_reviewed cross-reference in its own op-log", {

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -340,6 +340,37 @@ test_that("eri_ingest stages to the five-axis {data_source}/{data_type} path", {
   expect_equal(logged_dir, "uga/oncho/programmatic/treatment/logs")
 })
 
+test_that("eri_ingest prints the registered next-step hint on success (task-registry epilogue)", {
+  raw_csv <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(Year = 2024L, EpiWeek = 1L), raw_csv, row.names = FALSE)
+
+  schema <- list(
+    country = "uga", disease = "oncho",
+    data_source = "programmatic", data_type = "treatment",
+    temporal = list(year_col = "Year", period_col = "EpiWeek"),
+    columns  = list(
+      Year    = list(required = TRUE, type = "numeric"),
+      EpiWeek = list(required = TRUE, type = "numeric")
+    )
+  )
+
+  local_mocked_bindings(
+    .eri_blob_write  = function(...) invisible(NULL),
+    .eri_write_log   = function(...) invisible(NULL),
+    eri_dq_log       = function(...) invisible(NULL),
+    .eri_log_session = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(storage_dir_exists = function(...) TRUE, .package = "AzureStor")
+
+  expect_message(
+    eri_ingest(raw_csv, "uga", "oncho",
+               data_source = "programmatic", data_type = "treatment",
+               schema = schema, data_con = structure(list(), class = "mock")),
+    "Next:"
+  )
+})
+
 test_that("eri_ingest with data_type = NULL stays four-axis (no measure level)", {
   raw_csv <- withr::local_tempfile(fileext = ".csv")
   utils::write.csv(data.frame(Year = 2024L, EpiWeek = 1L), raw_csv, row.names = FALSE)

--- a/tests/testthat/test-research.R
+++ b/tests/testthat/test-research.R
@@ -83,6 +83,25 @@ test_that("eri_research_init scaffolds local dirs and research.yaml", {
   expect_true(is.list(manifest$outputs))
 })
 
+test_that("eri_research_init prints the registered next-step hint on success (task-registry epilogue)", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(
+    storage_dir_exists = function(...) FALSE,
+    create_storage_dir = function(...) invisible(NULL),
+    .package = "AzureStor"
+  )
+
+  expect_message(
+    eri_research_init("dr_irs_2024", "dr", "malaria", "ITS analysis", path = tmp),
+    "Next:"
+  )
+})
+
 test_that("eri_research_init errors if project already exists locally", {
   tmp <- withr::local_tempdir()
 

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -517,6 +517,21 @@ test_that("eri_spatial_reconcile matches exactly without geocoding", {
   expect_true(all(is.na(c(out$geocoded_adm4_name, out$geocoded_adm3_name, out$geocoded_adm2_name))))
 })
 
+test_that("eri_spatial_reconcile prints the registered next-step hint on success (task-registry epilogue)", {
+  skip_no_sf()
+  local_mocked_bindings(
+    .eri_geocode = function(...) stop("must not geocode a matched row"),
+    .package = "erifunctions"
+  )
+  df <- tibble::tibble(
+    loc  = "jinova", mun = "Juan de Herrera", prov = "San Juan", cases = 3L
+  )
+  expect_message(
+    eri_spatial_reconcile(df, recon_cols$loc_cols, recon_shp(), recon_cols$admin_cols),
+    "Next:"
+  )
+})
+
 test_that("eri_spatial_reconcile scopes matching by coarser levels", {
   skip_no_sf()
   # "Jínova" exists, but under the wrong municipality -> no match (no geocode).

--- a/tests/testthat/test-task-map.R
+++ b/tests/testthat/test-task-map.R
@@ -88,16 +88,73 @@ test_that("every `next:` id resolves to a real task id in the tree", {
   }
 })
 
+test_that("every `epilogue_after:` value is in that same leaf's own `reference:` list", {
+  # The runtime hook (.eri_task_epilogue()) is only ever called FROM the function it names, so an
+  # epilogue_after value the task doesn't even claim to touch would be a self-contradiction.
+  tree <- .eri_task_map()
+  for (branch in tree) {
+    for (leaf in branch$children) {
+      if (!is.null(leaf$epilogue_after)) {
+        expect_true(leaf$epilogue_after %in% leaf$reference, info = leaf$id)
+      }
+    }
+  }
+})
+
+test_that("every leaf with `epilogue_after:` also has a `next:` to point to", {
+  tree <- .eri_task_map()
+  for (branch in tree) {
+    for (leaf in branch$children) {
+      if (!is.null(leaf$epilogue_after)) {
+        expect_true(length(leaf[["next"]]) > 0L, info = leaf$id)
+      }
+    }
+  }
+})
+
+test_that("no two leaves hook the same `epilogue_after:` function", {
+  tree <- .eri_task_map()
+  hooks <- unlist(lapply(tree, function(b) {
+    Filter(Negate(is.null), lapply(b$children, function(l) l$epilogue_after))
+  }))
+  expect_equal(anyDuplicated(hooks), 0L)
+})
+
 test_that(".eri_task_flatten produces one row per leaf with the expected columns", {
   tree <- .eri_task_map()
   n_leaves <- sum(vapply(tree, function(b) length(b$children), integer(1)))
   flat <- .eri_task_flatten(tree)
   expect_equal(nrow(flat), n_leaves)
-  expect_true(all(c("branch", "id", "title", "role", "call", "guide", "reference", "next_ids") %in% names(flat)))
+  expect_true(all(
+    c("branch", "id", "title", "role", "call", "guide", "reference", "next_ids", "epilogue_after") %in%
+      names(flat)
+  ))
 })
 
 test_that("eri_task_map() prints and returns the flattened registry invisibly", {
   expect_invisible(out <- eri_task_map())
   expect_s3_class(out, "data.frame")
   expect_true(all(c("id", "title", "call") %in% names(out)))
+})
+
+test_that(".eri_task_epilogue prints the real registered next-step hint for a real hook", {
+  # eri_spatial_reconcile's epilogue_after -> next: join_map ("Join points to admin units and map
+  # them"), cross-checked against the actual registry rather than a hardcoded expectation, so this
+  # test can't drift out of sync with the YAML.
+  tree <- .eri_task_map()
+  flat <- .eri_task_flatten(tree)
+  hit  <- flat[!is.na(flat$epilogue_after) & flat$epilogue_after == "eri_spatial_reconcile", , drop = FALSE]
+  expect_equal(nrow(hit), 1L)
+  nxt <- flat[flat$id == hit$next_ids[[1]], , drop = FALSE]
+
+  expect_message(.eri_task_epilogue("eri_spatial_reconcile"), nxt$title[[1]], fixed = TRUE)
+})
+
+test_that(".eri_task_epilogue is silent for a function with no registered hook", {
+  expect_no_message(.eri_task_epilogue("not_a_real_hook"))
+})
+
+test_that(".eri_task_epilogue respects quiet verbosity like any other narration", {
+  withr::local_options(erifunctions.verbosity = "quiet")
+  expect_no_message(.eri_task_epilogue("eri_spatial_reconcile"))
 })


### PR DESCRIPTION
## Summary
- Phase 6 of the docs-site & guidance-system redesign: `eri_spatial_reconcile()`, `eri_split_cmr()`, `eri_ingest()`, `eri_approve_cmr()`, and `eri_research_init()` now print a one-line "Next:" hint on success, sourced from the task registry's own `next:` field via a new `.eri_task_epilogue()` (`R/task_registry.R`). Gated at "full" verbosity like every other narration.
- The hook point is a new optional `epilogue_after:` field in `inst/registry/task_map.yaml` naming one of the leaf's own `reference:` functions as the unambiguous completion point. Only 5 of ~32 tasks got one — most multi-reference leaves have no single call that means "done with this task," and guessing one would fire at the wrong moment; those are deliberately left unhooked.
- `test-task-map.R` gained 3 new integrity checks (`epilogue_after` must be in the leaf's own `reference:` list, must have a `next:` to point to, must be unique across the tree) plus 3 runtime tests exercising `.eri_task_epilogue()` directly.
- Version bumped 0.9.24 → 0.9.25.

## Test plan
- [x] `devtools::document()` — no changes (no exports/roxygen touched)
- [x] `devtools::test()` — full suite green (2729 pass, 0 fail; one unrelated same-second timing test confirmed flaky, passes in isolation)
- [ ] CI (R-CMD-check, pkgdown)
- [ ] review-agent pass