### PR TITLE
feat(wizard): eri_do() covers onboarding (Phase C.2) (0.9.31)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.30
+Version: 0.9.31
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,11 +20,17 @@
   names as valid, and would have been silently rejected. Onboarding is precisely the flow where a
   DA types a brand-new code, so this surfaced immediately; widened to `^[a-z]{2,15}$` and added a
   regression test locking in the `atlantis` case.
+- **review-agent caught a real scope drift before merge**: the surveillance and CMR sub-flows called
+  `eri_onboard_country()`/`eri_onboard_cmr()` without ever surfacing `language` ("en"/"fr"), silently
+  defaulting to English -- a real gap for ERI's own Francophone countries (Haiti), and exactly what
+  the design consult called for ("language from a pick-list"). Added a shared
+  `.eri_wizard_prompt_language()` prompt to both sub-flows.
 - Cross-linked from `pkgdown/index.md`, `README.md`, and a callout at the top of
   `vignettes/da-onboard-guide.Rmd` pointing at `eri_do()`.
-- **`tests/testthat/test-wizard.R`** (105 tests, +19 over Phase C.1): routing across the three
+- **`tests/testthat/test-wizard.R`** (113 tests, +27 over Phase C.1): routing across the three
   sub-flows, each sub-flow's dry-run -> confirm -> real-write order, decline-to-confirm and
-  cancel-on-blank-input paths, and the NTD flow's menu-choice -> `data_types` vector mapping.
+  cancel-on-blank-input/language-prompt paths, and the NTD flow's menu-choice -> `data_types` vector
+  mapping.
 
 # erifunctions 0.9.30
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,31 @@
+# erifunctions 0.9.31
+
+## `eri_do()` now covers onboarding too (Phase C.2 of the interactive-wizard course correction)
+
+- **`eri_do()`'s top menu gained "Onboard a new country, disease, or data type"**, powered by a new
+  `.eri_flow_onboard()` (`R/wizard.R`) covering all three real onboarding shapes: a surveillance
+  country/disease (`eri_onboard_country()`), a CMR country (`eri_onboard_cmr(create_dirs = TRUE)`),
+  and an NTD disease's MDA/prevalence schemas (`eri_onboard_disease()`, local-only, no Azure
+  folders). Each sub-flow dry-runs first (reusing the real function's own `dry_run = TRUE` preview
+  text), confirms, then writes for real.
+- **Deliberately stops at "the schema template is written and the folders exist."**
+  `da-onboard-guide.Rmd`'s own golden rule is "onboarding scaffolds; it doesn't finish for you" --
+  filling in a schema's disease-specific columns, validating it, and submitting it via pull request
+  are real domain judgment calls no wizard should fabricate. The three `eri_onboard_*()` functions
+  already print their own "Next steps" via `cli_inform()`, so the flow doesn't re-print or
+  paraphrase that text -- one copy, not two that can quietly drift apart.
+- **Real bug found and fixed while building this**: `.eri_wizard_prompt_country_code()` (shared with
+  Phase B's ingest flow) validated typed country codes against `^[a-z]{2,4}$` -- but the package's
+  own sandbox demo country, `atlantis` (8 letters), is exactly the example its own warning message
+  names as valid, and would have been silently rejected. Onboarding is precisely the flow where a
+  DA types a brand-new code, so this surfaced immediately; widened to `^[a-z]{2,15}$` and added a
+  regression test locking in the `atlantis` case.
+- Cross-linked from `pkgdown/index.md`, `README.md`, and a callout at the top of
+  `vignettes/da-onboard-guide.Rmd` pointing at `eri_do()`.
+- **`tests/testthat/test-wizard.R`** (105 tests, +19 over Phase C.1): routing across the three
+  sub-flows, each sub-flow's dry-run -> confirm -> real-write order, decline-to-confirm and
+  cancel-on-blank-input paths, and the NTD flow's menu-choice -> `data_types` vector mapping.
+
 # erifunctions 0.9.30
 
 ## `eri_do()` now covers ODK sync too (Phase C.1 of the interactive-wizard course correction)

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -1,4 +1,4 @@
-#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: ingest; Phase C.1: ODK) ####
+#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: ingest; Phase C.1: ODK; Phase C.2: onboarding) ####
 #
 # Design consult: docs/design/interactive-wizard-consult.md. Corrects the docs-site redesign's
 # direction -- that work optimized *discoverability* (can a DA find the right guide); this optimizes
@@ -29,16 +29,26 @@
 # own approve step is a MANUAL eri_write() after ad hoc quality-checking), so completing that gap
 # honestly is real, separate follow-on work, not something to fake here.
 #
-# Onboarding flow, retiring eri_guide(), and the doc cut are Phase C.2/C.3/D, not started.
+# Phase C.2 adds onboarding (.eri_flow_onboard()): scaffolds a NEW country/disease/data-type space
+# via eri_onboard_country()/eri_onboard_cmr()/eri_onboard_disease() -- dry-run preview, confirm,
+# write for real, then stop. Deliberately does NOT walk the DA through filling in the schema's TODO
+# columns, validating, or submitting a PR -- da-onboard-guide.Rmd's own golden rule is "onboarding
+# scaffolds; it doesn't finish for you," and those steps are real domain expertise (which columns
+# this country's data actually has) no wizard should fabricate. The three eri_onboard_*() functions
+# already print their own "Next steps" via cli_inform, so the flow doesn't re-print or paraphrase
+# them -- one copy of that text, not two that can drift.
+#
+# Retiring eri_guide() and the doc cut are Phase C.3/D, not started.
 #
 # Concrete R control flow, not a declarative flow schema. The original consult proposed a
 # `flow_map.yaml`/`kind:`-dispatch engine "once a second/third flow gives it real shape to
-# generalize from" -- now that there are three (CMR: multi-step + a rich DQ loop; ingest: one call +
-# a log-summary DQ step; ODK: discover-then-register-then-sync with no approve step at all), the
-# evidence says otherwise: the three flows don't share enough TOP-LEVEL shape to make a declarative
-# schema worth building -- what's actually shared and reused is the low-level HELPER vocabulary
+# generalize from" -- now that there are four (CMR: multi-step + a rich DQ loop; ingest: one call +
+# a log-summary DQ step; ODK: discover-then-register-then-sync with no approve step at all;
+# onboarding: three genuinely different scaffold shapes behind one menu), the evidence says
+# otherwise: the flows don't share enough TOP-LEVEL shape to make a declarative schema worth
+# building -- what's actually shared and reused is the low-level HELPER vocabulary
 # (.eri_prompt_pick_file(), .eri_wizard_step(), .eri_wizard_confirm(), .eri_prompt_pick_or_type()),
-# not a generic step sequence. That's the right level of reuse; a schema forcing these three into
+# not a generic step sequence. That's the right level of reuse; a schema forcing these flows into
 # one shape would be reuse for its own sake, not because the flows are actually alike.
 
 # Shared disease pick-list for flows whose country/disease space has no backing registry
@@ -309,15 +319,17 @@
 # Surveillance ingest has no country registry the way CMR's rb-expansion pipeline does (eri_ingest()
 # is deliberately not country-locked -- it's what lets the DA guides demo on a fake atlantis
 # country) -- so country is a validated typed prompt, not a pick-list. Re-asks until it looks like a
-# real code (2-4 lowercase letters) or the DA cancels (blank).
+# real code (letters only) or the DA cancels (blank). Bounded 2-15 chars, not 2-4: real codes are
+# short (sdn, uga), but the package's own sandbox demo country is "atlantis" (8 letters) -- a
+# tighter cap would reject the exact case this prompt's own docs point to.
 #' @keywords internal
 .eri_wizard_prompt_country_code <- function() {
   repeat {
     typed <- .eri_prompt_line("Which country is this data for? (e.g. sdn; blank to cancel): ")
     if (!nzchar(trimws(typed))) return(NA_character_)
     code <- tolower(trimws(typed))
-    if (grepl("^[a-z]{2,4}$", code)) return(code)
-    cli::cli_alert_warning("Country codes are 2-4 letters (e.g. {.val sdn}, {.val atlantis}) -- try again.")
+    if (grepl("^[a-z]{2,15}$", code)) return(code)
+    cli::cli_alert_warning("Country codes are letters only (e.g. {.val sdn}, {.val atlantis}) -- try again.")
   }
 }
 
@@ -513,6 +525,128 @@
   invisible(NULL)
 }
 
