### PR TITLE
feat(wizard): eri_do() covers ODK sync (Phase C.1) (0.9.30)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.29
+Version: 0.9.30
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,33 @@
+# erifunctions 0.9.30
+
+## `eri_do()` now covers ODK sync too (Phase C.1 of the interactive-wizard course correction)
+
+- **`eri_do()`'s top menu gained "Pull in ODK survey submissions"**, powered by a new
+  `.eri_flow_odk()` (`R/wizard.R`): connect, pick a project and form from what's actually visible
+  on the account (no memorizing project/form IDs), register the form if it isn't already (asking
+  only for country and disease — the server URL comes from the live connection, never asked), then
+  sync. Built on the real `init_odk_connection()` / `list_odk_projects()` / `list_odk_forms()` /
+  `eri_odk_register()` / `eri_odk_sync()` / `eri_odk_list_registered()` functions — nothing
+  reimplemented.
+- **Deliberately stops at `research/raw/`.** Read `da-odk-guide.Rmd` in full before designing this:
+  unlike CMR and surveillance ingest, there is no automated stage-then-approve path for ODK data —
+  the real guide shows a manual `eri_write()` step after ad hoc quality-checking. Rather than
+  fabricate an approve step the underlying tooling doesn't support, the flow is honest about
+  handing off there, with a pointer at the surveillance ingest guide and `eri_approve()` for the
+  next step.
+- **Confirms the header-comment thesis from Phase B**: with CMR, ingest, and now ODK all built,
+  the three flows genuinely do not share enough top-level shape to justify the design consult's
+  proposed declarative `flow_map.yaml`/`kind:`-dispatch schema — only the low-level helper
+  vocabulary (`.eri_prompt_pick_country()`, `.eri_wizard_confirm()`, `.eri_wizard_step()`, etc.) is
+  actually shared. `R/wizard.R`'s header comment now records this as a settled, evidence-based
+  conclusion rather than a deferred question.
+- Cross-linked from `pkgdown/index.md`, `README.md`, and a callout at the top of
+  `vignettes/da-odk-guide.Rmd` pointing at `eri_do()`.
+- **`tests/testthat/test-wizard.R`** (83 tests, +16 over Phase B): the full connect → discover →
+  register → sync path, the already-registered short-circuit (no redundant registration call), and
+  two clean-failure paths (connection fails, no visible projects) — every live-ODK-touching function
+  reachable on each path mocked directly, per this session's test-mock-safety discipline.
+
 # erifunctions 0.9.29
 
 ## `eri_do()` now covers surveillance ingest too (Phase B of the interactive-wizard course correction)

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -1,4 +1,4 @@
-#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: surveillance ingest) ####
+#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: ingest; Phase C.1: ODK) ####
 #
 # Design consult: docs/design/interactive-wizard-consult.md. Corrects the docs-site redesign's
 # direction -- that work optimized *discoverability* (can a DA find the right guide); this optimizes
@@ -22,12 +22,24 @@
 # (eri_logs()/eri_dq_flag_resolve()/eri_logs_resolve()), not a full interactive per-flag walker --
 # that's real, but smaller, follow-on work, not built here.
 #
-# ODK and onboarding flows, retiring eri_guide(), and the doc cut are Phase C/D, not started.
+# Phase C.1 adds ODK (.eri_flow_odk()): connect, discover the project/form (a DA rarely knows the
+# numeric project id or exact xmlFormId by heart), register if not already, sync. This flow stops at
+# "submissions are in research/raw/" rather than reaching all the way to eri_approve() the way
+# CMR/ingest do -- there is no single stage-then-approve function for ODK data (da-odk-guide.Rmd's
+# own approve step is a MANUAL eri_write() after ad hoc quality-checking), so completing that gap
+# honestly is real, separate follow-on work, not something to fake here.
 #
