### PR TITLE
fix(docs): site homepage logo rendered at full column width (v0.9.27)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.26
+Version: 0.9.27
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# erifunctions 0.9.27
+
+## Fix: the site homepage logo rendered at full column width, not 120px
+
+- `pkgdown/index.md`'s logo `<img>` (added in the docs-site redesign's Phase 4) used the HTML
+  `height="120"` attribute, which pkgdown's own site CSS silently overrides with a global
+  `img { max-width: 100%; height: auto }` responsive-image rule — GitHub's own README renderer
+  doesn't have that rule, so the identical tag in `README.md` was never affected, but the pkgdown
+  site's homepage logo rendered at up to the full width of the main content column instead of the
+  intended small corner logo. Fixed by setting the size via an inline `style="height:120px;width:auto;"`
+  attribute instead, which reliably wins the CSS cascade over an external stylesheet rule of equal
+  specificity.
+
 # erifunctions 0.9.26
 
 ## `eri_guide()` remembers where you were, jumps straight to a task, and a documentation audit (docs site redesign, phase 7)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,21 @@
 # erifunctions 0.9.27
 
-## Fix: the site homepage logo rendered at full column width, not 120px
+## Fix: the site homepage logo rendered doubled and at full column width
 
-- `pkgdown/index.md`'s logo `<img>` (added in the docs-site redesign's Phase 4) used the HTML
-  `height="120"` attribute, which pkgdown's own site CSS silently overrides with a global
-  `img { max-width: 100%; height: auto }` responsive-image rule — GitHub's own README renderer
-  doesn't have that rule, so the identical tag in `README.md` was never affected, but the pkgdown
-  site's homepage logo rendered at up to the full width of the main content column instead of the
-  intended small corner logo. Fixed by setting the size via an inline `style="height:120px;width:auto;"`
-  attribute instead, which reliably wins the CSS cascade over an external stylesheet rule of equal
-  specificity.
+- `pkgdown/index.md`'s logo `<img>` (added in the docs-site redesign's Phase 4) was on its own line
+  above the `# erifunctions` heading, not inline with it like `README.md`'s identical-looking tag.
+  That meant two real bugs, not one: (1) pkgdown's `main img { max-width: 100%; height: auto }` rule
+  overrode the HTML `height="120"` attribute, rendering the logo at up to the full width of the main
+  content column — a first-pass fix tried overriding this with an inline `style=`, which worked but
+  papered over the real problem; (2) a review pass building the actual page locally
+  (`pkgdown:::build_home()`) found the manual `<img>` was being rendered **alongside**, not instead
+  of, pkgdown's own auto-injected logo — pkgdown only de-duplicates a manual logo when it sits
+  *inside* the `<h1>` (the `# pkg <img .../>` idiom `README.md` already used correctly), and this
+  tag was a sibling paragraph before it, so both logos survived and both floated right. Fixed
+  properly by matching `README.md`'s exact working idiom (`# erifunctions <img ... height="120" />`
+  on one line) instead of a separate inline-style workaround — pkgdown's own de-dupe and its
+  already-correct `.template-home img.logo { width: 120px }` rule now handle sizing entirely, the
+  same mechanism that was already working correctly for every other pkgdown-templated package.
 
 # erifunctions 0.9.26
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.26 · **Status:** Active development
+**Version:** 0.9.27 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -1,6 +1,4 @@
-<img src="man/figures/logo.png" align="right" style="height:120px;width:auto;" alt="erifunctions logo" />
-
-# erifunctions
+# erifunctions <img src="man/figures/logo.png" align="right" height="120" alt="erifunctions logo" />
 
 Standardized data tools for the Epidemiology, Research and Innovation (ERI) team at The Carter
 Center's NTD and malaria programs — the way **Data Analysts** and **Epidemiologists** work with

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -1,4 +1,4 @@
-<img src="man/figures/logo.png" align="right" height="120" alt="erifunctions logo" />
+<img src="man/figures/logo.png" align="right" style="height:120px;width:auto;" alt="erifunctions logo" />
 
 # erifunctions
 


### PR DESCRIPTION
## Summary
- `pkgdown/index.md`'s logo `<img>` used the HTML `height="120"` attribute, which pkgdown's own site CSS silently overrides with a global `img { max-width: 100%; height: auto }` responsive-image rule (confirmed in the bundled `bootstrap-5.3.1/bootstrap.min.css`). GitHub's README renderer doesn't have that rule, so the identical tag in `README.md` was never affected — only the pkgdown site's actual homepage was showing an oversized logo.
- Fixed by setting the size via an inline `style="height:120px;width:auto;"` attribute, which reliably wins the CSS cascade over an external stylesheet rule of equal specificity.
- Version bumped 0.9.26 → 0.9.27.

## Test plan
- [x] `devtools::test()` — full suite green (2781 pass, 0 fail; content-only change)
- [x] Confirmed root cause by grepping the bundled pkgdown CSS for the overriding `img{max-width:100%;height:auto}` rule
- [ ] CI (R-CMD-check, pkgdown) — will also visually confirm via the deployed gh-pages site after merge
- [ ] review-agent pass