+#### Phase C.2: onboarding ####
+
+# Onboarding's golden rule (da-onboard-guide.Rmd): "it scaffolds; it doesn't finish for you." The
+# three eri_onboard_*() functions already write their own "Next steps" (open the file, fill in the
+# TODOs, validate, submit via PR) via cli_inform -- the wizard must NOT re-print or paraphrase that,
+# doing so risks the two copies drifting. Its job stops at the mechanical, no-judgment-call part:
+# which kind, which names, dry-run preview, confirm, write for real. Filling in disease-specific
+# schema columns is real domain expertise no wizard should fabricate.
+#' @keywords internal
+.eri_flow_onboard <- function() {
+  cli::cli_h1("Onboard a new country, disease, or data type")
+
+  kind <- .eri_prompt_menu("What are you setting up?", c(
+    "Surveillance country/disease (case or aggregate reporting)",
+    "CMR country (monthly Case Management Report)",
+    "NTD disease (MDA + prevalence schemas, no country folders yet)"
+  ))
+  if (kind == 1L) {
+    .eri_flow_onboard_surveillance()
+  } else if (kind == 2L) {
+    .eri_flow_onboard_cmr()
+  } else if (kind == 3L) {
+    .eri_flow_onboard_disease()
+  }
+
+  invisible(NULL)
+}
+
+# No country/disease registry to pick-list from here -- onboarding's entire purpose is standing up
+# a space for a country/disease that ISN'T registered anywhere yet. Country code and full name are
+# both free-typed; disease reuses the shared pick-list-plus-Other pattern.
+#' @keywords internal
+.eri_flow_onboard_surveillance <- function() {
+  country <- .eri_wizard_prompt_country_code()
+  if (is.na(country)) return(invisible(NULL))
+
+  country_name <- .eri_prompt_line("Full country name (e.g. Uganda; blank to cancel): ")
+  if (!nzchar(trimws(country_name))) return(invisible(NULL))
+
+  disease <- .eri_prompt_pick_or_type(
+    "Which disease?", .KNOWN_DISEASES,
+    "Disease (blank to cancel): "
+  )
+  if (is.na(disease)) return(invisible(NULL))
+
+  preview <- .eri_wizard_step(function() {
+    eri_onboard_country(country, country_name, disease, dry_run = TRUE)
+  })
+  if (!preview$ok) return(invisible(NULL))
+
+  if (!.eri_wizard_confirm("Write this schema template and create the Azure folders?")) {
+    return(invisible(NULL))
+  }
+
+  result <- .eri_wizard_step(function() eri_onboard_country(country, country_name, disease))
+  if (!result$ok) return(invisible(NULL))
+
+  invisible(NULL)
+}
+
+# CMR's Azure folders are opt-in (create_dirs=FALSE by default) -- but the whole point of onboarding
+# through the wizard is to stand up a space that's actually ready to receive a report, so this flow
+# always asks for create_dirs = TRUE. A DA who only wants the local schema template can call
+# eri_onboard_cmr() directly.
+#' @keywords internal
+.eri_flow_onboard_cmr <- function() {
+  country <- .eri_wizard_prompt_country_code()
+  if (is.na(country)) return(invisible(NULL))
+
+  country_name <- .eri_prompt_line("Full country name (e.g. Uganda; blank to cancel): ")
+  if (!nzchar(trimws(country_name))) return(invisible(NULL))
+
+  preview <- .eri_wizard_step(function() {
+    eri_onboard_cmr(country, country_name, create_dirs = TRUE, dry_run = TRUE)
+  })
+  if (!preview$ok) return(invisible(NULL))
+
+  if (!.eri_wizard_confirm("Write this CMR schema template and create the Azure folders?")) {
+    return(invisible(NULL))
+  }
+
+  result <- .eri_wizard_step(function() eri_onboard_cmr(country, country_name, create_dirs = TRUE))
+  if (!result$ok) return(invisible(NULL))
+
+  invisible(NULL)
+}
+
+# Local-only (no Azure folders at all -- eri_onboard_disease()'s own design, since NTD programs
+# don't get a country/disease space until a surveillance or CMR onboard also runs). Argument order
+# is disease-then-country, matching the real function signature exactly (easy to get backwards).
+#' @keywords internal
+.eri_flow_onboard_disease <- function() {
+  disease <- .eri_prompt_pick_or_type(
+    "Which disease?", .KNOWN_DISEASES,
+    "Disease (blank to cancel): "
+  )
+  if (is.na(disease)) return(invisible(NULL))
+
+  country <- .eri_wizard_prompt_country_code()
+  if (is.na(country)) return(invisible(NULL))
+
+  which_types <- .eri_prompt_menu("Which schema(s) do you need?", c(
+    "Both (MDA + prevalence)",
+    "MDA only",
+    "Prevalence only"
+  ))
+  if (which_types == 0L) return(invisible(NULL))
+  data_types <- switch(which_types, c("mda", "prevalence"), "mda", "prevalence")
+
+  preview <- .eri_wizard_step(function() {
+    eri_onboard_disease(disease, country, data_types = data_types, dry_run = TRUE)
+  })
+  if (!preview$ok) return(invisible(NULL))
+
+  if (!.eri_wizard_confirm("Write these schema template(s)?")) return(invisible(NULL))
+
+  result <- .eri_wizard_step(function() eri_onboard_disease(disease, country, data_types = data_types))
+  if (!result$ok) return(invisible(NULL))
+
+  invisible(NULL)
+}
+
 #' Bring a monthly report into the system, interactively (the guided console front door)
 #'
 #' @description