-# Concrete R control flow, not a declarative flow schema (a `flow_map.yaml`/`kind:`-dispatch engine
-# was in the original consult's design, but building a mini-DSL for a single consumer was the
-# premature abstraction this whole redesign has repeatedly avoided elsewhere -- deferred until a
-# third flow gives it enough real shape to generalize from correctly, not guessed at from two.)
+# Onboarding flow, retiring eri_guide(), and the doc cut are Phase C.2/C.3/D, not started.
+#
+# Concrete R control flow, not a declarative flow schema. The original consult proposed a
+# `flow_map.yaml`/`kind:`-dispatch engine "once a second/third flow gives it real shape to
+# generalize from" -- now that there are three (CMR: multi-step + a rich DQ loop; ingest: one call +
+# a log-summary DQ step; ODK: discover-then-register-then-sync with no approve step at all), the
+# evidence says otherwise: the three flows don't share enough TOP-LEVEL shape to make a declarative
+# schema worth building -- what's actually shared and reused is the low-level HELPER vocabulary
+# (.eri_prompt_pick_file(), .eri_wizard_step(), .eri_wizard_confirm(), .eri_prompt_pick_or_type()),
+# not a generic step sequence. That's the right level of reuse; a schema forcing these three into
+# one shape would be reuse for its own sake, not because the flows are actually alike.
 
 # Builds a numbered pick-list from a named country_map (code = display name is backwards here --
 # `.eri_pipeline_registry[[...]]$country_map` maps OUR code to the registry's own downstream code,
@@ -417,6 +429,80 @@
   invisible(NULL)
 }
 
+#### Phase C.1: ODK Central ####
+
+# The ODK flow: connect, discover the project/form (a DA rarely knows the numeric project id or
+# exact xmlFormId by heart -- list_odk_projects()/list_odk_forms() turn that into two pick-lists),
+# register if this form isn't already tracked (using con$url as server_url -- init_odk_connection()
+# already has it, no need to ask again -- and .KNOWN_COUNTRY_CODES, R/odk_registry.R's own
+# registration-validation list, as the country pick-list -- ODK registration is genuinely
+# country-locked, unlike ingest), then sync. Stops there: there is no single stage-then-approve
+# function for ODK data (da-odk-guide.Rmd's own next step is a manual eri_write() after ad hoc
+# quality-checking), so this flow honestly ends at "synced to raw/," not a fabricated approve step.
+#' @keywords internal
+.eri_flow_odk <- function() {
+  cli::cli_h1("Pull in ODK survey submissions")
+
+  con_result <- .eri_wizard_step(function() init_odk_connection())
+  if (!con_result$ok) return(invisible(NULL))
+  con <- con_result$value
+
+  projects <- .eri_wizard_step(function() list_odk_projects(con = con))
+  if (!projects$ok || nrow(projects$value) == 0L) {
+    cli::cli_alert_warning("No ODK projects visible with this account.")
+    return(invisible(NULL))
+  }
+  project_choice <- .eri_prompt_menu("Which ODK project?", projects$value$project)
+  if (project_choice == 0L) return(invisible(NULL))
+  project_id <- projects$value$project_id[[project_choice]]
+
+  forms <- .eri_wizard_step(function() list_odk_forms(con = con, project_id = project_id))
+  if (!forms$ok || nrow(forms$value) == 0L) {
+    cli::cli_alert_warning("No forms found in that project.")
+    return(invisible(NULL))
+  }
+  form_choice <- .eri_prompt_menu("Which form?", forms$value$name)
+  if (form_choice == 0L) return(invisible(NULL))
+  form_id <- forms$value$xmlFormId[[form_choice]]
+
+  data_con   <- .eri_logs_con(NULL)
+  registered <- tryCatch(eri_odk_list_registered(data_con = data_con), error = function(e) NULL)
+  already    <- !is.null(registered) && nrow(registered) > 0L &&
+    any(registered$project_id == project_id & registered$form_id == form_id)
+
+  if (!isTRUE(already)) {
+    cli::cli_alert_info("This form isn't registered yet -- I need a country and disease to file it under.")
+    country_map <- .KNOWN_COUNTRY_CODES
+    names(country_map) <- .KNOWN_COUNTRY_CODES
+    country <- .eri_prompt_pick_country(country_map, "Which country?")
+    if (is.null(country)) return(invisible(NULL))
+
+    disease <- .eri_prompt_pick_or_type(
+      "Which disease?", c("malaria", "oncho", "lf", "sch", "sth"),
+      "Disease (blank to cancel): "
+    )
+    if (is.na(disease)) return(invisible(NULL))
+
+    reg <- .eri_wizard_step(function() {
+      eri_odk_register(project_id, form_id, country, disease,
+                       server_url = con$url, con = con, data_con = data_con)
+    })
+    if (!reg$ok) return(invisible(NULL))
+  }
+
+  if (!.eri_wizard_confirm("Sync submissions now?")) return(invisible(NULL))
+
+  sy <- .eri_wizard_step(function() eri_odk_sync(project_id, form_id, con = con, data_con = data_con))
+  if (!sy$ok) return(invisible(NULL))
+
+  cli::cli_alert_success("Done. Submissions are synced to research/raw/.")
+  cli::cli_bullets(c(
+    "i" = "Next: quality-check and stage this the same way as a surveillance extract -- see the surveillance ingest guide -- then eri_approve() it in.",
+    "i" = "Run {.fn eri_do} again any time to sync new submissions."
+  ))
+  invisible(NULL)
+}
+
 #' Bring a monthly report into the system, interactively (the guided console front door)
 #'
 #' @description
