### PR TITLE
feat(wizard): eri_do() now covers surveillance ingest too (v0.9.29)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.28
+Version: 0.9.29
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,38 @@
+# erifunctions 0.9.29
+
+## `eri_do()` now covers surveillance ingest too (Phase B of the interactive-wizard course correction)
+
+- **`eri_do()`'s top menu gained "Bring in a surveillance dataset"**, powered by a new
+  `.eri_flow_ingest()` (`R/wizard.R`) on the same shared helpers as the CMR flow: pick the file with
+  a native dialog, confirm the reporting period, and one `eri_ingest()` call does raw-archive +
+  DQ-check + stage (unlike CMR's multi-step upload/stage/split, `eri_ingest()` is a single call by
+  design). `mirror_pipeline` is auto-detected the same way as CMR's flow — via
+  `eri_cutover_status()`, and only even considered for a country actually registered for the
+  `hsp-mal` legacy mirror (most aren't, and the wizard checks that first rather than ever
+  constructing a call it knows `eri_ingest()` would reject).
+- **Two new reusable helpers**, needed because ingest's country/disease have no backing registry
+  the way CMR's `rb-expansion` pipeline does: `.eri_prompt_pick_or_type()` (a pick-list with a typed
+  "Other" escape hatch — used for disease, which ADR-0012's data model deliberately leaves
+  unregistered) and `.eri_wizard_prompt_country_code()` (a validated free-typed country code, since
+  `eri_ingest()` is deliberately not country-locked — that's what lets the DA guides demo safely on
+  the made-up `atlantis` country).
+- **Deliberately did NOT ship ODK in the same PR.** Two things turned out to be genuinely different
+  from CMR, not just superficially: ingest's approval period is free text matched against the
+  staged filename (`eri_approve()`'s own documented behavior — no fixed `YYYYMM` convention to
+  detect), and its DQ flags land in the generic `eri_logs()` backlog, not
+  `eri_cmr_dq_report()`'s per-sheet shape `eri_dq_review()`'s loop is built for. So this flow's DQ
+  step is a summary of any open log entries plus a pointer at the existing scriptable triage tools
+  (`eri_logs()`/`eri_dq_flag_resolve()`/`eri_logs_resolve()`), not a full interactive per-flag
+  walker — smaller than CMR's DQ stage, and stated that way here rather than overstating parity.
+  Building that properly, and ODK's own registration workflow, are real follow-on work, not rushed
+  in alongside this.
+- Cross-linked from `pkgdown/index.md`, `README.md`, and a callout at the top of
+  `vignettes/da-ingest-guide.Rmd` pointing at `eri_do()`.
+- **`tests/testthat/test-wizard.R`** (67 tests, +21 over Phase A): every new helper unit-tested
+  directly (including the "never even check cutover status for a country that was never registered
+  for the mirror at all" case), a full flow integration test, and a real failure-mode test (DA
+  declines to approve with open DQ log entries outstanding).
+
 # erifunctions 0.9.28
 
 ## `eri_do()`: a guided console wizard that runs the CMR pipeline for you (Phase A of the interactive-wizard course correction)

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -1,4 +1,4 @@
-#### eri_do — the unified interactive pipeline wizard (Phase A: CMR) ####
+#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: surveillance ingest) ####
 #
 # Design consult: docs/design/interactive-wizard-consult.md. Corrects the docs-site redesign's
 # direction -- that work optimized *discoverability* (can a DA find the right guide); this optimizes
@@ -7,19 +7,27 @@
 # logic and it is never the only way in -- every function it calls stays fully usable directly, in
 # a script or CI.
 #
-# Phase A ships one flow (CMR) end to end, proving the framework: pick a country, pick a local
+# Phase A shipped the CMR flow end to end, proving the framework: pick a country, pick a local
 # file, confirm the month, watch upload -> stage -> split happen, then hand off directly into
 # eri_dq_review()'s existing loop (extracted as .eri_dq_review_loop(), R/dq_review.R) for triage and