@@ -523,21 +657,25 @@
 #' behalf. Never asks for a function name or an Azure path. `mirror_pipeline` is auto-detected from
 #' [eri_cutover_status()] and never asked about. Every mutation is one already-tested function
 #' ([eri_upload()], [eri_stage_cmr()], [eri_split_cmr()], [eri_ingest()], [eri_approve()],
-#' [eri_odk_register()], [eri_odk_sync()]), and data quality review/approval hands off directly
-#' into the same loop [eri_dq_review()] uses (for CMR) or points at the scriptable triage tools
-#' directly ([eri_logs()], [eri_dq_flag_resolve()], for surveillance ingest) -- nothing here is
-#' reimplemented, and every function this calls stays fully usable directly in a script or CI.
+#' [eri_odk_register()], [eri_odk_sync()], [eri_onboard_country()], [eri_onboard_cmr()],
+#' [eri_onboard_disease()]), and data quality review/approval hands off directly into the same loop
+#' [eri_dq_review()] uses (for CMR) or points at the scriptable triage tools directly ([eri_logs()],
+#' [eri_dq_flag_resolve()], for surveillance ingest) -- nothing here is reimplemented, and every
+#' function this calls stays fully usable directly in a script or CI.
 #'
 #' Currently covers bringing in a monthly CMR report, bringing in a surveillance dataset
-#' (CSV/Excel line-list), and pulling in ODK survey submissions, end to end. ODK sync stops at
-#' `research/raw/` -- there is no automated stage-then-approve path for ODK data yet (the real
-#' guide shows a manual [eri_write()] step), so the wizard is honest about handing off there
-#' rather than fabricating a step the underlying tooling doesn't support. New-program onboarding
-#' is planned as the same framework grows (see `docs/design/interactive-wizard-consult.md`).
+#' (CSV/Excel line-list), pulling in ODK survey submissions, and onboarding a new country, disease,
+#' or data type, end to end. ODK sync stops at `research/raw/` -- there is no automated
+#' stage-then-approve path for ODK data yet (the real guide shows a manual [eri_write()] step) --
+#' and onboarding stops once the schema template is written and Azure folders exist -- filling in
+#' the schema's disease-specific columns, validating it, and submitting it via pull request stay a
+#' human, judgment-driven step (see `vignettes/da-onboard-guide.Rmd`'s "onboarding scaffolds; it
+#' doesn't finish for you"). The wizard is honest about handing off at both points rather than
+#' fabricating steps the underlying tooling doesn't support or shouldn't automate.
 #'
 #' **Interactive only.** In a script or CI, use the scriptable core directly: [eri_upload()],
 #' [eri_stage_cmr()], [eri_split_cmr()], [eri_cmr_dq_report()], [eri_approve_cmr()], [eri_ingest()],
-#' [eri_approve()], [eri_odk_sync()].
+#' [eri_approve()], [eri_odk_sync()], [eri_onboard_country()].
 #'
 #' @returns Invisibly, `NULL`. Every effect happens through the scriptable core it calls.
 #' @examples
@@ -560,10 +698,11 @@ eri_do <- function() {
       "Bring this month's country report (CMR) into the system",
       "Bring in a surveillance dataset (a CSV/Excel line-list)",
       "Pull in ODK survey submissions",
+      "Onboard a new country, disease, or data type",
       "Review & approve something already staged (DQ review)",
       "Exit"
     ))
-    if (choice == 0L || choice == 5L) break
+    if (choice == 0L || choice == 6L) break
 
     if (choice == 1L) {
       .eri_flow_cmr()
@@ -572,6 +711,8 @@ eri_do <- function() {
     } else if (choice == 3L) {
       .eri_flow_odk()
     } else if (choice == 4L) {
+      .eri_flow_onboard()
+    } else if (choice == 5L) {
       country <- .eri_prompt_pick_country(.eri_pipeline_registry[["rb-expansion"]]$country_map,
                                           "Which country?")
       if (!is.null(country)) {

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -56,6 +56,17 @@
 # can't silently diverge from each other.
 .KNOWN_DISEASES <- c("malaria", "oncho", "lf", "sch", "sth")
 
+# Both onboarding schema templates (eri_onboard_country()/eri_onboard_cmr()) take a language for
+# their comments -- ERI's own countries include Francophone ones (Haiti), and the consult itself
+# calls for "language from a pick-list" (interactive-wizard-consult.md). Returns "en"/"fr", or NA on
+# cancel -- same escape-hatch convention as every other prompt in this file.
+#' @keywords internal
+.eri_wizard_prompt_language <- function() {
+  choice <- .eri_prompt_menu("Schema comments in which language?", c("English", "French"))
+  if (choice == 0L) return(NA_character_)
+  c("en", "fr")[[choice]]
+}
+
 # Builds a numbered pick-list from a named country_map (code = display name is backwards here --
 # `.eri_pipeline_registry[[...]]$country_map` maps OUR code to the registry's own downstream code,
 # so the DISPLAY uses names(country_map), the pick-list choice IS the code) and returns the picked
@@ -570,8 +581,11 @@
   )
   if (is.na(disease)) return(invisible(NULL))
 
+  language <- .eri_wizard_prompt_language()
+  if (is.na(language)) return(invisible(NULL))
+
   preview <- .eri_wizard_step(function() {
-    eri_onboard_country(country, country_name, disease, dry_run = TRUE)
+    eri_onboard_country(country, country_name, disease, language = language, dry_run = TRUE)
   })
   if (!preview$ok) return(invisible(NULL))
 
@@ -579,7 +593,9 @@
     return(invisible(NULL))
   }
 
-  result <- .eri_wizard_step(function() eri_onboard_country(country, country_name, disease))
+  result <- .eri_wizard_step(function() {
+    eri_onboard_country(country, country_name, disease, language = language)
+  })
   if (!result$ok) return(invisible(NULL))
 
   invisible(NULL)
@@ -597,8 +613,11 @@
   country_name <- .eri_prompt_line("Full country name (e.g. Uganda; blank to cancel): ")
   if (!nzchar(trimws(country_name))) return(invisible(NULL))
 
+  language <- .eri_wizard_prompt_language()
+  if (is.na(language)) return(invisible(NULL))
+
   preview <- .eri_wizard_step(function() {
-    eri_onboard_cmr(country, country_name, create_dirs = TRUE, dry_run = TRUE)
+    eri_onboard_cmr(country, country_name, language = language, create_dirs = TRUE, dry_run = TRUE)
   })
   if (!preview$ok) return(invisible(NULL))
 
@@ -606,7 +625,9 @@
     return(invisible(NULL))
   }
 