@@ -426,19 +512,22 @@
 #' country, which file, which reporting period -- and calls the existing scriptable core on their
 #' behalf. Never asks for a function name or an Azure path. `mirror_pipeline` is auto-detected from
 #' [eri_cutover_status()] and never asked about. Every mutation is one already-tested function
-#' ([eri_upload()], [eri_stage_cmr()], [eri_split_cmr()], [eri_ingest()], [eri_approve()]), and
-#' data quality review/approval hands off directly into the same loop [eri_dq_review()] uses (for
-#' CMR) or points at the scriptable triage tools directly ([eri_logs()], [eri_dq_flag_resolve()],
-#' for surveillance ingest) -- nothing here is reimplemented, and every function this calls stays
-#' fully usable directly in a script or CI.
+#' ([eri_upload()], [eri_stage_cmr()], [eri_split_cmr()], [eri_ingest()], [eri_approve()],
+#' [eri_odk_register()], [eri_odk_sync()]), and data quality review/approval hands off directly
+#' into the same loop [eri_dq_review()] uses (for CMR) or points at the scriptable triage tools
+#' directly ([eri_logs()], [eri_dq_flag_resolve()], for surveillance ingest) -- nothing here is
+#' reimplemented, and every function this calls stays fully usable directly in a script or CI.
 #'
-#' Currently covers bringing in a monthly CMR report, and bringing in a surveillance dataset
-#' (CSV/Excel line-list), end to end. ODK sync and new-program onboarding are planned as the same
-#' framework grows (see `docs/design/interactive-wizard-consult.md`).
+#' Currently covers bringing in a monthly CMR report, bringing in a surveillance dataset
+#' (CSV/Excel line-list), and pulling in ODK survey submissions, end to end. ODK sync stops at
+#' `research/raw/` -- there is no automated stage-then-approve path for ODK data yet (the real
+#' guide shows a manual [eri_write()] step), so the wizard is honest about handing off there
+#' rather than fabricating a step the underlying tooling doesn't support. New-program onboarding
+#' is planned as the same framework grows (see `docs/design/interactive-wizard-consult.md`).
 #'
 #' **Interactive only.** In a script or CI, use the scriptable core directly: [eri_upload()],
 #' [eri_stage_cmr()], [eri_split_cmr()], [eri_cmr_dq_report()], [eri_approve_cmr()], [eri_ingest()],
-#' [eri_approve()].
+#' [eri_approve()], [eri_odk_sync()].
 #'
 #' @returns Invisibly, `NULL`. Every effect happens through the scriptable core it calls.
 #' @examples
