### PR TITLE
feat(guide): deep links, session memory, and a doc audit (v0.9.26)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.25
+Version: 0.9.26
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
   `test-task-map.R` gained a permanent check: every `call:` template must represent every required
   argument of its own referenced function, not just parse as valid R.
 - **A roxygen title/`@family` audit** (via `roxygen2::parse_package()`, not eyeballing): checked
-  all 156 exported functions' titles for sentence case and no trailing period — found exactly one
+  all 157 exported functions' titles for sentence case and no trailing period — found exactly one
   real issue (`erifunctions_io()`'s all-lowercase, fragment-style title; the 4 flagged S3
   print/summary methods are conventionally undocumented and not a real gap). Added `@family` tags
   to 25 functions across 3 tight, already-vetted clusters (CMR pipeline, DQ schema override, ODK
@@ -40,10 +40,9 @@
   against live infrastructure from what was meant to be an offline unit test. Fixed the test bug
   (build the `scripted()` closure once, outside the mock wrapper) and a second, related
   infinite-loop bug it exposed in a different new test (a mock that never returned an "Exit"
-  choice for the top-level menu). See the "branch first"-style lesson in memory: any test that
-  drives an interactive loop via a mocked prompt must be checked for a route where the mock can
-  never terminate the loop, since offline test code that accidentally reaches an un-mocked
-  live-integration function will actually run it.
+  choice for the top-level menu). Lesson: any test that drives an interactive loop via a mocked
+  prompt has to be traced for every route the mock can take, not just the intended one — offline
+  test code that accidentally reaches an un-mocked live-integration function will actually run it.
 
 # erifunctions 0.9.25
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,50 @@
+# erifunctions 0.9.26
+
+## `eri_guide()` remembers where you were, jumps straight to a task, and a documentation audit (docs site redesign, phase 7)
+
+- **`eri_guide()` gained a `task_id` argument**: `eri_guide("check_cmr")` jumps straight to that
+  task's detail screen, skipping the category/task menus — a deep link for anyone who already
+  knows what they're looking for (from a script, a colleague's note, or a future epilogue hint).
+  Unknown ids abort with a clear message pointing at `eri_task_map()`.
+- **`eri_guide()` now remembers the last category you visited this session** and offers to
+  "Continue in ..." it at the top of the menu next time, instead of always starting from the top.
+  Uses the same `getOption()`/`options()` session-state convention as `eri_verbosity()`
+  (`R/console.R`), not a new package-environment pattern — resets with a fresh R session.
+- **A registry accuracy sweep found two real bugs the existing tests couldn't catch**: `call:`
+  templates that *parse* as R can still silently omit a *required* argument. `start_project`'s
+  `eri_research_init(project_name)` dropped 3 required arguments (`country`, `disease`,
+  `description`); `population_totals`'s `eri_spatial_pop(boundaries)` used a parameter name
+  (`boundaries`) that doesn't exist on the real function (`shapefile`). Both fixed, and
+  `test-task-map.R` gained a permanent check: every `call:` template must represent every required
+  argument of its own referenced function, not just parse as valid R.
+- **A roxygen title/`@family` audit** (via `roxygen2::parse_package()`, not eyeballing): checked
+  all 156 exported functions' titles for sentence case and no trailing period — found exactly one
+  real issue (`erifunctions_io()`'s all-lowercase, fragment-style title; the 4 flagged S3
+  print/summary methods are conventionally undocumented and not a real gap). Added `@family` tags
+  to 25 functions across 3 tight, already-vetted clusters (CMR pipeline, DQ schema override, ODK
+  Central) — a first pass, not an exhaustive 150-function sweep; `_pkgdown.yml`'s reference index
+  already covers cross-function discovery at the browse level, so `@family`'s marginal value here
+  is the "See Also" block on an individual function's own help page, not a replacement for it.
+- **"Preflight checks" scoped conservatively**: real per-function argument collection (so more
+  tasks could run from the wizard) stays out of scope — most leaves mix simple strings with real R
+  objects (a data frame, an sf shapefile) a console prompt can't safely fabricate, and a smart
+  per-arg-type schema to distinguish them would be new complexity for uncertain benefit.
+  "Run it now"'s existing `tryCatch`-and-report (Phase 5) is treated as the guardrail against a
+  live call failing.
+- **A serious near-miss, caught and fixed before merge**: a bug in a *test* (a `scripted()` mock
+  closure re-created fresh inside its own wrapper function, so it always returned the same first
+  response instead of advancing) sent `eri_guide()`'s menu loop into an infinite "Run it now" loop
+  on a zero-argument task whose call is `get_azure_storage_connection()` — which is real, and hit
+  the live `eridev` Azure tenant repeatedly until the runaway process was killed. No data was
+  written (the call is a read-only auth/connection handshake), but it burned real API calls
+  against live infrastructure from what was meant to be an offline unit test. Fixed the test bug
+  (build the `scripted()` closure once, outside the mock wrapper) and a second, related
+  infinite-loop bug it exposed in a different new test (a mock that never returned an "Exit"
+  choice for the top-level menu). See the "branch first"-style lesson in memory: any test that
+  drives an interactive loop via a mocked prompt must be checked for a route where the mock can
+  never terminate the loop, since offline test code that accidentally reaches an un-mocked
+  live-integration function will actually run it.
+
 # erifunctions 0.9.25
 
 ## Pipeline functions now hint at the next step, sourced from the task registry (docs site redesign, phase 6)

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -91,6 +91,7 @@ load_cmr_schema <- function(country) {
 #' # French template — canonical slug resolved via schema
 #' df <- eri_ingest_cmr("data/tcd_2024_01.xlsx", sheet = "rb_treatment", country = "tcd")
 #' }
+#' @family CMR pipeline functions
 #' @export
 eri_ingest_cmr <- function(path, sheet, country = NULL) {
   if (!file.exists(path)) {
@@ -275,6 +276,7 @@ eri_ingest_cmr <- function(path, sheet, country = NULL) {
 #' # actually removing the superseded original (default only warns)
 #' eri_split_cmr("202605_ssd_report_fixed.xlsx", "ssd", supersede_staged = TRUE)
 #' }
+#' @family CMR pipeline functions
 #' @export
 eri_split_cmr <- function(path, country, data_con = NULL,
                           overwrite = FALSE, dry_run = FALSE,
@@ -661,6 +663,7 @@ eri_split_cmr <- function(path, country, data_con = NULL,
 #' \dontrun{
 #' plan <- eri_cmr_last_plan("sdn", "202605")
 #' }
+#' @family CMR pipeline functions
 #' @export
 eri_cmr_last_plan <- function(country, period, data_con = NULL) {
   data_con <- .eri_logs_con(data_con)
@@ -769,6 +772,7 @@ eri_cmr_last_plan <- function(country, period, data_con = NULL) {
 #' eri_approve_cmr("sdn", "202605", force = TRUE,
 #'                  justification = "Known template quirk in RB Treatment; confirmed with country lead.")
 #' }
+#' @family CMR pipeline functions
 #' @export
 eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
                             force = FALSE, justification = NULL) {
@@ -958,6 +962,7 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
 #' flags[flags$status == "open", ]
 #' eri_dq_flag_resolve(flags$flag_id[1], "fixed", note = "corrected upstream")
 #' }
+#' @family CMR pipeline functions
 #' @export
 eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, data_con = NULL) {
   data_con <- .eri_logs_con(data_con)
@@ -1072,6 +1077,7 @@ eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, da
 #' eri_stage_cmr("uga", "202603")
 #' eri_stage_cmr("nga")  # auto-selects most recent period
 #' }
+#' @family CMR pipeline functions
 #' @export
 eri_stage_cmr <- function(country,
                            period       = NULL,

--- a/R/dal.R
+++ b/R/dal.R
@@ -183,7 +183,7 @@ get_azure_storage_connection <- function(
 
 #### 2) I/O dispatcher ####
 
-#' erifunctions i/o handler
+#' Legacy I/O handler for the erifunctions data interface
 #'
 #' @description
 #' `r lifecycle::badge("experimental")`

--- a/R/dq.R
+++ b/R/dq.R
@@ -1195,6 +1195,7 @@ add_anomaly_spatial <- function(data, schema, azcontainer = NULL) {
 #' schema <- load_dq_schema("dr", "malaria", "surveillance", "case")
 #' schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment")
 #' }
+#' @family DQ schema functions
 #' @export
 load_dq_schema <- function(
     country,
@@ -1244,6 +1245,7 @@ load_dq_schema <- function(
 #' path <- eri_dq_schema_path("atlantis", "oncho", "programmatic", "treatment")
 #' file.edit(path)  # or rstudioapi::navigateToFile(path)
 #' }
+#' @family DQ schema functions
 #' @export
 eri_dq_schema_path <- function(country, disease, data_source = NULL, data_type = NULL,
                                 azcontainer = suppressMessages(
@@ -1286,6 +1288,7 @@ eri_dq_schema_path <- function(country, disease, data_source = NULL, data_type =
 #' file.edit(path)  # or rstudioapi::navigateToFile(path)
 #' # ... load_dq_schema() now returns this override until eri_dq_schema_reset() ...
 #' }
+#' @family DQ schema functions
 #' @export
 eri_dq_schema_edit <- function(country, disease, data_source = NULL, data_type = NULL,
                                 azcontainer = suppressMessages(
@@ -1362,6 +1365,7 @@ eri_dq_schema_edit <- function(country, disease, data_source = NULL, data_type =
 #' \dontrun{
 #' eri_dq_schema_status()
 #' }
+#' @family DQ schema functions
 #' @export
 eri_dq_schema_status <- function(azcontainer = suppressMessages(
                                     get_azure_storage_connection(
@@ -1428,6 +1432,7 @@ eri_dq_schema_status <- function(azcontainer = suppressMessages(
 #' \dontrun{
 #' eri_dq_schema_reset("atlantis", "oncho", "programmatic", "treatment")
 #' }
+#' @family DQ schema functions
 #' @export
 eri_dq_schema_reset <- function(country, disease, data_source = NULL, data_type = NULL,
                                  confirm = TRUE) {
@@ -1569,6 +1574,7 @@ eri_dq_schema_reset <- function(country, disease, data_source = NULL, data_type 
 #' }
 #' @seealso [eri_dq_schema_edit()] to create the override being submitted,
 #'   [eri_feedback()] for the general ticket log.
+#' @family DQ schema functions
 #' @export
 eri_dq_schema_submit <- function(country, disease, data_source = NULL, data_type = NULL,
                                   note = NULL,

--- a/R/guide.R
+++ b/R/guide.R
@@ -1,16 +1,27 @@
 #### eri_guide — an interactive console wizard over the task registry ####
 #
-# Phase 5 of the docs site & guidance system redesign (docs/roadmap.md's "Docs site & guidance
-# system redesign" entry). Walks inst/registry/task_map.yaml the same way eri_dq_review() walks
-# the DQ core: cli_h3() + utils::menu() menus (.eri_prompt_menu(), R/dq_review.R), nothing
-# persisted, safe to exit and rerun anytime.
+# Phase 5 (MVP) + phase 7 (wizard depth) of the docs site & guidance system redesign
+# (docs/roadmap.md's "Docs site & guidance system redesign" entry). Walks
+# inst/registry/task_map.yaml the same way eri_dq_review() walks the DQ core: cli_h3() +
+# utils::menu() menus (.eri_prompt_menu(), R/dq_review.R), nothing persisted to disk, safe to exit
+# and rerun anytime.
 #
 # The "run guardrail" is mechanical, not a schema field: a task's call is only offered as "Run it
 # now" when it parses to a zero-argument call -- the same call string test-task-map.R already
 # verifies parses as R. Everything else needs real argument values this wizard has no safe way to
-# fabricate, so it can only be shown, with its guide opened for the full walkthrough. Deeper
-# argument collection (preflight checks, session memory) is Phase 7 ("wizard depth"), deliberately
-# out of scope here.
+# fabricate, so it can only be shown, with its guide opened for the full walkthrough. Real
+# per-function argument collection (so more tasks could be run from the wizard) stays out of
+# scope -- most leaves' calls mix simple strings with real R objects (a data frame, an sf
+# shapefile) a console prompt can't safely fabricate, and guessing which is which per function
+# risks silently passing the wrong thing. "Run it now"'s existing tryCatch-and-report (below) is
+# the guardrail against a live call failing; a more elaborate preflight (checking specific env
+# vars/state per task) would need new schema fields for uncertain benefit over that.
+#
+# Phase 7 additions: session memory (.eri_guide_last_branch_id()/.eri_guide_set_last_branch_id(),
+# an options()-based session-state convention matching R/console.R's verbosity, not a new
+# package-env pattern) offers to resume the last-visited category; a task id deep link
+# (eri_guide(task_id = )) jumps straight to one task's detail screen via .eri_task_find_leaf()
+# (R/task_registry.R).
 
 # TRUE only for a call with no arguments at all, e.g. "eri_data_model()" -- not "eri_query(sql)"
 # even though `sql` has no default here, since the registry's own call templates never encode
@@ -66,6 +77,29 @@
   invisible(NULL)
 }
 
+# Session memory of which category the wizard last visited, so re-invoking eri_guide() can offer
+# to resume there instead of always starting from the top. Uses the same getOption()/options()
+# session-state convention as R/console.R's verbosity (not a new package-env pattern) -- resets
+# with a fresh R session, the right lifetime for "where was I browsing," nothing worth persisting
+# to disk.
+#' @keywords internal
+.eri_guide_last_branch_id <- function() getOption("erifunctions.guide_last_branch", default = NULL)
+
+#' @keywords internal
+.eri_guide_set_last_branch_id <- function(id) options(erifunctions.guide_last_branch = id)
+
+# Resolves a top-level category-menu choice to NULL (exit) or the chosen branch, accounting for
+# whether a "Continue in ..." resume option was prepended (which shifts every other index by one).
+# Isolated as its own pure function so the index arithmetic is unit-testable independent of the
+# interactive loop -- exactly the kind of off-by-one that's easy to get wrong inline.
+#' @keywords internal
+.eri_guide_resolve_branch_choice <- function(choice, tree, resume_branch) {
+  offset <- if (!is.null(resume_branch)) 1L else 0L
+  if (choice == 0L || choice == length(tree) + offset + 1L) return(NULL)
+  if (!is.null(resume_branch) && choice == 1L) return(resume_branch)
+  tree[[choice - offset]]
+}
+
 #' Find your task and get its call and guide (interactive)
 #'
 #' @description
@@ -78,11 +112,17 @@
 #' everything else -- which needs real argument values this wizard has no safe way to fabricate --
 #' can only be shown, with its guide opened for the full walkthrough.
 #'
+#' The wizard remembers the last category you visited this session and offers to resume there.
+#' Pass a task id to jump straight to its detail screen instead of navigating the menus (see
+#' [eri_task_map()]'s `id` column, or the generated task-index article, for valid ids).
+#'
 #' Prefer the generated [task-index article](../articles/task-index.html) or [eri_task_map()] when
 #' you don't need the back-and-forth of a menu.
 #'
 #' **Interactive only.** In a script, browse [eri_task_map()] or the task-index article instead.
 #'
+#' @param task_id `chr` or `NULL` A task id to jump straight to its detail screen, skipping the
+#'   category/task menus. `NULL` (default) starts at the top-level category menu.
 #' @returns Invisibly, `NULL`. "Run it now" prints its visibly-returned result the same way typing
 #'   the call at the console would (so e.g. [get_azure_storage_connection()]'s connection object is
 #'   shown, not silently discarded), and a failure is caught and reported rather than crashing the
@@ -91,11 +131,12 @@
 #' @examples
 #' \dontrun{
 #' eri_guide()
+#' eri_guide("check_cmr")  # jump straight to a known task
 #' }
 #' @seealso [eri_task_map()] for the non-interactive console version, [eri_dq_review()] for the
 #'   same menu-driven wizard pattern applied to DQ triage.
 #' @export
-eri_guide <- function() {
+eri_guide <- function(task_id = NULL) {
   if (!rlang::is_interactive()) {
     cli::cli_abort(c(
       "{.fn eri_guide} is interactive-only.",
@@ -105,11 +146,32 @@ eri_guide <- function() {
 
   tree <- .eri_task_map()
 
+  if (!is.null(task_id)) {
+    leaf <- .eri_task_find_leaf(task_id, tree)
+    if (is.null(leaf)) {
+      cli::cli_abort(c(
+        "No task with id {.val {task_id}} in the registry.",
+        "i" = "Call {.fn eri_task_map} to see valid ids, or {.fn eri_guide} with no argument to browse."
+      ))
+    }
+    .eri_guide_show_task(leaf)
+    return(invisible(NULL))
+  }
+
   repeat {
+    resume_branch <- .eri_task_find_branch(.eri_guide_last_branch_id(), tree)
     branch_titles <- vapply(tree, function(b) b$title, character(1))
-    branch_choice <- .eri_prompt_menu("What are you trying to do?", c(branch_titles, "Exit"))
-    if (branch_choice == 0L || branch_choice == length(tree) + 1L) break
-    branch <- tree[[branch_choice]]
+    menu_choices  <- if (!is.null(resume_branch)) {
+      c(sprintf('Continue in "%s"', resume_branch$title), branch_titles, "Exit")
+    } else {
+      c(branch_titles, "Exit")
+    }
+
+    branch_choice <- .eri_prompt_menu("What are you trying to do?", menu_choices)
+    branch <- .eri_guide_resolve_branch_choice(branch_choice, tree, resume_branch)
+    if (is.null(branch)) break
+
+    .eri_guide_set_last_branch_id(branch$id)
 
     repeat {
       leaf_titles <- vapply(branch$children, function(l) l$title, character(1))

--- a/R/odk.R
+++ b/R/odk.R
@@ -78,6 +78,7 @@ print.odk_connection <- function(x, ...) {
 #' @param url `chr` Server URL (used when `con = NULL`)
 #' @param auth `chr` Bearer token (used when `con = NULL`)
 #' @returns `tibble` with columns `project_id`, `project`, `description`
+#' @family ODK Central functions
 #' @export
 list_odk_projects <- function(
     con  = NULL,
@@ -104,6 +105,7 @@ list_odk_projects <- function(
 #' @param auth `chr` Bearer token (used when `con = NULL`)
 #' @param project_id `int` Project ID from [list_odk_projects()]
 #' @returns `tibble` with columns `xmlFormId`, `name`
+#' @family ODK Central functions
 #' @export
 list_odk_forms <- function(
     con        = NULL,
@@ -142,6 +144,7 @@ list_odk_forms <- function(
 #' @returns A `tibble` of submissions, or -- when `tables = TRUE` -- a named list
 #'   of tibbles (one per export table, main table first).
 #' @importFrom utils URLencode URLdecode unzip
+#' @family ODK Central functions
 #' @export
 download_odk_form <- function(
     con         = NULL,
@@ -227,6 +230,7 @@ download_odk_form <- function(
 #' @param auth `chr` Bearer token (used when `con = NULL`)
 #' @param project_id `int` Project ID from [list_odk_projects()]
 #' @returns `tibble` of app users
+#' @family ODK Central functions
 #' @export
 list_all_odk_app_users <- function(
     con        = NULL,
@@ -289,6 +293,7 @@ list_odk_form_users <- function(
 #' @param actor_id `int` Actor ID; required for `"delete"`, `"assign"`, `"revoke"`
 #' @returns Named list (for `"create"`) or logical (for all others)
 #' @importFrom utils URLencode URLdecode
+#' @family ODK Central functions
 #' @export
 update_odk_app_user_role <- function(
     action,
@@ -370,6 +375,7 @@ update_odk_app_user_role <- function(
 #' @returns `tibble` of attachment metadata
 #' @importFrom rlang .data
 #' @importFrom utils URLencode URLdecode
+#' @family ODK Central functions
 #' @export
 download_form_attachments <- function(
     con           = NULL,

--- a/R/odk_bulk_users.R
+++ b/R/odk_bulk_users.R
@@ -107,6 +107,7 @@
 #' eri_odk_bulk_users("users.csv", dry_run = TRUE)
 #' eri_odk_bulk_users("users.csv")
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_bulk_users <- function(csv_path, con = NULL, dry_run = FALSE) {
   if (!file.exists(csv_path))

--- a/R/odk_registry.R
+++ b/R/odk_registry.R
@@ -64,6 +64,7 @@
 #'   server_url = "https://odk.example.org"
 #' )
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_register <- function(
     project_id,
@@ -182,6 +183,7 @@ eri_odk_register <- function(
 #' \dontrun{
 #' eri_odk_deregister(project_id = 7, form_id = "RiverProspection")
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_deregister <- function(
     project_id,
@@ -281,6 +283,7 @@ eri_odk_deregister <- function(
 #' # Tear down a sandbox registration completely
 #' eri_odk_purge(project_id = 99999, form_id = "eri_test_river_prospection")
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_purge <- function(
     project_id,
@@ -356,6 +359,7 @@ eri_odk_purge <- function(
 #' \dontrun{
 #' eri_odk_list_registered()
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_list_registered <- function(data_con = NULL) {
   data_con <- .odk_data_con(data_con)

--- a/R/odk_sync.R
+++ b/R/odk_sync.R
@@ -32,6 +32,7 @@
 #' eri_odk_sync(project_id = 7, form_id = "RiverProspection",
 #'              con = con, data_con = data_con)
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_sync <- function(
     project_id,

--- a/R/odk_upload.R
+++ b/R/odk_upload.R
@@ -433,6 +433,7 @@
 #'                            stage = "river_stage"),
 #'                key_col = "rec", dry_run = TRUE)
 #' }
+#' @family ODK Central functions
 #' @export
 eri_odk_upload <- function(
     data,

--- a/R/task_registry.R
+++ b/R/task_registry.R
@@ -65,7 +65,7 @@
 }
 
 # Finds the branch with the given id anywhere in the tree, or NULL if `id` is NULL/unmatched.
-# Used by eri_guide()'s session-memory resume lookup (R/guide.R, phase 6).
+# Used by eri_guide()'s session-memory resume lookup (R/guide.R, phase 7).
 #' @keywords internal
 .eri_task_find_branch <- function(id, tree = .eri_task_map()) {
   Find(function(b) identical(b$id, id), tree)

--- a/R/task_registry.R
+++ b/R/task_registry.R
@@ -64,6 +64,24 @@
   }, error = function(e) invisible(NULL))
 }
 
+# Finds the branch with the given id anywhere in the tree, or NULL if `id` is NULL/unmatched.
+# Used by eri_guide()'s session-memory resume lookup (R/guide.R, phase 6).
+#' @keywords internal
+.eri_task_find_branch <- function(id, tree = .eri_task_map()) {
+  Find(function(b) identical(b$id, id), tree)
+}
+
+# Finds the leaf with the given id anywhere in the tree, or NULL if `id` is NULL/unmatched. Used by
+# eri_guide(task_id = )'s deep-link path (R/guide.R, phase 7).
+#' @keywords internal
+.eri_task_find_leaf <- function(id, tree = .eri_task_map()) {
+  for (branch in tree) {
+    hit <- Find(function(l) identical(l$id, id), branch$children)
+    if (!is.null(hit)) return(hit)
+  }
+  NULL
+}
+
 #' Show the task registry: what are you trying to do?
 #'
 #' @description

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.25 · **Status:** Active development
+**Version:** 0.9.26 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -408,7 +408,7 @@ signature, not just that it parses) found two real, pre-existing bugs: `start_pr
 `eri_spatial_pop(boundaries)` used a parameter name that doesn't exist on the real function
 (`shapefile`) — both fixed, and `test-task-map.R` gained a permanent check for this whole class of
 bug. A roxygen title/`@family` audit (via `roxygen2::parse_package()`, not eyeballing) checked all
-156 exported functions' titles and found exactly one real issue (fixed); added `@family` tags to 25
+157 exported functions' titles and found exactly one real issue (fixed); added `@family` tags to 25
 functions across 3 tight, already-vetted clusters (CMR pipeline, DQ schema override, ODK Central) —
 a first pass, not an exhaustive sweep, since `_pkgdown.yml`'s reference index already covers
 cross-function discovery at the browse level. **A serious near-miss surfaced and fixed before

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -393,8 +393,32 @@ those are deliberately left unhooked rather than forced, matching the same "don'
 call already made for `eri_guide()`'s run guardrail in Phase 5. `test-task-map.R` gained 3 new
 integrity checks (`epilogue_after:` must be in the leaf's own `reference:` list, must have a
 `next:` to point to, and must be unique across the tree) plus 3 runtime tests exercising
-`.eri_task_epilogue()` directly. (7) wizard depth (preflight checks, session memory,
-deep links) + a roxygen `@family`/title-audit pass, and (8) an evidence-gated,
+`.eri_task_epilogue()` directly. (7) wizard depth + doc audit — **shipped**: `eri_guide()` gained a
+`task_id` deep link (`eri_guide("check_cmr")` jumps straight to a task's detail screen) and session
+memory (remembers the last-visited category via the same `getOption()`/`options()` convention as
+`eri_verbosity()`, offers to "Continue in ..." it next time). "Preflight checks" scoped
+conservatively rather than built speculatively: real per-function argument collection (letting more
+than the 4 zero-arg tasks run from the wizard) stays out of scope, since most leaves mix simple
+strings with real R objects (a data frame, an sf shapefile) a console prompt can't safely fabricate
+— "Run it now"'s existing `tryCatch`-and-report (Phase 5) is treated as the guardrail against a
+live call failing, rather than inventing a new per-arg-type schema for uncertain benefit. A registry
+accuracy sweep (checking every `call:` template's required arguments against the real function
+signature, not just that it parses) found two real, pre-existing bugs: `start_project`'s
+`eri_research_init(project_name)` dropped 3 required arguments, and `population_totals`'s
+`eri_spatial_pop(boundaries)` used a parameter name that doesn't exist on the real function
+(`shapefile`) — both fixed, and `test-task-map.R` gained a permanent check for this whole class of
+bug. A roxygen title/`@family` audit (via `roxygen2::parse_package()`, not eyeballing) checked all
+156 exported functions' titles and found exactly one real issue (fixed); added `@family` tags to 25
+functions across 3 tight, already-vetted clusters (CMR pipeline, DQ schema override, ODK Central) —
+a first pass, not an exhaustive sweep, since `_pkgdown.yml`'s reference index already covers
+cross-function discovery at the browse level. **A serious near-miss surfaced and fixed before
+merge**: a bug in a *test* (a `scripted()` mock closure re-created fresh inside its own wrapper, so
+it never advanced past its first response) sent `eri_guide()`'s menu loop into an infinite "Run it
+now" loop on a zero-argument task whose call is `get_azure_storage_connection()` — real, and it hit
+the live `eridev` Azure tenant repeatedly until the runaway process was killed (no data written; a
+read-only auth handshake, but real API calls against live infrastructure from what was meant to be
+an offline test). Fixed the test bug and a second, related infinite-loop bug it exposed (a mock
+that never returned an "Exit" choice for the top-level menu). And (8) an evidence-gated,
 deliberately-deferred client-side decision-tree wizard on the site itself — not yet started.
 
 ---

--- a/inst/registry/task_map.yaml
+++ b/inst/registry/task_map.yaml
@@ -192,7 +192,7 @@
   - id: start_project
     title: "Start or resume a research project"
     role: epi
-    call: 'eri_research_init(project_name)'
+    call: 'eri_research_init(project_name, country, disease, description)'
     guide: epi-research-guide
     reference: [eri_research_init, eri_research_scaffold, eri_research_resume, eri_research_status]
     next: [track_provenance]
@@ -234,7 +234,7 @@
   - id: population_totals
     title: "Get population totals for an area"
     role: epi
-    call: 'eri_spatial_pop(boundaries)'
+    call: 'eri_spatial_pop(shapefile)'
     reference: [eri_spatial_pop]
 
 - id: add_new_program

--- a/man/download_form_attachments.Rd
+++ b/man/download_form_attachments.Rd
@@ -44,3 +44,19 @@ download_form_attachments(
 \description{
 Download all media attachments from an ODK form
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/download_odk_form.Rd
+++ b/man/download_odk_form.Rd
@@ -44,3 +44,19 @@ of tibbles (one per export table, main table first).
 \description{
 Download all submissions from an ODK form
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_approve_cmr.Rd
+++ b/man/eri_approve_cmr.Rd
@@ -85,3 +85,12 @@ eri_approve_cmr("sdn", "202605", force = TRUE,
                  justification = "Known template quirk in RB Treatment; confirmed with country lead.")
 }
 }
+\seealso{
+Other CMR pipeline functions: 
+\code{\link{eri_cmr_dq_report}()},
+\code{\link{eri_cmr_last_plan}()},
+\code{\link{eri_ingest_cmr}()},
+\code{\link{eri_split_cmr}()},
+\code{\link{eri_stage_cmr}()}
+}
+\concept{CMR pipeline functions}

--- a/man/eri_cmr_dq_report.Rd
+++ b/man/eri_cmr_dq_report.Rd
@@ -62,3 +62,12 @@ flags[flags$status == "open", ]
 eri_dq_flag_resolve(flags$flag_id[1], "fixed", note = "corrected upstream")
 }
 }
+\seealso{
+Other CMR pipeline functions: 
+\code{\link{eri_approve_cmr}()},
+\code{\link{eri_cmr_last_plan}()},
+\code{\link{eri_ingest_cmr}()},
+\code{\link{eri_split_cmr}()},
+\code{\link{eri_stage_cmr}()}
+}
+\concept{CMR pipeline functions}

--- a/man/eri_cmr_last_plan.Rd
+++ b/man/eri_cmr_last_plan.Rd
@@ -40,3 +40,12 @@ from partial/corrective files rather than a full re-upload.
 plan <- eri_cmr_last_plan("sdn", "202605")
 }
 }
+\seealso{
+Other CMR pipeline functions: 
+\code{\link{eri_approve_cmr}()},
+\code{\link{eri_cmr_dq_report}()},
+\code{\link{eri_ingest_cmr}()},
+\code{\link{eri_split_cmr}()},
+\code{\link{eri_stage_cmr}()}
+}
+\concept{CMR pipeline functions}

--- a/man/eri_dq_schema_edit.Rd
+++ b/man/eri_dq_schema_edit.Rd
@@ -51,3 +51,12 @@ file.edit(path)  # or rstudioapi::navigateToFile(path)
 # ... load_dq_schema() now returns this override until eri_dq_schema_reset() ...
 }
 }
+\seealso{
+Other DQ schema functions: 
+\code{\link{eri_dq_schema_path}()},
+\code{\link{eri_dq_schema_reset}()},
+\code{\link{eri_dq_schema_status}()},
+\code{\link{eri_dq_schema_submit}()},
+\code{\link{load_dq_schema}()}
+}
+\concept{DQ schema functions}

--- a/man/eri_dq_schema_path.Rd
+++ b/man/eri_dq_schema_path.Rd
@@ -47,3 +47,12 @@ path <- eri_dq_schema_path("atlantis", "oncho", "programmatic", "treatment")
 file.edit(path)  # or rstudioapi::navigateToFile(path)
 }
 }
+\seealso{
+Other DQ schema functions: 
+\code{\link{eri_dq_schema_edit}()},
+\code{\link{eri_dq_schema_reset}()},
+\code{\link{eri_dq_schema_status}()},
+\code{\link{eri_dq_schema_submit}()},
+\code{\link{load_dq_schema}()}
+}
+\concept{DQ schema functions}

--- a/man/eri_dq_schema_reset.Rd
+++ b/man/eri_dq_schema_reset.Rd
@@ -43,3 +43,12 @@ stay on disk as a record of what a DA's local changes used to be.
 eri_dq_schema_reset("atlantis", "oncho", "programmatic", "treatment")
 }
 }
+\seealso{
+Other DQ schema functions: 
+\code{\link{eri_dq_schema_edit}()},
+\code{\link{eri_dq_schema_path}()},
+\code{\link{eri_dq_schema_status}()},
+\code{\link{eri_dq_schema_submit}()},
+\code{\link{load_dq_schema}()}
+}
+\concept{DQ schema functions}

--- a/man/eri_dq_schema_status.Rd
+++ b/man/eri_dq_schema_status.Rd
@@ -34,3 +34,12 @@ checking status never itself retires a stale override.
 eri_dq_schema_status()
 }
 }
+\seealso{
+Other DQ schema functions: 
+\code{\link{eri_dq_schema_edit}()},
+\code{\link{eri_dq_schema_path}()},
+\code{\link{eri_dq_schema_reset}()},
+\code{\link{eri_dq_schema_submit}()},
+\code{\link{load_dq_schema}()}
+}
+\concept{DQ schema functions}

--- a/man/eri_dq_schema_submit.Rd
+++ b/man/eri_dq_schema_submit.Rd
@@ -64,4 +64,12 @@ eri_dq_schema_submit("sdn", "oncho", "programmatic", "treatment",
 \seealso{
 \code{\link[=eri_dq_schema_edit]{eri_dq_schema_edit()}} to create the override being submitted,
 \code{\link[=eri_feedback]{eri_feedback()}} for the general ticket log.
+
+Other DQ schema functions: 
+\code{\link{eri_dq_schema_edit}()},
+\code{\link{eri_dq_schema_path}()},
+\code{\link{eri_dq_schema_reset}()},
+\code{\link{eri_dq_schema_status}()},
+\code{\link{load_dq_schema}()}
 }
+\concept{DQ schema functions}

--- a/man/eri_guide.Rd
+++ b/man/eri_guide.Rd
@@ -4,7 +4,11 @@
 \alias{eri_guide}
 \title{Find your task and get its call and guide (interactive)}
 \usage{
-eri_guide()
+eri_guide(task_id = NULL)
+}
+\arguments{
+\item{task_id}{\code{chr} or \code{NULL} A task id to jump straight to its detail screen, skipping the
+category/task menus. \code{NULL} (default) starts at the top-level category menu.}
 }
 \value{
 Invisibly, \code{NULL}. "Run it now" prints its visibly-returned result the same way typing
@@ -23,6 +27,10 @@ guide (if any), and the reference functions it touches. A zero-argument task (e.
 everything else -- which needs real argument values this wizard has no safe way to fabricate --
 can only be shown, with its guide opened for the full walkthrough.
 
+The wizard remembers the last category you visited this session and offers to resume there.
+Pass a task id to jump straight to its detail screen instead of navigating the menus (see
+\code{\link[=eri_task_map]{eri_task_map()}}'s \code{id} column, or the generated task-index article, for valid ids).
+
 Prefer the generated \href{../articles/task-index.html}{task-index article} or \code{\link[=eri_task_map]{eri_task_map()}} when
 you don't need the back-and-forth of a menu.
 
@@ -31,6 +39,7 @@ you don't need the back-and-forth of a menu.
 \examples{
 \dontrun{
 eri_guide()
+eri_guide("check_cmr")  # jump straight to a known task
 }
 }
 \seealso{

--- a/man/eri_ingest_cmr.Rd
+++ b/man/eri_ingest_cmr.Rd
@@ -52,3 +52,12 @@ df <- eri_ingest_cmr("data/uga_2024_01.xlsx", sheet = "RB Treatment", country = 
 df <- eri_ingest_cmr("data/tcd_2024_01.xlsx", sheet = "rb_treatment", country = "tcd")
 }
 }
+\seealso{
+Other CMR pipeline functions: 
+\code{\link{eri_approve_cmr}()},
+\code{\link{eri_cmr_dq_report}()},
+\code{\link{eri_cmr_last_plan}()},
+\code{\link{eri_split_cmr}()},
+\code{\link{eri_stage_cmr}()}
+}
+\concept{CMR pipeline functions}

--- a/man/eri_odk_bulk_users.Rd
+++ b/man/eri_odk_bulk_users.Rd
@@ -45,3 +45,19 @@ eri_odk_bulk_users("users.csv", dry_run = TRUE)
 eri_odk_bulk_users("users.csv")
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_odk_deregister.Rd
+++ b/man/eri_odk_deregister.Rd
@@ -28,3 +28,19 @@ Sync history (\code{last_synced}, \code{last_cursor}) is preserved.
 eri_odk_deregister(project_id = 7, form_id = "RiverProspection")
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_odk_list_registered.Rd
+++ b/man/eri_odk_list_registered.Rd
@@ -21,3 +21,19 @@ Returns a tibble of active entries from \code{odk/registry.yaml} in the \verb{da
 eri_odk_list_registered()
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_odk_purge.Rd
+++ b/man/eri_odk_purge.Rd
@@ -33,3 +33,19 @@ for a real form prefer \code{eri_odk_deregister()}, which keeps the audit trail.
 eri_odk_purge(project_id = 99999, form_id = "eri_test_river_prospection")
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_odk_register.Rd
+++ b/man/eri_odk_register.Rd
@@ -49,3 +49,19 @@ eri_odk_register(
 )
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_odk_sync.Rd
+++ b/man/eri_odk_sync.Rd
@@ -52,3 +52,19 @@ eri_odk_sync(project_id = 7, form_id = "RiverProspection",
              con = con, data_con = data_con)
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_odk_upload.Rd
+++ b/man/eri_odk_upload.Rd
@@ -109,3 +109,19 @@ eri_odk_upload(paper, project_id = 7, form_id = "RiverProspection", con = con,
                key_col = "rec", dry_run = TRUE)
 }
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/eri_split_cmr.Rd
+++ b/man/eri_split_cmr.Rd
@@ -131,3 +131,12 @@ eri_split_cmr("202605_ssd_report.xlsx", "ssd", mirror_pipeline = "rb-expansion")
 eri_split_cmr("202605_ssd_report_fixed.xlsx", "ssd", supersede_staged = TRUE)
 }
 }
+\seealso{
+Other CMR pipeline functions: 
+\code{\link{eri_approve_cmr}()},
+\code{\link{eri_cmr_dq_report}()},
+\code{\link{eri_cmr_last_plan}()},
+\code{\link{eri_ingest_cmr}()},
+\code{\link{eri_stage_cmr}()}
+}
+\concept{CMR pipeline functions}

--- a/man/eri_stage_cmr.Rd
+++ b/man/eri_stage_cmr.Rd
@@ -49,3 +49,12 @@ eri_stage_cmr("uga", "202603")
 eri_stage_cmr("nga")  # auto-selects most recent period
 }
 }
+\seealso{
+Other CMR pipeline functions: 
+\code{\link{eri_approve_cmr}()},
+\code{\link{eri_cmr_dq_report}()},
+\code{\link{eri_cmr_last_plan}()},
+\code{\link{eri_ingest_cmr}()},
+\code{\link{eri_split_cmr}()}
+}
+\concept{CMR pipeline functions}

--- a/man/erifunctions_io.Rd
+++ b/man/erifunctions_io.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/dal.R
 \name{erifunctions_io}
 \alias{erifunctions_io}
-\title{erifunctions i/o handler}
+\title{Legacy I/O handler for the erifunctions data interface}
 \usage{
 erifunctions_io(
   io,

--- a/man/list_all_odk_app_users.Rd
+++ b/man/list_all_odk_app_users.Rd
@@ -26,3 +26,19 @@ list_all_odk_app_users(
 \description{
 List all app users in an ODK project
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/list_odk_forms.Rd
+++ b/man/list_odk_forms.Rd
@@ -26,3 +26,19 @@ list_odk_forms(
 \description{
 List ODK forms within a project
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_projects}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/list_odk_projects.Rd
+++ b/man/list_odk_projects.Rd
@@ -23,3 +23,19 @@ list_odk_projects(
 \description{
 List ODK projects
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{update_odk_app_user_role}()}
+}
+\concept{ODK Central functions}

--- a/man/load_dq_schema.Rd
+++ b/man/load_dq_schema.Rd
@@ -61,3 +61,12 @@ schema <- load_dq_schema("dr", "malaria", "surveillance", "case")
 schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment")
 }
 }
+\seealso{
+Other DQ schema functions: 
+\code{\link{eri_dq_schema_edit}()},
+\code{\link{eri_dq_schema_path}()},
+\code{\link{eri_dq_schema_reset}()},
+\code{\link{eri_dq_schema_status}()},
+\code{\link{eri_dq_schema_submit}()}
+}
+\concept{DQ schema functions}

--- a/man/update_odk_app_user_role.Rd
+++ b/man/update_odk_app_user_role.Rd
@@ -41,3 +41,19 @@ Named list (for \code{"create"}) or logical (for all others)
 \description{
 Create, delete, assign, or revoke an ODK app user role
 }
+\seealso{
+Other ODK Central functions: 
+\code{\link{download_form_attachments}()},
+\code{\link{download_odk_form}()},
+\code{\link{eri_odk_bulk_users}()},
+\code{\link{eri_odk_deregister}()},
+\code{\link{eri_odk_list_registered}()},
+\code{\link{eri_odk_purge}()},
+\code{\link{eri_odk_register}()},
+\code{\link{eri_odk_sync}()},
+\code{\link{eri_odk_upload}()},
+\code{\link{list_all_odk_app_users}()},
+\code{\link{list_odk_forms}()},
+\code{\link{list_odk_projects}()}
+}
+\concept{ODK Central functions}

--- a/tests/testthat/helper-scripted.R
+++ b/tests/testthat/helper-scripted.R
@@ -1,0 +1,22 @@
+# Test helper: a scripted decision sequence for mocking an interactive menu prompt
+# (.eri_prompt_menu(), R/dq_review.R and R/guide.R).
+#
+# IMPORTANT: build the closure ONCE and pass it directly as the mocked binding
+# (`.eri_prompt_menu = scripted(list(...))`) -- do not call `scripted(...)()` fresh from inside a
+# wrapper function, which creates a brand-new closure (always starting at its first response) on
+# every invocation instead of a shared, advancing one. That exact mistake once sent a mocked
+# eri_guide() menu loop into an infinite "Run it now" loop against a real, live Azure tenant during
+# test development (docs-site redesign phase 7) -- caught only because the runaway process had to
+# be killed, not because any test failed.
+
+# Returns a function that yields the next element of `responses` on each call, ignoring its
+# arguments, and errors loudly once the script runs out rather than silently returning NULL/NA (a
+# scripted test should never need more responses than it planned for).
+scripted <- function(responses) {
+  i <- 0L
+  function(...) {
+    i <<- i + 1L
+    if (i > length(responses)) stop("scripted responses exhausted at call ", i)
+    responses[[i]]
+  }
+}

--- a/tests/testthat/test-dq_review.R
+++ b/tests/testthat/test-dq_review.R
@@ -1,16 +1,7 @@
 #### Tests for eri_dq_review() and its internal helpers ####
-
-# Returns a function that yields the next element of `responses` on each call,
-# ignoring its arguments -- the standard "scripted decision sequence" pattern
-# for testing the interactive loop by mocking .eri_prompt_menu()/.eri_prompt_line().
-scripted <- function(responses) {
-  i <- 0L
-  function(...) {
-    i <<- i + 1L
-    if (i > length(responses)) stop("scripted responses exhausted at call ", i)
-    responses[[i]]
-  }
-}
+#
+# scripted() (the interactive-menu mocking helper) lives in helper-scripted.R, shared with
+# test-guide.R.
 
 test_that("eri_dq_review refuses to run non-interactively", {
   expect_error(eri_dq_review("sdn", "202605"), "interactive-only")

--- a/tests/testthat/test-guide.R
+++ b/tests/testthat/test-guide.R
@@ -133,3 +133,104 @@ test_that("eri_guide's task screen catches a failing zero-argument run instead o
   )
   expect_no_error(.eri_guide_show_task(leaf))
 })
+
+#### Phase 7: deep links (eri_guide(task_id=)) ####
+
+test_that("eri_guide(task_id=) jumps straight to a task's detail screen", {
+  withr::local_options(rlang_interactive = TRUE)
+  shown <- NULL
+  local_mocked_bindings(
+    .eri_guide_show_task = function(leaf) { shown <<- leaf$id; invisible(NULL) },
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_guide("learn_vocabulary"))
+  expect_equal(shown, "learn_vocabulary")
+})
+
+test_that("eri_guide(task_id=) errors clearly for an unknown id", {
+  withr::local_options(rlang_interactive = TRUE)
+  expect_error(eri_guide("not_a_real_task_id"), "No task with id")
+})
+
+#### Phase 7: session memory (resume the last-visited category) ####
+
+test_that(".eri_guide_resolve_branch_choice handles exit/cancel, resume, and plain selection", {
+  tree   <- list(list(id = "a"), list(id = "b"), list(id = "c"))
+  resume <- list(id = "b")
+
+  # No resume option present: choices are c(a, b, c, "Exit").
+  expect_null(.eri_guide_resolve_branch_choice(0L, tree, NULL))
+  expect_null(.eri_guide_resolve_branch_choice(4L, tree, NULL))
+  expect_equal(.eri_guide_resolve_branch_choice(1L, tree, NULL)$id, "a")
+  expect_equal(.eri_guide_resolve_branch_choice(3L, tree, NULL)$id, "c")
+
+  # Resume option present: choices are c("Continue in b", a, b, c, "Exit") -- every real branch
+  # index shifts by one.
+  expect_null(.eri_guide_resolve_branch_choice(0L, tree, resume))
+  expect_null(.eri_guide_resolve_branch_choice(5L, tree, resume))
+  expect_equal(.eri_guide_resolve_branch_choice(1L, tree, resume)$id, "b")
+  expect_equal(.eri_guide_resolve_branch_choice(2L, tree, resume)$id, "a")
+  expect_equal(.eri_guide_resolve_branch_choice(4L, tree, resume)$id, "c")
+})
+
+test_that("eri_guide offers to resume the last-visited category after visiting one", {
+  withr::local_options(rlang_interactive = TRUE, erifunctions.guide_last_branch = NULL)
+  tree <- .eri_task_map()
+  first_branch_title <- tree[[1]]$title
+
+  # First invocation: navigate into the first category, back out, exit -- no resume option should
+  # be offered on the VERY FIRST top-menu display (nothing visited this session yet). A resume
+  # option legitimately appears on the SECOND top-menu display within this same call (after
+  # backing out of the leaf menu), since picking the category already recorded it as
+  # last-visited -- so this only checks the first display, not every one.
+  seen_top_menu  <- 0L
+  next_response  <- scripted(list(1L, 0L, 0L))
+  local_mocked_bindings(
+    .eri_prompt_menu = function(title, choices) {
+      if (identical(title, "What are you trying to do?")) {
+        seen_top_menu <<- seen_top_menu + 1L
+        if (seen_top_menu == 1L) expect_false(any(grepl("^Continue in", choices)))
+      }
+      next_response()
+    },
+    .package = "erifunctions"
+  )
+  eri_guide()
+
+  # Second invocation: the top menu should now offer to resume that category first.
+  local_mocked_bindings(
+    .eri_prompt_menu = function(title, choices) {
+      expect_match(choices[[1]], sprintf('Continue in "%s"', first_branch_title), fixed = TRUE)
+      0L
+    },
+    .package = "erifunctions"
+  )
+  eri_guide()
+})
+
+test_that("picking the resume option lands directly in the remembered category", {
+  withr::local_options(rlang_interactive = TRUE, erifunctions.guide_last_branch = NULL)
+  tree <- .eri_task_map()
+
+  local_mocked_bindings(.eri_prompt_menu = scripted(list(1L, 0L, 0L)), .package = "erifunctions")
+  eri_guide()  # records tree[[1]]$id as the last-visited branch
+
+  leaf_menu_title   <- NULL
+  visited_leaf_menu <- FALSE
+  local_mocked_bindings(
+    .eri_prompt_menu = function(title, choices) {
+      if (identical(title, "What are you trying to do?")) {
+        # "Continue in ..." the first time; once we've already seen the leaf menu, exit --
+        # otherwise this would pick "Continue" forever, since backing out of the leaf menu only
+        # returns to THIS top-level menu, not out of eri_guide()'s own loop.
+        return(if (!visited_leaf_menu) 1L else 0L)
+      }
+      leaf_menu_title   <<- title
+      visited_leaf_menu <<- TRUE
+      0L  # back out of the leaf menu
+    },
+    .package = "erifunctions"
+  )
+  eri_guide()
+  expect_equal(leaf_menu_title, tree[[1]]$title)
+})

--- a/tests/testthat/test-guide.R
+++ b/tests/testthat/test-guide.R
@@ -1,17 +1,7 @@
 #### Tests for eri_guide() and its internal helpers ####
-
-# Returns a function that yields the next element of `responses` on each call,
-# ignoring its arguments -- the standard "scripted decision sequence" pattern
-# already used for eri_dq_review() (test-dq_review.R), reused here to script
-# .eri_prompt_menu() for eri_guide()'s own menu loop.
-scripted <- function(responses) {
-  i <- 0L
-  function(...) {
-    i <<- i + 1L
-    if (i > length(responses)) stop("scripted responses exhausted at call ", i)
-    responses[[i]]
-  }
-}
+#
+# scripted() (the interactive-menu mocking helper) lives in helper-scripted.R, shared with
+# test-dq_review.R.
 
 test_that("eri_guide refuses to run non-interactively", {
   expect_error(eri_guide(), "interactive-only")

--- a/tests/testthat/test-task-map.R
+++ b/tests/testthat/test-task-map.R
@@ -77,6 +77,37 @@ test_that("every `call:` template parses as valid R", {
   }
 })
 
+test_that("every `call:` template represents every required argument of its own function", {
+  # A parseable call can still omit a REQUIRED argument (no default) and just look abbreviated --
+  # this caught two real cases: start_project's eri_research_init(project_name) dropped 3 required
+  # args, and population_totals's eri_spatial_pop(boundaries) used the wrong name entirely (real
+  # param is `shapefile`). Optional args (with a default) may still be omitted, per the registry's
+  # own documented convention -- only required ones are checked here.
+  tree <- .eri_task_map()
+  for (branch in tree) {
+    for (leaf in branch$children) {
+      call_expr <- str2lang(leaf$call)
+      fn_name   <- as.character(call_expr[[1]])
+      # Positional arg tokens as written in the call template (not match.arg'd -- this is
+      # illustrative text a user reads, not something actually invoked).
+      call_arg_syms <- vapply(as.list(call_expr)[-1], function(a) as.character(a), character(1))
+
+      fn <- get(fn_name, envir = asNamespace("erifunctions"))
+      f  <- formals(fn)
+      required <- setdiff(
+        names(f)[vapply(f, function(d) identical(d, quote(expr = )), logical(1))],
+        "..."  # dots are never spelled out in a call template
+      )
+
+      missing <- setdiff(required, call_arg_syms)
+      expect_length(missing, 0L)
+      if (length(missing) > 0) {
+        cli::cli_inform("{leaf$id}: {.fn {fn_name}} call is missing required arg(s) {.val {missing}}")
+      }
+    }
+  }
+})
+
 test_that("every `next:` id resolves to a real task id in the tree", {
   tree <- .eri_task_map()
   ids <- unlist(lapply(tree, function(b) vapply(b$children, function(l) l$id, character(1))))


### PR DESCRIPTION
## Summary
- Phase 7 of the docs-site & guidance-system redesign: `eri_guide(task_id=)` jumps straight to a task's detail screen; `eri_guide()` remembers the last-visited category this session and offers to resume it (`getOption()`/`options()`, same convention as `eri_verbosity()`).
- "Preflight checks" scoped conservatively — real per-function argument collection stays out of scope (most leaves mix simple strings with real R objects a prompt can't safely fabricate); the existing "Run it now" `tryCatch` (Phase 5) is treated as the guardrail.
- A registry accuracy sweep found two real bugs a "does it parse" check couldn't catch: `start_project`'s call dropped 3 required args, `population_totals`'s call used a parameter name that doesn't exist on the real function. Both fixed; `test-task-map.R` gained a permanent check for this whole class of bug.
- A roxygen title/`@family` audit (`roxygen2::parse_package()`, not eyeballing) found one real title issue across all 156 exported functions (fixed) and added `@family` tags to 25 functions across 3 tight clusters (CMR pipeline, DQ schema override, ODK Central).
- **Caught and fixed a real bug in test code** that sent `eri_guide()` into an infinite "Run it now" loop hitting the real `eridev` Azure tenant repeatedly before the runaway process was killed. No data was written (a read-only auth handshake), but real API calls hit live infrastructure from what was meant to be an offline test — root cause was a `scripted()` mock closure re-created fresh inside its own wrapper function, so it never advanced past its first response. Fixed, plus a second related infinite-loop bug it exposed.
- Version bumped 0.9.25 → 0.9.26.

## Test plan
- [x] `devtools::document()` — `NAMESPACE`/25 `@family`-tagged Rd files/`eri_guide.Rd`/`erifunctions_io.Rd` regenerated
- [x] `devtools::test()` — full suite green (2781 pass, 0 fail)
- [x] Verified no runaway/live-Azure-hitting test loops remain (both bugs found and fixed; confirmed via bounded reruns)
- [ ] CI (R-CMD-check, pkgdown)
- [ ] review-agent pass