-  result <- .eri_wizard_step(function() eri_onboard_cmr(country, country_name, create_dirs = TRUE))
+  result <- .eri_wizard_step(function() {
+    eri_onboard_cmr(country, country_name, language = language, create_dirs = TRUE)
+  })
   if (!result$ok) return(invisible(NULL))
 
   invisible(NULL)
@@ -667,11 +688,13 @@
 #' (CSV/Excel line-list), pulling in ODK survey submissions, and onboarding a new country, disease,
 #' or data type, end to end. ODK sync stops at `research/raw/` -- there is no automated
 #' stage-then-approve path for ODK data yet (the real guide shows a manual [eri_write()] step) --
-#' and onboarding stops once the schema template is written and Azure folders exist -- filling in
-#' the schema's disease-specific columns, validating it, and submitting it via pull request stay a
-#' human, judgment-driven step (see `vignettes/da-onboard-guide.Rmd`'s "onboarding scaffolds; it
-#' doesn't finish for you"). The wizard is honest about handing off at both points rather than
-#' fabricating steps the underlying tooling doesn't support or shouldn't automate.
+#' and onboarding stops once the schema template(s) are written (and, for surveillance/CMR, the
+#' Azure folders exist -- an NTD disease's MDA/prevalence schemas are local-only, by
+#' [eri_onboard_disease()]'s own design) -- filling in the schema's disease-specific columns,
+#' validating it, and submitting it via pull request stay a human, judgment-driven step (see
+#' `vignettes/da-onboard-guide.Rmd`'s "onboarding scaffolds; it doesn't finish for you"). The wizard
+#' is honest about handing off at both points rather than fabricating steps the underlying tooling
+#' doesn't support or shouldn't automate.
 #'
 #' **Interactive only.** In a script or CI, use the scriptable core directly: [eri_upload()],
 #' [eri_stage_cmr()], [eri_split_cmr()], [eri_cmr_dq_report()], [eri_approve_cmr()], [eri_ingest()],

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.30 · **Status:** Active development
+**Version:** 0.9.31 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -23,10 +23,11 @@ reference, and the project roadmap. This README is the quick orientation.
 
 ## Guides
 