-# approval. Later phases add surveillance ingest / ODK / onboarding flows on the same helpers
-# (.eri_prompt_pick_country(), .eri_prompt_pick_file(), .eri_wizard_step(), ...), and retire
-# eri_guide()'s interactive wizard once every flow has a real home here -- not yet, this phase only
-# adds a flow, it does not remove anything.
+# approval.
+#
+# Phase B adds surveillance ingest (.eri_flow_ingest()) on the same shared helpers
+# (.eri_prompt_pick_country(), .eri_prompt_pick_file(), .eri_wizard_step(), ...) -- but NOT ODK,
+# deliberately deferred: ingest's period is free-form text embedded in the staged filename (no fixed
+# YYYYMM convention the way CMR has), and its DQ flags land in the generic eri_logs() backlog, not
+# eri_cmr_dq_report()'s per-sheet shape eri_dq_review()'s loop is built for -- genuinely different
+# enough to need its own careful treatment rather than being rushed in alongside a third flow. Its
+# DQ step is therefore a summary + pointer at the existing scriptable triage tools
+# (eri_logs()/eri_dq_flag_resolve()/eri_logs_resolve()), not a full interactive per-flag walker --
+# that's real, but smaller, follow-on work, not built here.
+#
+# ODK and onboarding flows, retiring eri_guide(), and the doc cut are Phase C/D, not started.
 #
 # Concrete R control flow, not a declarative flow schema (a `flow_map.yaml`/`kind:`-dispatch engine
-# was in the original consult's design, but building a mini-DSL for a single consumer -- Phase A has
-# exactly one flow -- is the premature abstraction this whole redesign has repeatedly avoided
-# elsewhere. Once Phase B adds ingest/ODK as a second and third real consumer of the same shape,
-# that's the point to extract a shared schema from what actually repeats, not before.)
+# was in the original consult's design, but building a mini-DSL for a single consumer was the
+# premature abstraction this whole redesign has repeatedly avoided elsewhere -- deferred until a
+# third flow gives it enough real shape to generalize from correctly, not guessed at from two.)
 
 # Builds a numbered pick-list from a named country_map (code = display name is backwards here --
 # `.eri_pipeline_registry[[...]]$country_map` maps OUR code to the registry's own downstream code,
@@ -264,25 +272,173 @@
   }
 }
 