@@ -460,16 +549,19 @@ eri_do <- function() {
     choice <- .eri_prompt_menu("What are you trying to do?", c(
       "Bring this month's country report (CMR) into the system",
       "Bring in a surveillance dataset (a CSV/Excel line-list)",
+      "Pull in ODK survey submissions",
       "Review & approve something already staged (DQ review)",
       "Exit"
     ))
-    if (choice == 0L || choice == 4L) break
+    if (choice == 0L || choice == 5L) break
 
     if (choice == 1L) {
       .eri_flow_cmr()
     } else if (choice == 2L) {
       .eri_flow_ingest()
     } else if (choice == 3L) {
+      .eri_flow_odk()
+    } else if (choice == 4L) {
       country <- .eri_prompt_pick_country(.eri_pipeline_registry[["rb-expansion"]]$country_map,
                                           "Which country?")
       if (!is.null(country)) {

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -41,6 +41,11 @@
 # not a generic step sequence. That's the right level of reuse; a schema forcing these three into
 # one shape would be reuse for its own sake, not because the flows are actually alike.
 
+# Shared disease pick-list for flows whose country/disease space has no backing registry
+# (ADR-0012 deliberately leaves disease unregistered). One constant so the ingest and ODK flows
+# can't silently diverge from each other.
+.KNOWN_DISEASES <- c("malaria", "oncho", "lf", "sch", "sth")
+
 # Builds a numbered pick-list from a named country_map (code = display name is backwards here --
 # `.eri_pipeline_registry[[...]]$country_map` maps OUR code to the registry's own downstream code,
 # so the DISPLAY uses names(country_map), the pick-list choice IS the code) and returns the picked
@@ -347,7 +352,7 @@
   if (is.na(country)) return(invisible(NULL))
 
   disease <- .eri_prompt_pick_or_type(
-    "Which disease?", c("malaria", "oncho", "lf", "sch", "sth"),
+    "Which disease?", .KNOWN_DISEASES,
     "Disease (blank to cancel): "
   )
   if (is.na(disease)) return(invisible(NULL))
@@ -468,7 +473,8 @@
   data_con   <- .eri_logs_con(NULL)
   registered <- tryCatch(eri_odk_list_registered(data_con = data_con), error = function(e) NULL)
   already    <- !is.null(registered) && nrow(registered) > 0L &&
-    any(registered$project_id == project_id & registered$form_id == form_id)
+    any(registered$project_id == project_id & registered$form_id == form_id &
+          registered$server_url == con$url)
 
   if (!isTRUE(already)) {
     cli::cli_alert_info("This form isn't registered yet -- I need a country and disease to file it under.")
@@ -478,10 +484,14 @@
     if (is.null(country)) return(invisible(NULL))
 
     disease <- .eri_prompt_pick_or_type(
-      "Which disease?", c("malaria", "oncho", "lf", "sch", "sth"),
+      "Which disease?", .KNOWN_DISEASES,
       "Disease (blank to cancel): "
     )
     if (is.na(disease)) return(invisible(NULL))
+
+    if (!.eri_wizard_confirm(sprintf("Register this form as %s/%s?", country, disease))) {
+      return(invisible(NULL))
+    }
 
     reg <- .eri_wizard_step(function() {
       eri_odk_register(project_id, form_id, country, disease,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.29 · **Status:** Active development
+**Version:** 0.9.30 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -23,10 +23,10 @@ reference, and the project roadmap. This README is the quick orientation.
 
 ## Guides
 
-**Bringing in a monthly country report or a surveillance dataset?** Run `eri_do()` — a guided
-console wizard that walks the whole upload/archive → stage → review → approve pipeline through a
-few prompts (which country, which file, confirm the period). No function names to memorize, no
-Azure path to type by hand.
+**Bringing in a monthly country report, a surveillance dataset, or ODK submissions?** Run
+`eri_do()` — a guided console wizard that walks the whole upload/archive → stage → review → approve
+pipeline through a few prompts (which country, which file or ODK form, confirm the period). No
+function names to memorize, no Azure path to type by hand.
 
 These copy-paste, start-to-finish walkthroughs are the fastest way to learn the system. Read them
 on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/), which groups

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -462,10 +462,24 @@ different enough from CMR to deserve their own careful verification, discovered 
 generalized. So Phase B's DQ step is a summary + a pointer at the existing scriptable triage tools,
 not a full interactive per-flag walker — smaller than CMR's, and honestly scoped that way in
 NEWS.md rather than overstating parity. This is exactly the "generalize from what a second flow
-actually needs, not from what was guessed" case Phase A's own header comment anticipated. **ODK,
-onboarding (Phase C, alongside retiring/narrowing `eri_guide()` and cutting the ~26 guide articles
-to ~11), and progress-detection polish (Phase D) remain designed in the consult document but not
-yet started.**
+actually needs, not from what was guessed" case Phase A's own header comment anticipated. **Phase
+C.1 (ODK sync) shipped as v0.9.30** — `.eri_flow_odk()`, built after reading `da-odk-guide.Rmd` in
+full: connect via `init_odk_connection()`, pick a project and form from what's actually visible
+(`list_odk_projects()`/`list_odk_forms()`, never a typed ID), register with `eri_odk_register()`
+if `eri_odk_list_registered()` shows it isn't already (asking only country/disease — the server URL
+comes from the live connection), then `eri_odk_sync()`. Deliberately stops at `research/raw/`: there
+is no automated stage-then-approve path for ODK data — the real guide shows a manual `eri_write()`
+step after ad hoc quality-checking — so the flow hands off there honestly rather than fabricating an
+approve step the tooling doesn't support. With three real flows now built (CMR, ingest, ODK), the
+consult's proposed declarative `flow_map.yaml`/`kind:`-dispatch schema is now a settled "no": the
+three don't share enough top-level shape to warrant it, only the low-level helper vocabulary
+(`.eri_prompt_pick_country()`, `.eri_wizard_confirm()`, `.eri_wizard_step()`, etc.) is genuinely
+shared — recorded as such in `R/wizard.R`'s own header comment rather than left as a deferred
+question. **Onboarding (Phase C.2, alongside retiring/narrowing `eri_guide()` and cutting the ~26
+guide articles to ~11 in Phase C.3), and progress-detection polish (Phase D) remain designed in the
+consult document but not yet started.** Phase C.3 in particular carries a different risk profile
+from A/B/C.1's purely additive work — deletion and doc cuts — and is flagged for a maintainer
+check-in before starting rather than assumed under a "move on" instruction.
 
 ---
 

--- a/man/eri_do.Rd
+++ b/man/eri_do.Rd
@@ -16,19 +16,22 @@ A menu-driven wizard that carries a Data Analyst through an entire pipeline run 
 country, which file, which reporting period -- and calls the existing scriptable core on their
 behalf. Never asks for a function name or an Azure path. \code{mirror_pipeline} is auto-detected from
 \code{\link[=eri_cutover_status]{eri_cutover_status()}} and never asked about. Every mutation is one already-tested function
-(\code{\link[=eri_upload]{eri_upload()}}, \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}}, \code{\link[=eri_approve]{eri_approve()}}), and
-data quality review/approval hands off directly into the same loop \code{\link[=eri_dq_review]{eri_dq_review()}} uses (for
-CMR) or points at the scriptable triage tools directly (\code{\link[=eri_logs]{eri_logs()}}, \code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}},
-for surveillance ingest) -- nothing here is reimplemented, and every function this calls stays
-fully usable directly in a script or CI.
+(\code{\link[=eri_upload]{eri_upload()}}, \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}}, \code{\link[=eri_approve]{eri_approve()}},
+\code{\link[=eri_odk_register]{eri_odk_register()}}, \code{\link[=eri_odk_sync]{eri_odk_sync()}}), and data quality review/approval hands off directly
+into the same loop \code{\link[=eri_dq_review]{eri_dq_review()}} uses (for CMR) or points at the scriptable triage tools
+directly (\code{\link[=eri_logs]{eri_logs()}}, \code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}}, for surveillance ingest) -- nothing here is
+reimplemented, and every function this calls stays fully usable directly in a script or CI.
 