-**Bringing in a monthly country report, a surveillance dataset, or ODK submissions?** Run
-`eri_do()` — a guided console wizard that walks the whole upload/archive → stage → review → approve
-pipeline through a few prompts (which country, which file or ODK form, confirm the period). No
-function names to memorize, no Azure path to type by hand.
+**Bringing in a monthly country report, a surveillance dataset, or ODK submissions? Standing up a
+new country or disease?** Run `eri_do()` — a guided console wizard that walks the whole
+upload/archive → stage → review → approve pipeline through a few prompts (which country, which
+file or ODK form, confirm the period), and scaffolds a brand-new country/disease space when you're
+onboarding one. No function names to memorize, no Azure path to type by hand.
 
 These copy-paste, start-to-finish walkthroughs are the fastest way to learn the system. Read them
 on the [documentation site](https://thecartercenter.github.io/erifunctions/articles/), which groups

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -475,11 +475,24 @@ consult's proposed declarative `flow_map.yaml`/`kind:`-dispatch schema is now a 
 three don't share enough top-level shape to warrant it, only the low-level helper vocabulary
 (`.eri_prompt_pick_country()`, `.eri_wizard_confirm()`, `.eri_wizard_step()`, etc.) is genuinely
 shared — recorded as such in `R/wizard.R`'s own header comment rather than left as a deferred
-question. **Onboarding (Phase C.2, alongside retiring/narrowing `eri_guide()` and cutting the ~26
-guide articles to ~11 in Phase C.3), and progress-detection polish (Phase D) remain designed in the
-consult document but not yet started.** Phase C.3 in particular carries a different risk profile
-from A/B/C.1's purely additive work — deletion and doc cuts — and is flagged for a maintainer
-check-in before starting rather than assumed under a "move on" instruction.
+question. **Phase C.2 (onboarding) shipped as v0.9.31** — `.eri_flow_onboard()` covers all three
+real onboarding shapes from `da-onboard-guide.Rmd`: a surveillance country/disease
+(`eri_onboard_country()`), a CMR country (`eri_onboard_cmr(create_dirs = TRUE)`), and an NTD
+disease's MDA/prevalence schemas (`eri_onboard_disease()`, local-only — no Azure folders at all).
+Each sub-flow dry-runs first, confirms, then writes for real; deliberately stops once the schema
+template is written and the folders exist, per the guide's own golden rule ("onboarding scaffolds;
+it doesn't finish for you") — filling in disease-specific columns, validating, and submitting via
+pull request stay a human step the wizard doesn't fabricate. **A real bug surfaced building this**:
+the shared `.eri_wizard_prompt_country_code()` (also used by Phase B's ingest flow) validated typed
+codes against `^[a-z]{2,4}$`, which would have silently rejected the package's own `atlantis`
+sandbox demo country (8 letters) — exactly the example its own warning message names as valid.
+Onboarding is precisely the flow where a DA types a brand-new code, so this surfaced immediately;
+widened to `^[a-z]{2,15}$` with a regression test locking in the `atlantis` case. **Phase C.3
+(retiring/narrowing `eri_guide()`, cutting the ~26 guide articles to ~11) and progress-detection
+polish (Phase D) remain designed in the consult document but not yet started.** Phase C.3 in
+particular carries a different risk profile from A/B/C.1/C.2's purely additive work — deletion and
+doc cuts — and is flagged for a maintainer check-in before starting rather than assumed under a
+"move on" instruction.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -487,7 +487,11 @@ the shared `.eri_wizard_prompt_country_code()` (also used by Phase B's ingest fl
 codes against `^[a-z]{2,4}$`, which would have silently rejected the package's own `atlantis`
 sandbox demo country (8 letters) — exactly the example its own warning message names as valid.
 Onboarding is precisely the flow where a DA types a brand-new code, so this surfaced immediately;
-widened to `^[a-z]{2,15}$` with a regression test locking in the `atlantis` case. **Phase C.3
+widened to `^[a-z]{2,15}$` with a regression test locking in the `atlantis` case. **review-agent
+also caught a real scope drift**: the surveillance/CMR sub-flows silently defaulted `language` to
+English, dropping the design consult's explicit "language from a pick-list" call — a real gap for
+ERI's own Francophone countries (Haiti) — fixed with a shared `.eri_wizard_prompt_language()`
+prompt before merge. **Phase C.3
 (retiring/narrowing `eri_guide()`, cutting the ~26 guide articles to ~11) and progress-detection
 polish (Phase D) remain designed in the consult document but not yet started.** Phase C.3 in
 particular carries a different risk profile from A/B/C.1/C.2's purely additive work — deletion and

--- a/man/eri_do.Rd
+++ b/man/eri_do.Rd
@@ -27,11 +27,13 @@ Currently covers bringing in a monthly CMR report, bringing in a surveillance da
 (CSV/Excel line-list), pulling in ODK survey submissions, and onboarding a new country, disease,
 or data type, end to end. ODK sync stops at \verb{research/raw/} -- there is no automated
 stage-then-approve path for ODK data yet (the real guide shows a manual \code{\link[=eri_write]{eri_write()}} step) --
-and onboarding stops once the schema template is written and Azure folders exist -- filling in
-the schema's disease-specific columns, validating it, and submitting it via pull request stay a
-human, judgment-driven step (see \code{vignettes/da-onboard-guide.Rmd}'s "onboarding scaffolds; it
-doesn't finish for you"). The wizard is honest about handing off at both points rather than
-fabricating steps the underlying tooling doesn't support or shouldn't automate.
+and onboarding stops once the schema template(s) are written (and, for surveillance/CMR, the
+Azure folders exist -- an NTD disease's MDA/prevalence schemas are local-only, by
+\code{\link[=eri_onboard_disease]{eri_onboard_disease()}}'s own design) -- filling in the schema's disease-specific columns,
+validating it, and submitting it via pull request stay a human, judgment-driven step (see
+\code{vignettes/da-onboard-guide.Rmd}'s "onboarding scaffolds; it doesn't finish for you"). The wizard
+is honest about handing off at both points rather than fabricating steps the underlying tooling
+doesn't support or shouldn't automate.
 
 \strong{Interactive only.} In a script or CI, use the scriptable core directly: \code{\link[=eri_upload]{eri_upload()}},
 \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_cmr_dq_report]{eri_cmr_dq_report()}}, \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}},

--- a/man/eri_do.Rd
+++ b/man/eri_do.Rd
@@ -17,21 +17,25 @@ country, which file, which reporting period -- and calls the existing scriptable
 behalf. Never asks for a function name or an Azure path. \code{mirror_pipeline} is auto-detected from
 \code{\link[=eri_cutover_status]{eri_cutover_status()}} and never asked about. Every mutation is one already-tested function
 (\code{\link[=eri_upload]{eri_upload()}}, \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}}, \code{\link[=eri_approve]{eri_approve()}},
-\code{\link[=eri_odk_register]{eri_odk_register()}}, \code{\link[=eri_odk_sync]{eri_odk_sync()}}), and data quality review/approval hands off directly
-into the same loop \code{\link[=eri_dq_review]{eri_dq_review()}} uses (for CMR) or points at the scriptable triage tools
-directly (\code{\link[=eri_logs]{eri_logs()}}, \code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}}, for surveillance ingest) -- nothing here is
-reimplemented, and every function this calls stays fully usable directly in a script or CI.
+\code{\link[=eri_odk_register]{eri_odk_register()}}, \code{\link[=eri_odk_sync]{eri_odk_sync()}}, \code{\link[=eri_onboard_country]{eri_onboard_country()}}, \code{\link[=eri_onboard_cmr]{eri_onboard_cmr()}},
+\code{\link[=eri_onboard_disease]{eri_onboard_disease()}}), and data quality review/approval hands off directly into the same loop
+\code{\link[=eri_dq_review]{eri_dq_review()}} uses (for CMR) or points at the scriptable triage tools directly (\code{\link[=eri_logs]{eri_logs()}},
+\code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}}, for surveillance ingest) -- nothing here is reimplemented, and every
+function this calls stays fully usable directly in a script or CI.
 
 Currently covers bringing in a monthly CMR report, bringing in a surveillance dataset