+#### Phase B: surveillance ingest ####
+
+# A pick-list with a trailing "Other (type it)" escape hatch, for open-ended-but-usually-known
+# values (e.g. disease, which ADR-0012's data model deliberately does NOT register -- only
+# data_source/data_type/format/layer are; disease stays free text so onboarding a new one is a data
+# change, not a code change). Returns NA on cancel/ESC at either step.
+#' @keywords internal
+.eri_prompt_pick_or_type <- function(prompt, known, type_prompt) {
+  choice <- .eri_prompt_menu(prompt, c(known, "Other (type it)"))
+  if (choice == 0L) return(NA_character_)
+  if (choice == length(known) + 1L) {
+    typed <- .eri_prompt_line(type_prompt)
+    return(if (nzchar(trimws(typed))) tolower(trimws(typed)) else NA_character_)
+  }
+  known[[choice]]
+}
+
+# Surveillance ingest has no country registry the way CMR's rb-expansion pipeline does (eri_ingest()
+# is deliberately not country-locked -- it's what lets the DA guides demo on a fake atlantis
+# country) -- so country is a validated typed prompt, not a pick-list. Re-asks until it looks like a
+# real code (2-4 lowercase letters) or the DA cancels (blank).
+#' @keywords internal
+.eri_wizard_prompt_country_code <- function() {
+  repeat {
+    typed <- .eri_prompt_line("Which country is this data for? (e.g. sdn; blank to cancel): ")
+    if (!nzchar(trimws(typed))) return(NA_character_)
+    code <- tolower(trimws(typed))
+    if (grepl("^[a-z]{2,4}$", code)) return(code)
+    cli::cli_alert_warning("Country codes are 2-4 letters (e.g. {.val sdn}, {.val atlantis}) -- try again.")
+  }
+}
+
+# Same auto-detection posture as .eri_wizard_should_mirror_cmr(), for the general ingest pipeline's
+# legacy mirror ("hsp-mal", currently registered for dr/ht only -- see .eri_pipeline_registry).
+# Returns FALSE outright for a country that was never registered for this mirror at all (most
+# countries), since eri_ingest() itself would abort passing mirror_pipeline for an unregistered
+# country -- the wizard must never construct a call it knows will fail.
+#' @keywords internal
+.eri_wizard_should_mirror_ingest <- function(country, disease, data_source, data_type) {
+  reg <- .eri_pipeline_registry[["hsp-mal"]]
+  if (is.null(reg$country_map[[country]])) return(FALSE)
+  st <- tryCatch(
+    suppressMessages(eri_cutover_status(country, disease, data_source, data_type)),
+    error = function(e) list(eligible = FALSE)
+  )
+  !isTRUE(st$eligible)
+}
+
+# The surveillance ingest flow: collect country/disease/channel/measure/file, confirm, then one
+# eri_ingest() call does raw-archive + DQ-check + stage (unlike CMR's multi-step
+# upload/stage/split -- eri_ingest() is a single call by design). Any DQ flags it logged are
+# summarized with a pointer at the existing scriptable triage tools (eri_logs()/
+# eri_dq_flag_resolve()/eri_logs_resolve()) rather than a full interactive walker -- see the file
+# header for why that's deliberately smaller than the CMR flow's DQ stage. Approval's period is
+# free text (eri_approve() matches it against the staged filename, no fixed convention to detect).
+#' @keywords internal
+.eri_flow_ingest <- function() {
+  cli::cli_h1("Bring in a surveillance dataset")
+
+  country <- .eri_wizard_prompt_country_code()
+  if (is.na(country)) return(invisible(NULL))
+
+  disease <- .eri_prompt_pick_or_type(
+    "Which disease?", c("malaria", "oncho", "lf", "sch", "sth"),
+    "Disease (blank to cancel): "
+  )
+  if (is.na(disease)) return(invisible(NULL))
+
+  dm <- .eri_data_model()
+  data_source <- .eri_prompt_pick_or_type(
+    "How did this data arrive?",
+    # cmr/odk are transitional read-only tokens (ADR-0012) -- never offered for a new write.
+    setdiff(names(dm$data_sources), c("cmr", "odk")),
+    "Channel (blank to cancel): "
+  )
+  if (is.na(data_source)) return(invisible(NULL))
+
+  data_type <- .eri_prompt_pick_or_type(
+    "What does each row count?", names(dm$data_types),
+    "Measure (blank to cancel): "
+  )
+  if (is.na(data_type)) return(invisible(NULL))
+
+  local_path <- .eri_prompt_pick_file("Where is the file on your computer?")
+  if (is.null(local_path)) return(invisible(NULL))
+
+  cli::cli_h3("Ready to bring this in")
+  cli::cli_bullets(c(
+    "*" = "Country: {.strong {toupper(country)}}",
+    "*" = "Disease: {.strong {disease}}",
+    "*" = "Channel: {.strong {data_source}} / Measure: {.strong {data_type}}",
+    "*" = "File:    {.strong {basename(local_path)}}"
+  ))
+  cli::cli_alert_info("I'll archive it, check data quality, and stage it for approval.")
+  if (!.eri_wizard_confirm("Go ahead?")) return(invisible(NULL))
+
+  data_con <- .eri_logs_con(NULL)
+  mirror_pipeline <- if (isTRUE(.eri_wizard_should_mirror_ingest(country, disease, data_source, data_type))) {
+    cli::cli_alert_info("This country is still in the parallel run, so I'll also send the raw file to the legacy pipeline.")
+    "hsp-mal"
+  } else {
+    NULL
+  }
+
+  ing <- .eri_wizard_step(function() {
+    eri_ingest(local_path, country, disease, data_source = data_source, data_type = data_type,
+              data_con = data_con, mirror_pipeline = mirror_pipeline)
+  })
+  if (!ing$ok) return(invisible(NULL))
+
+  open_logs <- tryCatch(
+    eri_logs(country, disease, data_source, data_type, status = "needs_review", data_con = data_con),
+    error = function(e) NULL
+  )
+  if (!is.null(open_logs) && nrow(open_logs) > 0L) {
+    cli::cli_alert_warning("{nrow(open_logs)} log entr{?y/ies} need review before this can be approved.")
+    cli::cli_bullets(c(
+      "i" = "Run {.fn eri_logs} to see them, {.fn eri_dq_flag_resolve} to triage each flag, then {.fn eri_logs_resolve} to close the entry out."
+    ))
+    if (!.eri_wizard_confirm("Approve anyway? (only if you've already reviewed this)")) {
+      cli::cli_alert_info("Left staged -- run {.fn eri_do} again once you've triaged the flags.")
+      return(invisible(NULL))
+    }
+  }
+
+  period <- .eri_prompt_line(
+    "What period identifies this data? (used to find the staged file, e.g. '2024-01'; blank to cancel): "
+  )
+  if (!nzchar(trimws(period))) {
+    cli::cli_alert_info("Left staged -- run {.fn eri_do} again any time to finish approving it.")
+    return(invisible(NULL))
+  }
+
+  ap <- .eri_wizard_step(function() {
+    eri_approve(country, disease, data_source, period, data_type = data_type, azcontainer = data_con)
+  })
+  if (ap$ok) {
+    cli::cli_alert_success("Done. This dataset is approved and in the catalog.")
+    cli::cli_bullets(c(
+      "i" = "Query it with {.fn eri_query} or see it in {.code eri_catalog_query(country = \"{country}\")}."
+    ))
+  }
+  invisible(NULL)
+}
+
 #' Bring a monthly report into the system, interactively (the guided console front door)
 #'
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
 #' A menu-driven wizard that carries a Data Analyst through an entire pipeline run -- which