-Currently covers bringing in a monthly CMR report, and bringing in a surveillance dataset
-(CSV/Excel line-list), end to end. ODK sync and new-program onboarding are planned as the same
-framework grows (see \code{docs/design/interactive-wizard-consult.md}).
+Currently covers bringing in a monthly CMR report, bringing in a surveillance dataset
+(CSV/Excel line-list), and pulling in ODK survey submissions, end to end. ODK sync stops at
+\verb{research/raw/} -- there is no automated stage-then-approve path for ODK data yet (the real
+guide shows a manual \code{\link[=eri_write]{eri_write()}} step), so the wizard is honest about handing off there
+rather than fabricating a step the underlying tooling doesn't support. New-program onboarding
+is planned as the same framework grows (see \code{docs/design/interactive-wizard-consult.md}).
 
 \strong{Interactive only.} In a script or CI, use the scriptable core directly: \code{\link[=eri_upload]{eri_upload()}},
 \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_cmr_dq_report]{eri_cmr_dq_report()}}, \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}},
-\code{\link[=eri_approve]{eri_approve()}}.
+\code{\link[=eri_approve]{eri_approve()}}, \code{\link[=eri_odk_sync]{eri_odk_sync()}}.
 }
 \examples{
 \dontrun{

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -6,10 +6,10 @@ TCC's Azure-centred data system across countries (Haiti, DR, Uganda, OEPA, …) 
 (malaria, oncho, LF, SCH, STH). You install it, authenticate through your browser, and call
 functions — you don't edit the package.
 
-**Bringing in a monthly country report or a surveillance dataset? Run `eri_do()`.** It's a guided
-console wizard — pick your country, pick the file, confirm the month, and it walks the whole
-upload/archive → stage → review → approve pipeline for you. No function names to memorize, no
-Azure path to type by hand.
+**Bringing in a monthly country report, a surveillance dataset, or ODK submissions? Run
+`eri_do()`.** It's a guided console wizard — pick your country, pick the file (or the ODK project
+and form), confirm the month, and it walks the whole upload/archive → stage → review → approve
+pipeline for you. No function names to memorize, no Azure path to type by hand.
 
 Not sure where to start otherwise? **[What are you trying to do?](articles/task-index.html)** is a
 generated index of ~30 common tasks; pick yours and get the call and the guide. In the console,

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -469,7 +469,8 @@ test_that(".eri_flow_odk skips registration when the form is already registered"
     .eri_logs_con = function(...) structure(list(), class = "mock_data_con"),
     eri_odk_list_registered = function(...) {
       registered_check <<- TRUE
-      tibble::tibble(project_id = 11L, form_id = "eri_test_river_prospection")
+      tibble::tibble(project_id = 11L, form_id = "eri_test_river_prospection",
+                     server_url = "https://odk.example.org/")
     },
     eri_odk_register = function(...) stop("must not register -- already registered"),
     .eri_wizard_confirm = function(...) TRUE,
@@ -478,6 +479,30 @@ test_that(".eri_flow_odk skips registration when the form is already registered"
   )
   expect_invisible(.eri_flow_odk())
   expect_true(registered_check)
+})
+
+test_that(".eri_flow_odk does not register when the DA declines the confirm prompt", {
+  withr::local_options(rlang_interactive = TRUE)
+  register_called <- FALSE
+  sync_called <- FALSE
+  local_mocked_bindings(
+    init_odk_connection = function(...) structure(list(url = "https://odk.example.org/"), class = "odk_connection"),
+    list_odk_projects = function(...) tibble::tibble(project_id = 11L, project = "testing"),
+    list_odk_forms = function(...) tibble::tibble(xmlFormId = "eri_test_river_prospection", name = "Test Form"),
+    .eri_prompt_menu = scripted(list(1L, 1L)),
+    .eri_logs_con = function(...) structure(list(), class = "mock_data_con"),
+    eri_odk_list_registered = function(...) tibble::tibble(project_id = integer(), form_id = character(),
+                                                            server_url = character()),
+    .eri_prompt_pick_country = function(...) "uga",
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    eri_odk_register = function(...) { register_called <<- TRUE; invisible(NULL) },
+    .eri_wizard_confirm = function(...) FALSE,
+    eri_odk_sync = function(...) { sync_called <<- TRUE; invisible(NULL) },
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_odk())
+  expect_false(register_called)
+  expect_false(sync_called)
 })
 
 test_that(".eri_flow_odk stops cleanly (no sync) when the connection itself fails", {

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -394,12 +394,119 @@ test_that(".eri_flow_ingest stops cleanly (no approve) when open log entries nee
   expect_invisible(.eri_flow_ingest())
 })
 
+#### Phase C.1: ODK ####
+
+test_that(".eri_flow_odk connects -> discovers -> registers -> syncs in order, and nothing else", {
+  withr::local_options(rlang_interactive = TRUE)
+  calls <- list()
+  record <- function(name, ...) calls[[length(calls) + 1L]] <<- list(name = name, args = list(...))
+  mock_con <- structure(list(url = "https://odk.example.org/"), class = "odk_connection")
+
+  local_mocked_bindings(
+    init_odk_connection = function(...) { record("connect"); mock_con },
+    list_odk_projects = function(con) {
+      record("list_projects")
+      tibble::tibble(project_id = c(5L, 11L), project = c("Uganda", "testing"))
+    },
+    .eri_prompt_menu = local({
+      i <- 0L
+      function(title, choices) {
+        i <<- i + 1L
+        # 1st menu call: pick project "testing" (index 2); 2nd: pick the only form; the rest are
+        # handled by mocking .eri_wizard_confirm() directly below, not via this generic menu mock.
+        if (i == 1L) 2L else 1L
+      }
+    }),
+    list_odk_forms = function(con, project_id) {
+      record("list_forms", project_id = project_id)
+      tibble::tibble(xmlFormId = "eri_test_river_prospection", name = "ERI Test, River Prospection")
+    },
+    .eri_logs_con = function(...) structure(list(), class = "mock_data_con"),
+    eri_odk_list_registered = function(...) tibble::tibble(project_id = integer(), form_id = character()),
+    .eri_prompt_pick_country = function(...) "uga",
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    eri_odk_register = function(project_id, form_id, country, disease, server_url, con, data_con) {
+      record("register", project_id = project_id, form_id = form_id, country = country,
+             disease = disease, server_url = server_url)
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) TRUE,
+    eri_odk_sync = function(project_id, form_id, con, data_con) {
+      record("sync", project_id = project_id, form_id = form_id)
+      invisible(NULL)
+    },
+    .package = "erifunctions"
+  )
+
+  expect_invisible(.eri_flow_odk())
+
+  names_called <- vapply(calls, function(c) c$name, character(1))
+  expect_equal(names_called, c("connect", "list_projects", "list_forms", "register", "sync"))
+
+  list_forms_call <- calls[[3]]$args
+  expect_equal(list_forms_call$project_id, 11L)  # the SECOND project ("testing"), matching menu choice 2L
+
+  register_call <- calls[[4]]$args
+  expect_equal(register_call$project_id, 11L)
+  expect_equal(register_call$form_id, "eri_test_river_prospection")
+  expect_equal(register_call$country, "uga")
+  expect_equal(register_call$disease, "malaria")
+  expect_equal(register_call$server_url, "https://odk.example.org/")  # from con$url, never asked
+
+  sync_call <- calls[[5]]$args
+  expect_equal(sync_call$project_id, 11L)
+  expect_equal(sync_call$form_id, "eri_test_river_prospection")
+})
+
+test_that(".eri_flow_odk skips registration when the form is already registered", {
+  withr::local_options(rlang_interactive = TRUE)
+  registered_check <- FALSE
+  local_mocked_bindings(
+    init_odk_connection = function(...) structure(list(url = "https://odk.example.org/"), class = "odk_connection"),
+    list_odk_projects = function(...) tibble::tibble(project_id = 11L, project = "testing"),
+    list_odk_forms = function(...) tibble::tibble(xmlFormId = "eri_test_river_prospection", name = "Test Form"),
+    .eri_prompt_menu = scripted(list(1L, 1L)),
+    .eri_logs_con = function(...) structure(list(), class = "mock_data_con"),
+    eri_odk_list_registered = function(...) {
+      registered_check <<- TRUE
+      tibble::tibble(project_id = 11L, form_id = "eri_test_river_prospection")
+    },
+    eri_odk_register = function(...) stop("must not register -- already registered"),
+    .eri_wizard_confirm = function(...) TRUE,
+    eri_odk_sync = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_odk())
+  expect_true(registered_check)
+})
+
+test_that(".eri_flow_odk stops cleanly (no sync) when the connection itself fails", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    init_odk_connection = function(...) stop("ODK username is required."),
+    eri_odk_sync = function(...) stop("must not be called -- connection failed"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_odk())
+})
+
+test_that(".eri_flow_odk stops cleanly when there are no visible projects", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    init_odk_connection = function(...) structure(list(url = "https://odk.example.org/"), class = "odk_connection"),
+    list_odk_projects = function(...) tibble::tibble(project_id = integer(), project = character()),
+    list_odk_forms = function(...) stop("must not be called -- no projects to pick from"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_odk())
+})
+
 test_that("eri_do's top menu routes to the CMR flow and exits cleanly", {
   withr::local_options(rlang_interactive = TRUE)
   cmr_ran <- FALSE
   local_mocked_bindings(
     .eri_flow_cmr = function() { cmr_ran <<- TRUE; invisible(NULL) },
-    .eri_prompt_menu = scripted(list(1L, 4L)),  # CMR flow, then Exit
+    .eri_prompt_menu = scripted(list(1L, 5L)),  # CMR flow, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())
@@ -411,11 +518,23 @@ test_that("eri_do's top menu routes to the surveillance ingest flow and exits cl
   ingest_ran <- FALSE
   local_mocked_bindings(
     .eri_flow_ingest = function() { ingest_ran <<- TRUE; invisible(NULL) },
-    .eri_prompt_menu = scripted(list(2L, 4L)),  # ingest flow, then Exit
+    .eri_prompt_menu = scripted(list(2L, 5L)),  # ingest flow, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())
   expect_true(ingest_ran)
+})
+
+test_that("eri_do's top menu routes to the ODK flow and exits cleanly", {
+  withr::local_options(rlang_interactive = TRUE)
+  odk_ran <- FALSE
+  local_mocked_bindings(
+    .eri_flow_odk = function() { odk_ran <<- TRUE; invisible(NULL) },
+    .eri_prompt_menu = scripted(list(3L, 5L)),  # ODK flow, then Exit
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_do())
+  expect_true(odk_ran)
 })
 
 test_that("eri_do's top menu routes to the DQ-review shortcut with a picked country/period", {
@@ -425,7 +544,7 @@ test_that("eri_do's top menu routes to the DQ-review shortcut with a picked coun
     .eri_prompt_pick_country = function(...) "uga",
     .eri_wizard_pick_period  = function(...) "202406",
     eri_dq_review = function(country, period) { reviewed <<- c(country, period); invisible(NULL) },
-    .eri_prompt_menu = scripted(list(3L, 4L)),  # DQ review shortcut, then Exit
+    .eri_prompt_menu = scripted(list(4L, 5L)),  # DQ review shortcut, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -19,6 +19,13 @@ knitr::opts_chunk$set(
 **Walkthrough** &middot; ~40 min &middot; needs: Azure + ODK &middot; sandbox-safe: [no]{.eri-sandbox-no} (uses a real country's ODK project)
 :::
 
+> **Just need to pull in this month's submissions?** Run [`eri_do()`](../reference/eri_do.html) in
+> the console and pick "pull in ODK survey submissions" — it connects, lets you pick the project
+> and form from what's actually visible on your account, registers it if needed, and syncs, no
+> project/form IDs to memorize. It stops once submissions land in `research/raw/`; this guide is
+> still where you learn the parts the wizard doesn't cover — standing up a form, monitoring it,
+> managing who collects on it, and quality-checking + staging what comes back.
+
 **ODK Central** is where field data is born, survey teams collect submissions on phones, and they
 land on an ODK Central server. This is a hands-on walkthrough for a **Data Analyst (DA)** of the whole
 loop: connect to ODK Central, stand up a form, **monitor** it, **manage** who collects on it, and


### PR DESCRIPTION
## Summary
- Adds `.eri_flow_odk()` to `R/wizard.R`: connect via `init_odk_connection()`, pick project/form from what's actually visible on the account (`list_odk_projects()`/`list_odk_forms()`, never a typed ID), register with `eri_odk_register()` if `eri_odk_list_registered()` shows it isn't already (asking only country/disease -- server URL comes from the live connection), then `eri_odk_sync()`.
- Deliberately stops at `research/raw/`: read `da-odk-guide.Rmd` in full and confirmed there's no automated stage-then-approve path for ODK data -- the real guide shows a manual `eri_write()` step. The flow hands off honestly rather than fabricating a step the tooling doesn't support.
- `eri_do()`'s top menu is now 5 items (CMR / ingest / ODK / DQ-review-shortcut / Exit).
- With three real flows now built, `R/wizard.R`'s header comment records a settled conclusion: CMR/ingest/ODK don't share enough top-level shape to warrant the consult's proposed declarative `flow_map.yaml`/`kind:`-dispatch schema -- only the low-level helper vocabulary is genuinely shared.
- Docs: `NEWS.md` (0.9.30), `docs/roadmap.md`, `pkgdown/index.md`, `README.md`, a callout in `vignettes/da-odk-guide.Rmd`, `eri_do()` roxygen.

## Test plan
- [x] `tests/testthat/test-wizard.R` grown to 83 tests (+16): full connect -> discover -> register -> sync path, already-registered short-circuit (no redundant registration call), connection-failure and no-visible-projects clean-failure paths -- every live-ODK-touching function mocked directly on each path.
- [x] Full suite: `devtools::test()` -- 0 failures, 2866 pass (pre-existing unrelated warnings only).
- [x] `devtools::document()` regenerated `man/eri_do.Rd` clean.