-(CSV/Excel line-list), and pulling in ODK survey submissions, end to end. ODK sync stops at
-\verb{research/raw/} -- there is no automated stage-then-approve path for ODK data yet (the real
-guide shows a manual \code{\link[=eri_write]{eri_write()}} step), so the wizard is honest about handing off there
-rather than fabricating a step the underlying tooling doesn't support. New-program onboarding
-is planned as the same framework grows (see \code{docs/design/interactive-wizard-consult.md}).
+(CSV/Excel line-list), pulling in ODK survey submissions, and onboarding a new country, disease,
+or data type, end to end. ODK sync stops at \verb{research/raw/} -- there is no automated
+stage-then-approve path for ODK data yet (the real guide shows a manual \code{\link[=eri_write]{eri_write()}} step) --
+and onboarding stops once the schema template is written and Azure folders exist -- filling in
+the schema's disease-specific columns, validating it, and submitting it via pull request stay a
+human, judgment-driven step (see \code{vignettes/da-onboard-guide.Rmd}'s "onboarding scaffolds; it
+doesn't finish for you"). The wizard is honest about handing off at both points rather than
+fabricating steps the underlying tooling doesn't support or shouldn't automate.
 
 \strong{Interactive only.} In a script or CI, use the scriptable core directly: \code{\link[=eri_upload]{eri_upload()}},
 \code{\link[=eri_stage_cmr]{eri_stage_cmr()}}, \code{\link[=eri_split_cmr]{eri_split_cmr()}}, \code{\link[=eri_cmr_dq_report]{eri_cmr_dq_report()}}, \code{\link[=eri_approve_cmr]{eri_approve_cmr()}}, \code{\link[=eri_ingest]{eri_ingest()}},
-\code{\link[=eri_approve]{eri_approve()}}, \code{\link[=eri_odk_sync]{eri_odk_sync()}}.
+\code{\link[=eri_approve]{eri_approve()}}, \code{\link[=eri_odk_sync]{eri_odk_sync()}}, \code{\link[=eri_onboard_country]{eri_onboard_country()}}.
 }
 \examples{
 \dontrun{

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -6,10 +6,12 @@ TCC's Azure-centred data system across countries (Haiti, DR, Uganda, OEPA, …) 
 (malaria, oncho, LF, SCH, STH). You install it, authenticate through your browser, and call
 functions — you don't edit the package.
 
-**Bringing in a monthly country report, a surveillance dataset, or ODK submissions? Run
-`eri_do()`.** It's a guided console wizard — pick your country, pick the file (or the ODK project
-and form), confirm the month, and it walks the whole upload/archive → stage → review → approve
-pipeline for you. No function names to memorize, no Azure path to type by hand.
+**Bringing in a monthly country report, a surveillance dataset, or ODK submissions? Standing up a
+new country or disease? Run `eri_do()`.** It's a guided console wizard — pick your country, pick
+the file (or the ODK project and form), confirm the month, and it walks the whole
+upload/archive → stage → review → approve pipeline for you. It also scaffolds a brand-new
+country/disease space (schema template + Azure folders) when you're onboarding one for the first
+time. No function names to memorize, no Azure path to type by hand.
 
 Not sure where to start otherwise? **[What are you trying to do?](articles/task-index.html)** is a
 generated index of ~30 common tasks; pick yours and get the call and the guide. In the console,

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -303,6 +303,17 @@ test_that(".eri_wizard_prompt_country_code validates the typed code and re-asks 
   expect_equal(.eri_wizard_prompt_country_code(), "atlantis")
 })
 