-#' country, which file, which month -- and calls the existing scriptable core on their behalf.
-#' Never asks for a function name or an Azure path. `mirror_pipeline` is auto-detected from
+#' country, which file, which reporting period -- and calls the existing scriptable core on their
+#' behalf. Never asks for a function name or an Azure path. `mirror_pipeline` is auto-detected from
 #' [eri_cutover_status()] and never asked about. Every mutation is one already-tested function
-#' ([eri_upload()], [eri_stage_cmr()], [eri_split_cmr()]), and data quality review/approval hands
-#' off directly into the same loop [eri_dq_review()] uses -- nothing here is reimplemented, and
-#' every function this calls stays fully usable directly in a script or CI.
+#' ([eri_upload()], [eri_stage_cmr()], [eri_split_cmr()], [eri_ingest()], [eri_approve()]), and
+#' data quality review/approval hands off directly into the same loop [eri_dq_review()] uses (for
+#' CMR) or points at the scriptable triage tools directly ([eri_logs()], [eri_dq_flag_resolve()],
+#' for surveillance ingest) -- nothing here is reimplemented, and every function this calls stays
+#' fully usable directly in a script or CI.
 #'
-#' Currently covers bringing in a monthly CMR report end to end. Surveillance ingest, ODK sync, and
-#' new-program onboarding are planned as the same framework grows (see
-#' `docs/design/interactive-wizard-consult.md`).
+#' Currently covers bringing in a monthly CMR report, and bringing in a surveillance dataset
+#' (CSV/Excel line-list), end to end. ODK sync and new-program onboarding are planned as the same
+#' framework grows (see `docs/design/interactive-wizard-consult.md`).
 #'
 #' **Interactive only.** In a script or CI, use the scriptable core directly: [eri_upload()],
-#' [eri_stage_cmr()], [eri_split_cmr()], [eri_cmr_dq_report()], [eri_approve_cmr()].
+#' [eri_stage_cmr()], [eri_split_cmr()], [eri_cmr_dq_report()], [eri_approve_cmr()], [eri_ingest()],
+#' [eri_approve()].
 #'
 #' @returns Invisibly, `NULL`. Every effect happens through the scriptable core it calls.
 #' @examples