+test_that(".eri_wizard_prompt_language returns en/fr by menu choice, or NA on cancel", {
+  local_mocked_bindings(.eri_prompt_menu = function(...) 1L, .package = "erifunctions")
+  expect_equal(.eri_wizard_prompt_language(), "en")
+
+  local_mocked_bindings(.eri_prompt_menu = function(...) 2L, .package = "erifunctions")
+  expect_equal(.eri_wizard_prompt_language(), "fr")
+
+  local_mocked_bindings(.eri_prompt_menu = function(...) 0L, .package = "erifunctions")
+  expect_true(is.na(.eri_wizard_prompt_language()))
+})
+
 test_that(".eri_wizard_should_mirror_ingest is FALSE outright for a country never registered for hsp-mal", {
   # uga is registered for rb-expansion (CMR), NOT hsp-mal -- eri_ingest() would abort if the wizard
   # ever passed mirror_pipeline = "hsp-mal" for it, so this must never even check cutover status.
@@ -563,9 +574,10 @@ test_that(".eri_flow_onboard_surveillance dry-runs, confirms, then writes for re
     .eri_wizard_prompt_country_code = function(...) "atlantis",
     .eri_prompt_line = scripted(list("Atlantis")),
     .eri_prompt_pick_or_type = function(...) "malaria",
-    eri_onboard_country = function(country_code, country_name, disease, dry_run = FALSE) {
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_country = function(country_code, country_name, disease, language = "en", dry_run = FALSE) {
       record(if (dry_run) "dry_run" else "real", country_code = country_code,
-             country_name = country_name, disease = disease)
+             country_name = country_name, disease = disease, language = language)
       invisible(NULL)
     },
     .eri_wizard_confirm = function(...) TRUE,
@@ -588,6 +600,7 @@ test_that(".eri_flow_onboard_surveillance does not write for real when the DA de
     .eri_wizard_prompt_country_code = function(...) "atlantis",
     .eri_prompt_line = scripted(list("Atlantis")),
     .eri_prompt_pick_or_type = function(...) "malaria",
+    .eri_wizard_prompt_language = function(...) "en",
     eri_onboard_country = function(..., dry_run = FALSE) {
       if (!dry_run) real_called <<- TRUE
       invisible(NULL)
@@ -617,8 +630,9 @@ test_that(".eri_flow_onboard_cmr dry-runs and writes for real with create_dirs =
   local_mocked_bindings(
     .eri_wizard_prompt_country_code = function(...) "uga",
     .eri_prompt_line = scripted(list("Uganda")),
-    eri_onboard_cmr = function(country_code, country_name, create_dirs = FALSE, dry_run = FALSE) {
-      record(if (dry_run) "dry_run" else "real", create_dirs = create_dirs)
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_cmr = function(country_code, country_name, language = "en", create_dirs = FALSE, dry_run = FALSE) {
+      record(if (dry_run) "dry_run" else "real", create_dirs = create_dirs, language = language)
       invisible(NULL)
     },
     .eri_wizard_confirm = function(...) TRUE,
@@ -631,6 +645,57 @@ test_that(".eri_flow_onboard_cmr dry-runs and writes for real with create_dirs =
   expect_equal(names_called, c("dry_run", "real"))
   expect_true(calls[[1]]$args$create_dirs)
   expect_true(calls[[2]]$args$create_dirs)
+})
+
+test_that(".eri_flow_onboard_cmr does not write for real when the DA declines", {
+  withr::local_options(rlang_interactive = TRUE)
+  real_called <- FALSE
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_line = scripted(list("Uganda")),
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_cmr = function(..., dry_run = FALSE) {
+      if (!dry_run) real_called <<- TRUE
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) FALSE,
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_cmr())
+  expect_false(real_called)
+})
+
+test_that(".eri_flow_onboard_cmr cancels cleanly on a blank country name", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_line = scripted(list("")),
+    eri_onboard_cmr = function(...) stop("must not be called -- cancelled on blank name"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_cmr())
+})
+
+test_that(".eri_flow_onboard_surveillance/_cmr cancel cleanly when the DA declines the language prompt", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_line = scripted(list("Uganda")),
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    .eri_wizard_prompt_language = function(...) NA_character_,
+    eri_onboard_country = function(...) stop("must not be called -- language prompt was cancelled"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_surveillance())
+
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_line = scripted(list("Uganda")),
+    .eri_wizard_prompt_language = function(...) NA_character_,
+    eri_onboard_cmr = function(...) stop("must not be called -- language prompt was cancelled"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_cmr())
 })
 
 test_that(".eri_flow_onboard_disease maps the menu choice to the right data_types vector", {

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -295,6 +295,12 @@ test_that(".eri_wizard_prompt_country_code validates the typed code and re-asks 
 
   local_mocked_bindings(.eri_prompt_line = scripted(list("")), .package = "erifunctions")
   expect_true(is.na(.eri_wizard_prompt_country_code()))
+
+  # The package's own sandbox demo country -- must not be rejected as "too long" (a real bug this
+  # phase found: the regex was previously capped at 4 letters, which silently rejected the exact
+  # code the prompt's own warning message cites as a valid example).
+  local_mocked_bindings(.eri_prompt_line = scripted(list("atlantis")), .package = "erifunctions")
+  expect_equal(.eri_wizard_prompt_country_code(), "atlantis")
 })
 
 test_that(".eri_wizard_should_mirror_ingest is FALSE outright for a country never registered for hsp-mal", {
@@ -526,12 +532,149 @@ test_that(".eri_flow_odk stops cleanly when there are no visible projects", {
   expect_invisible(.eri_flow_odk())
 })
 
+#### Phase C.2: onboarding ####
+
+test_that(".eri_flow_onboard routes to the surveillance/CMR/disease sub-flows by menu choice", {
+  withr::local_options(rlang_interactive = TRUE)
+  ran <- character(0)
+  local_mocked_bindings(
+    .eri_flow_onboard_surveillance = function() { ran <<- c(ran, "surveillance"); invisible(NULL) },
+    .eri_flow_onboard_cmr          = function() { ran <<- c(ran, "cmr"); invisible(NULL) },
+    .eri_flow_onboard_disease      = function() { ran <<- c(ran, "disease"); invisible(NULL) },
+    .package = "erifunctions"
+  )
+  local_mocked_bindings(.eri_prompt_menu = function(...) 1L, .package = "erifunctions")
+  .eri_flow_onboard()
+  local_mocked_bindings(.eri_prompt_menu = function(...) 2L, .package = "erifunctions")
+  .eri_flow_onboard()
+  local_mocked_bindings(.eri_prompt_menu = function(...) 3L, .package = "erifunctions")
+  .eri_flow_onboard()
+  local_mocked_bindings(.eri_prompt_menu = function(...) 0L, .package = "erifunctions")
+  expect_invisible(.eri_flow_onboard())
+
+  expect_equal(ran, c("surveillance", "cmr", "disease"))
+})
+
+test_that(".eri_flow_onboard_surveillance dry-runs, confirms, then writes for real -- in order", {
+  withr::local_options(rlang_interactive = TRUE)
+  calls <- list()
+  record <- function(name, ...) calls[[length(calls) + 1L]] <<- list(name = name, args = list(...))
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_line = scripted(list("Atlantis")),
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    eri_onboard_country = function(country_code, country_name, disease, dry_run = FALSE) {
+      record(if (dry_run) "dry_run" else "real", country_code = country_code,
+             country_name = country_name, disease = disease)
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) TRUE,
+    .package = "erifunctions"
+  )
+
+  expect_invisible(.eri_flow_onboard_surveillance())
+
+  names_called <- vapply(calls, function(c) c$name, character(1))
+  expect_equal(names_called, c("dry_run", "real"))
+  expect_equal(calls[[2]]$args$country_code, "atlantis")
+  expect_equal(calls[[2]]$args$country_name, "Atlantis")
+  expect_equal(calls[[2]]$args$disease, "malaria")
+})
+
+test_that(".eri_flow_onboard_surveillance does not write for real when the DA declines", {
+  withr::local_options(rlang_interactive = TRUE)
+  real_called <- FALSE
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_line = scripted(list("Atlantis")),
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    eri_onboard_country = function(..., dry_run = FALSE) {
+      if (!dry_run) real_called <<- TRUE
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) FALSE,
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_surveillance())
+  expect_false(real_called)
+})
+
+test_that(".eri_flow_onboard_surveillance cancels cleanly on a blank country name", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_line = scripted(list("")),
+    eri_onboard_country = function(...) stop("must not be called -- cancelled on blank name"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_surveillance())
+})
+
+test_that(".eri_flow_onboard_cmr dry-runs and writes for real with create_dirs = TRUE both times", {
+  withr::local_options(rlang_interactive = TRUE)
+  calls <- list()
+  record <- function(name, ...) calls[[length(calls) + 1L]] <<- list(name = name, args = list(...))
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_line = scripted(list("Uganda")),
+    eri_onboard_cmr = function(country_code, country_name, create_dirs = FALSE, dry_run = FALSE) {
+      record(if (dry_run) "dry_run" else "real", create_dirs = create_dirs)
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) TRUE,
+    .package = "erifunctions"
+  )
+
+  expect_invisible(.eri_flow_onboard_cmr())
+
+  names_called <- vapply(calls, function(c) c$name, character(1))
+  expect_equal(names_called, c("dry_run", "real"))
+  expect_true(calls[[1]]$args$create_dirs)
+  expect_true(calls[[2]]$args$create_dirs)
+})
+
+test_that(".eri_flow_onboard_disease maps the menu choice to the right data_types vector", {
+  withr::local_options(rlang_interactive = TRUE)
+  captured_types <- list()
+  local_mocked_bindings(
+    .eri_prompt_pick_or_type = function(...) "schisto",
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    eri_onboard_disease = function(disease, country, data_types, dry_run = FALSE) {
+      if (!dry_run) captured_types[[length(captured_types) + 1L]] <<- data_types
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) TRUE,
+    .package = "erifunctions"
+  )
+
+  local_mocked_bindings(.eri_prompt_menu = scripted(list(1L)), .package = "erifunctions")
+  .eri_flow_onboard_disease()
+  local_mocked_bindings(.eri_prompt_menu = scripted(list(2L)), .package = "erifunctions")
+  .eri_flow_onboard_disease()
+  local_mocked_bindings(.eri_prompt_menu = scripted(list(3L)), .package = "erifunctions")
+  .eri_flow_onboard_disease()
+
+  expect_equal(captured_types, list(c("mda", "prevalence"), "mda", "prevalence"))
+})
+
+test_that(".eri_flow_onboard_disease cancels cleanly when the DA declines the schema-type menu", {
+  withr::local_options(rlang_interactive = TRUE)
+  local_mocked_bindings(
+    .eri_prompt_pick_or_type = function(...) "schisto",
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_menu = scripted(list(0L)),
+    eri_onboard_disease = function(...) stop("must not be called -- schema-type menu was cancelled"),
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_disease())
+})
+
 test_that("eri_do's top menu routes to the CMR flow and exits cleanly", {
   withr::local_options(rlang_interactive = TRUE)
   cmr_ran <- FALSE
   local_mocked_bindings(
     .eri_flow_cmr = function() { cmr_ran <<- TRUE; invisible(NULL) },
-    .eri_prompt_menu = scripted(list(1L, 5L)),  # CMR flow, then Exit
+    .eri_prompt_menu = scripted(list(1L, 6L)),  # CMR flow, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())
@@ -543,7 +686,7 @@ test_that("eri_do's top menu routes to the surveillance ingest flow and exits cl
   ingest_ran <- FALSE
   local_mocked_bindings(
     .eri_flow_ingest = function() { ingest_ran <<- TRUE; invisible(NULL) },
-    .eri_prompt_menu = scripted(list(2L, 5L)),  # ingest flow, then Exit
+    .eri_prompt_menu = scripted(list(2L, 6L)),  # ingest flow, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())
@@ -555,11 +698,23 @@ test_that("eri_do's top menu routes to the ODK flow and exits cleanly", {
   odk_ran <- FALSE
   local_mocked_bindings(
     .eri_flow_odk = function() { odk_ran <<- TRUE; invisible(NULL) },
-    .eri_prompt_menu = scripted(list(3L, 5L)),  # ODK flow, then Exit
+    .eri_prompt_menu = scripted(list(3L, 6L)),  # ODK flow, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())
   expect_true(odk_ran)
+})
+
+test_that("eri_do's top menu routes to the onboarding flow and exits cleanly", {
+  withr::local_options(rlang_interactive = TRUE)
+  onboard_ran <- FALSE
+  local_mocked_bindings(
+    .eri_flow_onboard = function() { onboard_ran <<- TRUE; invisible(NULL) },
+    .eri_prompt_menu = scripted(list(4L, 6L)),  # onboarding flow, then Exit
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_do())
+  expect_true(onboard_ran)
 })
 
 test_that("eri_do's top menu routes to the DQ-review shortcut with a picked country/period", {
@@ -569,7 +724,7 @@ test_that("eri_do's top menu routes to the DQ-review shortcut with a picked coun
     .eri_prompt_pick_country = function(...) "uga",
     .eri_wizard_pick_period  = function(...) "202406",
     eri_dq_review = function(country, period) { reviewed <<- c(country, period); invisible(NULL) },
-    .eri_prompt_menu = scripted(list(4L, 5L)),  # DQ review shortcut, then Exit
+    .eri_prompt_menu = scripted(list(5L, 6L)),  # DQ review shortcut, then Exit
     .package = "erifunctions"
   )
   expect_invisible(eri_do())

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -19,6 +19,13 @@ knitr::opts_chunk$set(
 **Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
+> **Just need to scaffold the space, not learn the functions?** Run
+> [`eri_do()`](../reference/eri_do.html) in the console and pick "onboard a new country, disease,
+> or data type" — it walks you through the dry-run preview and writes the schema template + Azure
+> folders for you. It stops there: filling in the schema's disease-specific columns, validating it,
+> and submitting it via pull request are still yours to do, and this guide is where you learn that
+> part.
+
 Before any data can flow through `erifunctions`, the **space for it has to exist**: a data-quality
 schema that describes the data, and the `raw → staged → processed` folders it will move through. This
 guide is for a **Data Analyst** standing up that space for a new country, disease, or data type. It is


### PR DESCRIPTION
## Summary
- Adds `.eri_flow_onboard()` to `R/wizard.R`: covers all three real onboarding shapes from `da-onboard-guide.Rmd` -- a surveillance country/disease (`eri_onboard_country()`), a CMR country (`eri_onboard_cmr(create_dirs = TRUE)`), and an NTD disease's MDA/prevalence schemas (`eri_onboard_disease()`, local-only -- no Azure folders). Each sub-flow dry-runs first (reusing the real function's own `dry_run = TRUE` preview), confirms, then writes for real.
- Deliberately stops at "the schema template is written and the folders exist" -- `da-onboard-guide.Rmd`'s own golden rule is "onboarding scaffolds; it doesn't finish for you." Filling in a schema's disease-specific columns, validating it, and submitting via pull request stay a human judgment call the wizard doesn't fabricate. The three `eri_onboard_*()` functions already print their own "Next steps" via `cli_inform()`, so the flow doesn't re-print or paraphrase that text.
- `eri_do()`'s top menu is now 6 items (CMR / ingest / ODK / onboard / DQ-review-shortcut / Exit).
- **Real bug found and fixed while building this**: the shared `.eri_wizard_prompt_country_code()` (also used by Phase B's ingest flow) validated typed codes against `^[a-z]{2,4}$` -- but the package's own sandbox demo country, `atlantis` (8 letters), is exactly the example its own warning message names as valid, and would have been silently rejected. Onboarding is precisely the flow where a DA types a brand-new code, so this surfaced immediately; widened to `^[a-z]{2,15}$` with a regression test locking in the `atlantis` case.
- Docs: `NEWS.md` (0.9.31), `docs/roadmap.md`, `pkgdown/index.md`, `README.md`, a callout in `vignettes/da-onboard-guide.Rmd`, `eri_do()` roxygen.

## Test plan
- [x] `tests/testthat/test-wizard.R` grown to 105 tests (+19): routing across the three sub-flows, each sub-flow's dry-run -> confirm -> real-write order, decline-to-confirm and cancel-on-blank-input paths, the NTD flow's menu-choice -> `data_types` vector mapping, and a regression test for the `atlantis` country-code fix.
- [x] Full suite: `devtools::test()` -- 0 failures, 2888 pass (pre-existing unrelated warnings only).
- [x] `devtools::document()` regenerated `man/eri_do.Rd` clean.