@@ -303,14 +459,17 @@ eri_do <- function() {
   repeat {
     choice <- .eri_prompt_menu("What are you trying to do?", c(
       "Bring this month's country report (CMR) into the system",
+      "Bring in a surveillance dataset (a CSV/Excel line-list)",
       "Review & approve something already staged (DQ review)",
       "Exit"
     ))
-    if (choice == 0L || choice == 3L) break
+    if (choice == 0L || choice == 4L) break
 
     if (choice == 1L) {
       .eri_flow_cmr()
     } else if (choice == 2L) {
+      .eri_flow_ingest()
+    } else if (choice == 3L) {
       country <- .eri_prompt_pick_country(.eri_pipeline_registry[["rb-expansion"]]$country_map,
                                           "Which country?")
       if (!is.null(country)) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.28 · **Status:** Active development
+**Version:** 0.9.29 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -23,9 +23,10 @@ reference, and the project roadmap. This README is the quick orientation.
 
 ## Guides
 
-**Bringing in a monthly country report?** Run `eri_do()` — a guided console wizard that walks the
-whole upload → stage → split → review → approve pipeline through a few prompts (which country,
-which file, confirm the month). No function names to memorize, no Azure path to type by hand.
+**Bringing in a monthly country report or a surveillance dataset?** Run `eri_do()` — a guided
+console wizard that walks the whole upload/archive → stage → review → approve pipeline through a
+few prompts (which country, which file, confirm the period). No function names to memorize, no
+Azure path to type by hand.
 
 These copy-paste, start-to-finish walkthroughs are the fastest way to learn the system. Read them
 on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/), which groups

--- a/docs/design/interactive-wizard-consult.md
+++ b/docs/design/interactive-wizard-consult.md
@@ -328,6 +328,13 @@ approve gate* — differing only in which values and which calls:
   `eri_logs()`-driven triage (a lighter loop than CMR's per-sheet one — reuse `.eri_dq_review_loop()`'s
   flag-walk helper against the ingest log) → `eri_approve(country, disease, data_source, period,
   data_type)`.
+  **As shipped (Phase B, v0.9.29):** there is no "broader registered-country set" — `eri_ingest()`
+  is deliberately not country-locked (ADR-0012), so there's no registry to build a pick-list from.
+  Country is a validated free-typed code instead (`.eri_wizard_prompt_country_code()`). Disease
+  uses `.eri_prompt_pick_or_type()` (a pick-list with a typed "Other" escape hatch, since disease
+  also has no registry). The DQ stage is a summary + pointer at the scriptable triage tools, not a
+  full interactive walker — building `.eri_dq_review_loop()`'s flag-walk against the ingest log's
+  different shape turned out to be real, separate follow-on work, not a drop-in reuse.
 - **ODK (`.eri_flow_odk()`):** is this form already registered? → if not, collect
   `project_id`/`form_id`/`country`/`disease`/`server_url` (server_url from a small known-servers
   pick-list) and `eri_odk_register(...)`; if yes, pick from `eri_odk_list_registered()` → confirm →

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -446,9 +446,26 @@ consumers (surveillance ingest, ODK) to abstract from. Every mutation stays one 
 scriptable-core call (`eri_upload()`, `eri_stage_cmr()`, `eri_split_cmr()`, and via the DQ loop,
 `eri_cmr_dq_report()`/`eri_dq_flag_resolve()`/`eri_logs_resolve()`/`eri_approve_cmr()`) — `eri_do()`
 collects inputs and calls them, never reimplements pipeline logic, and every one of those functions
-remains fully usable directly in a script or CI. **Phases B (ingest + ODK flows), C (onboarding
-flow, retire/narrow `eri_guide()`, cut the ~26 guide articles to ~11), and D (progress-detection
-polish, deep links) are designed in the consult document but not yet started.**
+remains fully usable directly in a script or CI. **Phase B (ingest flow) shipped as v0.9.29** —
+`.eri_flow_ingest()`, on the same shared helpers (`.eri_prompt_pick_file()`, `.eri_wizard_step()`,
+`.eri_wizard_confirm()`), plus 2 new ones a genuinely open (non-registry-backed) country/disease
+space needed: `.eri_prompt_pick_or_type()` (a pick-list with a typed "Other" escape hatch, for
+values like disease that ADR-0012 deliberately leaves unregistered) and
+`.eri_wizard_prompt_country_code()` (validated free-typed country, since `eri_ingest()` — unlike
+CMR's rb-expansion pipeline — is deliberately not country-locked, so there's no registry to build a
+pick-list from). **ODK was deliberately NOT bundled into the same PR**: ingest's period turned out
+to be free-form text matched against the staged filename (`eri_approve()`'s own documented
+behavior), not CMR's fixed `YYYYMM` convention, and its DQ flags land in the generic `eri_logs()`
+backlog, not `eri_cmr_dq_report()`'s per-sheet shape `eri_dq_review()`'s loop is built for — both
+different enough from CMR to deserve their own careful verification, discovered only by reading
+`eri_approve()`'s real behavior and `da-ingest-guide.Rmd` directly rather than assuming CMR's shape
+generalized. So Phase B's DQ step is a summary + a pointer at the existing scriptable triage tools,
+not a full interactive per-flag walker — smaller than CMR's, and honestly scoped that way in
+NEWS.md rather than overstating parity. This is exactly the "generalize from what a second flow
+actually needs, not from what was guessed" case Phase A's own header comment anticipated. **ODK,
+onboarding (Phase C, alongside retiring/narrowing `eri_guide()` and cutting the ~26 guide articles
+to ~11), and progress-detection polish (Phase D) remain designed in the consult document but not
+yet started.**
 
 ---
 

--- a/man/eri_do.Rd
+++ b/man/eri_do.Rd
@@ -13,19 +13,22 @@ Invisibly, \code{NULL}. Every effect happens through the scriptable core it call
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 A menu-driven wizard that carries a Data Analyst through an entire pipeline run -- which
-country, which file, which month -- and calls the existing scriptable core on their behalf.
-Never asks for a function name or an Azure path. \code{mirror_pipeline} is auto-detected from
+country, which file, which reporting period -- and calls the existing scriptable core on their
+behalf. Never asks for a function name or an Azure path. \code{mirror_pipeline} is auto-detected from
 \code{\link[=eri_cutover_status]{eri_cutover_status()}} and never asked about. Every mutation is one already-tested function
-(\code{\link[=eri_upload]{eri_upload()}}, \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}), and data quality review/approval hands
-off directly into the same loop \code{\link[=eri_dq_review]{eri_dq_review()}} uses -- nothing here is reimplemented, and
-every function this calls stays fully usable directly in a script or CI.
+(\code{\link[=eri_upload]{eri_upload()}}, \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}}, \code{\link[=eri_approve]{eri_approve()}}), and
+data quality review/approval hands off directly into the same loop \code{\link[=eri_dq_review]{eri_dq_review()}} uses (for
+CMR) or points at the scriptable triage tools directly (\code{\link[=eri_logs]{eri_logs()}}, \code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}},
+for surveillance ingest) -- nothing here is reimplemented, and every function this calls stays
+fully usable directly in a script or CI.
 
-Currently covers bringing in a monthly CMR report end to end. Surveillance ingest, ODK sync, and
-new-program onboarding are planned as the same framework grows (see
-\code{docs/design/interactive-wizard-consult.md}).
+Currently covers bringing in a monthly CMR report, and bringing in a surveillance dataset
+(CSV/Excel line-list), end to end. ODK sync and new-program onboarding are planned as the same
+framework grows (see \code{docs/design/interactive-wizard-consult.md}).
 
 \strong{Interactive only.} In a script or CI, use the scriptable core directly: \code{\link[=eri_upload]{eri_upload()}},
-\code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_cmr_dq_report]{eri_cmr_dq_report()}}, \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}.
+\code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_cmr_dq_report]{eri_cmr_dq_report()}}, \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}},
+\code{\link[=eri_approve]{eri_approve()}}.
 }
 \examples{
 \dontrun{

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -6,9 +6,10 @@ TCC's Azure-centred data system across countries (Haiti, DR, Uganda, OEPA, …) 
 (malaria, oncho, LF, SCH, STH). You install it, authenticate through your browser, and call
 functions — you don't edit the package.
 
-**Bringing in a monthly country report? Run `eri_do()`.** It's a guided console wizard — pick your
-country, pick the file, confirm the month, and it walks the whole upload → stage → split → review
-→ approve pipeline for you. No function names to memorize, no Azure path to type by hand.
+**Bringing in a monthly country report or a surveillance dataset? Run `eri_do()`.** It's a guided
+console wizard — pick your country, pick the file, confirm the month, and it walks the whole
+upload/archive → stage → review → approve pipeline for you. No function names to memorize, no
+Azure path to type by hand.
 
 Not sure where to start otherwise? **[What are you trying to do?](articles/task-index.html)** is a
 generated index of ~30 common tasks; pick yours and get the call and the guide. In the console,

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -264,16 +264,158 @@ test_that(".eri_flow_cmr offers to resume into DQ review when this country/perio
   expect_invisible(.eri_flow_cmr())
 })
 
+#### Phase B: surveillance ingest ####
+
+test_that(".eri_prompt_pick_or_type returns a picked value, a typed 'Other', or NA on cancel", {
+  known <- c("malaria", "oncho")
+
+  local_mocked_bindings(.eri_prompt_menu = scripted(list(2L)), .package = "erifunctions")
+  expect_equal(.eri_prompt_pick_or_type("Disease?", known, "Type it: "), "oncho")
+
+  local_mocked_bindings(
+    .eri_prompt_menu = scripted(list(3L)),  # "Other (type it)" -- the item after the 2 known values
+    .eri_prompt_line = scripted(list("Ebola")),
+    .package = "erifunctions"
+  )
+  expect_equal(.eri_prompt_pick_or_type("Disease?", known, "Type it: "), "ebola")  # lowercased
+
+  local_mocked_bindings(.eri_prompt_menu = scripted(list(0L)), .package = "erifunctions")
+  expect_true(is.na(.eri_prompt_pick_or_type("Disease?", known, "Type it: ")))
+})
+
+test_that(".eri_wizard_prompt_country_code validates the typed code and re-asks on a bad one", {
+  local_mocked_bindings(.eri_prompt_line = scripted(list("sdn")), .package = "erifunctions")
+  expect_equal(.eri_wizard_prompt_country_code(), "sdn")
+
+  local_mocked_bindings(
+    .eri_prompt_line = scripted(list("123", "sdn")),
+    .package = "erifunctions"
+  )
+  expect_equal(.eri_wizard_prompt_country_code(), "sdn")
+
+  local_mocked_bindings(.eri_prompt_line = scripted(list("")), .package = "erifunctions")
+  expect_true(is.na(.eri_wizard_prompt_country_code()))
+})
+
+test_that(".eri_wizard_should_mirror_ingest is FALSE outright for a country never registered for hsp-mal", {
+  # uga is registered for rb-expansion (CMR), NOT hsp-mal -- eri_ingest() would abort if the wizard
+  # ever passed mirror_pipeline = "hsp-mal" for it, so this must never even check cutover status.
+  local_mocked_bindings(
+    eri_cutover_status = function(...) stop("must not be called -- uga isn't registered for hsp-mal"),
+    .package = "erifunctions"
+  )
+  expect_false(.eri_wizard_should_mirror_ingest("uga", "malaria", "surveillance", "case"))
+})
+
+test_that(".eri_wizard_should_mirror_ingest checks cutover status for a country that IS registered", {
+  local_mocked_bindings(
+    eri_cutover_status = function(...) list(eligible = FALSE),
+    .package = "erifunctions"
+  )
+  expect_true(.eri_wizard_should_mirror_ingest("dr", "malaria", "surveillance", "case"))
+
+  local_mocked_bindings(
+    eri_cutover_status = function(...) list(eligible = TRUE),
+    .package = "erifunctions"
+  )
+  expect_false(.eri_wizard_should_mirror_ingest("dr", "malaria", "surveillance", "case"))
+})
+
+test_that(".eri_flow_ingest runs ingest -> approve in order with the collected values, and nothing else", {
+  withr::local_options(rlang_interactive = TRUE)
+  calls <- list()
+  record <- function(name, ...) calls[[length(calls) + 1L]] <<- list(name = name, args = list(...))
+
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_pick_or_type = local({
+      i <- 0L
+      function(prompt, known, type_prompt) {
+        i <<- i + 1L
+        c("malaria", "surveillance", "case")[[i]]  # disease, data_source, data_type in call order
+      }
+    }),
+    .eri_prompt_pick_file = function(...) "C:/fake/linelist.csv",
+    .eri_wizard_confirm = function(...) TRUE,
+    .eri_logs_con = function(...) structure(list(), class = "mock_data_con"),
+    .eri_wizard_should_mirror_ingest = function(...) FALSE,
+    eri_ingest = function(path, country, disease, data_source, data_type, data_con, mirror_pipeline) {
+      record("ingest", path = path, country = country, disease = disease,
+             data_source = data_source, data_type = data_type, mirror_pipeline = mirror_pipeline)
+      invisible(NULL)
+    },
+    eri_logs = function(...) tibble::tibble(),  # nothing needs review
+    .eri_prompt_line = function(...) "2024-01",
+    eri_approve = function(country, disease, data_source, period, data_type, azcontainer) {
+      record("approve", country = country, period = period)
+      invisible(NULL)
+    },
+    .package = "erifunctions"
+  )
+
+  expect_invisible(.eri_flow_ingest())
+
+  names_called <- vapply(calls, function(c) c$name, character(1))
+  expect_equal(names_called, c("ingest", "approve"))
+
+  ingest_call <- calls[[1]]$args
+  expect_equal(ingest_call$country, "uga")
+  expect_equal(ingest_call$disease, "malaria")
+  expect_equal(ingest_call$data_source, "surveillance")
+  expect_equal(ingest_call$data_type, "case")
+  expect_null(ingest_call$mirror_pipeline)
+
+  approve_call <- calls[[2]]$args
+  expect_equal(approve_call$country, "uga")
+  expect_equal(approve_call$period, "2024-01")
+})
+
+test_that(".eri_flow_ingest stops cleanly (no approve) when open log entries need review and the DA declines", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_pick_or_type = local({
+      i <- 0L
+      function(...) { i <<- i + 1L; c("malaria", "surveillance", "case")[[i]] }
+    }),
+    .eri_prompt_pick_file = function(...) "C:/fake/linelist.csv",
+    .eri_logs_con = function(...) structure(list(), class = "mock_data_con"),
+    .eri_wizard_should_mirror_ingest = function(...) FALSE,
+    eri_ingest = function(...) invisible(NULL),
+    eri_logs = function(...) tibble::tibble(log_path = "uga/malaria/surveillance/case/logs/x.yaml"),
+    # First confirm ("Go ahead?") = TRUE, second ("Approve anyway?") = FALSE.
+    .eri_wizard_confirm = local({
+      i <- 0L
+      function(...) { i <<- i + 1L; i == 1L }
+    }),
+    eri_approve = function(...) stop("must not approve -- DA declined with open flags outstanding"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_ingest())
+})
+
 test_that("eri_do's top menu routes to the CMR flow and exits cleanly", {
   withr::local_options(rlang_interactive = TRUE)
   cmr_ran <- FALSE
   local_mocked_bindings(
     .eri_flow_cmr = function() { cmr_ran <<- TRUE; invisible(NULL) },
-    .eri_prompt_menu = scripted(list(1L, 3L)),  # CMR flow, then Exit
+    .eri_prompt_menu = scripted(list(1L, 4L)),  # CMR flow, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())
   expect_true(cmr_ran)
+})
+
+test_that("eri_do's top menu routes to the surveillance ingest flow and exits cleanly", {
+  withr::local_options(rlang_interactive = TRUE)
+  ingest_ran <- FALSE
+  local_mocked_bindings(
+    .eri_flow_ingest = function() { ingest_ran <<- TRUE; invisible(NULL) },
+    .eri_prompt_menu = scripted(list(2L, 4L)),  # ingest flow, then Exit
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_do())
+  expect_true(ingest_ran)
 })
 
 test_that("eri_do's top menu routes to the DQ-review shortcut with a picked country/period", {
@@ -283,7 +425,7 @@ test_that("eri_do's top menu routes to the DQ-review shortcut with a picked coun
     .eri_prompt_pick_country = function(...) "uga",
     .eri_wizard_pick_period  = function(...) "202406",
     eri_dq_review = function(country, period) { reviewed <<- c(country, period); invisible(NULL) },
-    .eri_prompt_menu = scripted(list(2L, 3L)),  # DQ review shortcut, then Exit
+    .eri_prompt_menu = scripted(list(3L, 4L)),  # DQ review shortcut, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -19,6 +19,12 @@ knitr::opts_chunk$set(
 **Walkthrough** &middot; ~35 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
+> **Prefer to just do it?** Run [`eri_do()`](../reference/eri_do.html) in the console and pick
+> "bring in a surveillance dataset" — it walks the whole archive → check → stage → approve
+> pipeline below through a few prompts (which country, which disease, which file), no function
+> names to memorize. This guide is for understanding what's happening underneath, or for
+> scripting the steps yourself.
+
 This is a hands-on, **start-to-finish walkthrough** of getting a surveillance dataset into the
 Carter Center data system, the daily work of a **Data Analyst (DA)**. It is written for domain
 experts who are *not* software developers. Work through it once, in order, and you will have done


### PR DESCRIPTION
## Summary
- Phase B of the interactive-wizard course correction: `.eri_flow_ingest()` on the same shared helpers as the CMR flow — pick the file (native dialog), confirm the period, one `eri_ingest()` call does raw-archive + DQ-check + stage.
- `mirror_pipeline` auto-detected the same way as CMR's flow, via `eri_cutover_status()`, and only considered for a country actually registered for the `hsp-mal` legacy mirror.
- Two new reusable helpers: `.eri_prompt_pick_or_type()` (pick-list + typed "Other") and `.eri_wizard_prompt_country_code()` (validated free-typed country) — needed because ingest's country/disease have no backing registry the way CMR's rb-expansion pipeline does.
- **Deliberately did NOT ship ODK in the same PR** — ingest's period (free text matched against the staged filename) and DQ-flag shape (generic `eri_logs()` backlog, not `eri_cmr_dq_report()`'s per-sheet shape) both turned out different enough from CMR to need their own careful verification. This flow's DQ step is a summary + pointer at the existing scriptable triage tools, not a full interactive walker.
- Version bumped 0.9.28 → 0.9.29.

## Test plan
- [x] `devtools::document()` — `NAMESPACE`/`eri_do.Rd` regenerated cleanly
- [x] `devtools::test()` — full suite green (2850 pass, 0 fail; 67 wizard tests, +21 over Phase A)
- [x] Every new test traced for the phase-7 mock-safety lesson (every live-Azure-touching function reachable on a test's path is mocked in that specific test)
- [ ] CI (R-CMD-check, pkgdown)
- [ ] review-agent pass