### PR TITLE
feat(wizard): retire eri_guide(), narrow doc cut to genuine overlap (Phase C.3) (0.9.32)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.31
+Version: 0.9.32
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,44 @@
+# erifunctions 0.9.32
+
+## `eri_guide()` retired to a static lookup; doc cut turned out much smaller than planned (Phase C.3 of the interactive-wizard course correction)
+
+- **`eri_guide()` is deprecated** (`r lifecycle::badge("deprecated")`, `.Deprecated()` warning on every
+  call). Its menu-driven console wizard could only ever *run* 4 of ~32 tasks; everything else it could
+  only describe, which the vignettes and `eri_task_map()` already do. Rather than delete the exported
+  name outright mid-transition, it's narrowed: `eri_guide(task_id)` still shows that task's call, guide,
+  and reference functions (no menu); called with no argument, it now just prints `eri_task_map()`'s full
+  listing. Deleted with the menu: `.eri_guide_zero_arg()`, `.eri_guide_show_task()`,
+  `.eri_guide_last_branch_id()`/`.eri_guide_set_last_branch_id()` (session memory),
+  `.eri_guide_resolve_branch_choice()` -- none had a purpose once there's no menu to drive.
+- **The documentation-cutting plan turned out to be much smaller than the design consult estimated**,
+  and this is worth explaining rather than force-fitting a number a stale plan guessed at. The consult
+  (written before Phases A/B/C.1/C.2 shipped) assumed 7 DA pipeline guides (`da-cmr-guide`,
+  `da-ingest-guide`, `da-odk-guide`, `da-onboard-guide`, `da-dq-review-guide`, `da-logs-guide`,
+  `da-qc-feedback-guide`) were redundant "walkthroughs `eri_do()` replaces" and proposed folding all 7
+  into one ~10-vignette reference set. In practice: (1) each pipeline guide already got a
+  "prefer to just do it? run `eri_do()`" callout as its own phase shipped, so the redirect the consult
+  wanted was already delivered incrementally, not deferred to this phase; (2) `da-odk-guide` and
+  `da-onboard-guide` cover substantial ground `eri_do()` does NOT automate (monitoring a survey,
+  managing ODK app users, filling in/validating/submitting a schema) -- cutting them would have
+  destroyed real, non-redundant domain knowledge; (3) `da-dq-review-guide` documents the *exact*
+  interactive loop `eri_do()`'s CMR flow hands off into, and `da-logs-guide` documents the *exact*
+  tools `eri_do()` points a DA at for manual backlog triage -- both are reference material for what the
+  wizard is already doing, not competing walkthroughs; (4) `da-qc-feedback-guide` has no wizard overlap
+  at all (offline QC + Teams notification, a different task entirely). The actual redundancy was much
+  narrower: two "quick reference" pages (`da-cheatsheet`, `orientation`) whose "which pipeline do I
+  use?" decision trees purely duplicated `eri_do()`'s own menu, with no other unique content -- both
+  trimmed to a one-line pointer at `eri_do()`, keeping everything else. Also also added the missing
+  wizard-context callouts to `da-dq-review-guide`/`da-logs-guide` (point 3 above). **Net: 0 vignettes
+  deleted** (still 25) -- the consult's own audit (§2) had already flagged 8 real vignettes it never
+  accounted for in its "~26 -> ~11" count, and forcing a cut to hit that stale number would have been
+  solving to a guessed target instead of to genuine redundancy.
+- **`onboarding.Rmd`** (the paced new-DA path): the "ingestion spine" days now point at `eri_do()` as
+  the primary way to do each task, with the existing guides reframed as "what's happening underneath."
+  Also removed the "Competency checklist (DA + mentor sign off)" heading's mentor-sign-off framing (a
+  DA rules complaint raised earlier this session, superseded at the time by the larger course
+  correction -- finally addressed here since this file was already being revised).
+  `pkgdown/index.md`/`README.md`'s `eri_guide()` mentions reworded to `eri_task_map()`.
+
 # erifunctions 0.9.31
 
 ## `eri_do()` now covers onboarding too (Phase C.2 of the interactive-wizard course correction)

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,11 +27,13 @@
   at all (offline QC + Teams notification, a different task entirely). The actual redundancy was much
   narrower: two "quick reference" pages (`da-cheatsheet`, `orientation`) whose "which pipeline do I
   use?" decision trees purely duplicated `eri_do()`'s own menu, with no other unique content -- both
-  trimmed to a one-line pointer at `eri_do()`, keeping everything else. Also also added the missing
+  trimmed to a one-line pointer at `eri_do()`, keeping everything else. Also added the missing
   wizard-context callouts to `da-dq-review-guide`/`da-logs-guide` (point 3 above). **Net: 0 vignettes
-  deleted** (still 25) -- the consult's own audit (§2) had already flagged 8 real vignettes it never
-  accounted for in its "~26 -> ~11" count, and forcing a cut to hit that stale number would have been
-  solving to a guessed target instead of to genuine redundancy.
+  deleted** (still 25) -- this re-audit found 8 real vignettes the consult's own plan never mentions
+  at all (`da-adhoc-guide`, `da-cheatsheet`, `da-reporting-guide`, `da-survey-report-guide`,
+  `dq-pipeline`, `epi-dq-guide`, `orientation`, `sharepoint-workflow`), meaning its "~26 -> ~11" count
+  was already built on an incomplete picture -- forcing a cut to hit that stale number would have
+  been solving to a guessed target instead of to genuine redundancy.
 - **`onboarding.Rmd`** (the paced new-DA path): the "ingestion spine" days now point at `eri_do()` as
   the primary way to do each task, with the existing guides reframed as "what's happening underneath."
   Also removed the "Competency checklist (DA + mentor sign off)" heading's mentor-sign-off framing (a

--- a/R/guide.R
+++ b/R/guide.R
@@ -1,40 +1,71 @@
-#### eri_guide — an interactive console wizard over the task registry ####
+#### eri_guide — deprecated, narrowed to a static lookup (Phase C.3 of the interactive-wizard course correction) ####
 #
-# Phase 5 (MVP) + phase 7 (wizard depth) of the docs site & guidance system redesign
-# (docs/roadmap.md's "Docs site & guidance system redesign" entry). Walks
-# inst/registry/task_map.yaml the same way eri_dq_review() walks the DQ core: cli_h3() +
-# utils::menu() menus (.eri_prompt_menu(), R/dq_review.R), nothing persisted to disk, safe to exit
-# and rerun anytime.
+# eri_guide() used to be a menu-driven console wizard over inst/registry/task_map.yaml (Phase 5+7 of
+# the docs-site redesign). The interactive-wizard consult (docs/design/interactive-wizard-consult.md
+# section 2/3.9) assessed it against eri_do(): it could only ever RUN 4 of ~32 tasks (the
+# zero-argument ones); everything else it could just *describe*, which the vignettes already do.
+# Once eri_do() exists as the executor, a menu-driven front door that mostly can't act is worse than
+# either (a) the executor, for the tasks it covers, or (b) a plain lookup, for browsing. The consult
+# offered two options: delete outright, or narrow to a non-menu `eri_guide(task_id)` lookup. This
+# takes the narrower path rather than deleting the exported name outright -- eri_guide() is a real,
+# already-shipped tool DAs may have muscle memory or scripts referencing; removing the export
+# entirely mid-transition would turn a design decision into a breaking surprise. `.Deprecated()`
+# points every caller at eri_do() (to act) or eri_task_map() (to browse) and the function keeps doing
+# something useful -- lookup, not a dead end.
 #
-# The "run guardrail" is mechanical, not a schema field: a task's call is only offered as "Run it
-# now" when it parses to a zero-argument call -- the same call string test-task-map.R already
-# verifies parses as R. Everything else needs real argument values this wizard has no safe way to
-# fabricate, so it can only be shown, with its guide opened for the full walkthrough. Real
-# per-function argument collection (so more tasks could be run from the wizard) stays out of
-# scope -- most leaves' calls mix simple strings with real R objects (a data frame, an sf
-# shapefile) a console prompt can't safely fabricate, and guessing which is which per function
-# risks silently passing the wrong thing. "Run it now"'s existing tryCatch-and-report (below) is
-# the guardrail against a live call failing; a more elaborate preflight (checking specific env
-# vars/state per task) would need new schema fields for uncertain benefit over that.
-#
-# Phase 7 additions: session memory (.eri_guide_last_branch_id()/.eri_guide_set_last_branch_id(),
-# an options()-based session-state convention matching R/console.R's verbosity, not a new
-# package-env pattern) offers to resume the last-visited category; a task id deep link
-# (eri_guide(task_id = )) jumps straight to one task's detail screen via .eri_task_find_leaf()
-# (R/task_registry.R).
+# Deleted with the menu wizard: `.eri_guide_zero_arg()` (the "is this safe to run" test),
+# `.eri_guide_show_task()` (the menu-driven task detail screen with "run it now"),
+# `.eri_guide_last_branch_id()`/`.eri_guide_set_last_branch_id()` (session memory of the last-browsed
+# category), `.eri_guide_resolve_branch_choice()` (menu index arithmetic). None of these have a
+# purpose once there's no menu to drive.
 
-# TRUE only for a call with no arguments at all, e.g. "eri_data_model()" -- not "eri_query(sql)"
-# even though `sql` has no default here, since the registry's own call templates never encode
-# defaults, only the shape of a representative invocation.
-#' @keywords internal
-.eri_guide_zero_arg <- function(call) {
-  length(as.list(str2lang(call))) == 1L
-}
+#' Look up a task's call and guide (deprecated; use [eri_do()] or [eri_task_map()])
+#'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' `eri_guide()` used to be a menu-driven console wizard. It's deprecated in favor of two sharper
+#' tools: [eri_do()], which actually *runs* the CMR/ingest/ODK/onboarding pipelines through a guided
+#' console flow, and [eri_task_map()] (or the generated task-index article), which browses every
+#' task's representative call, guide, and reference functions as a static list. `eri_guide()` never
+#' had "run it now" for more than 4 of ~32 tasks -- for anything else it could only describe, which is
+#' what the vignettes and [eri_task_map()] already do, without a menu to navigate.
+#'
+#' This function is kept, narrowed, rather than removed outright: pass a `task_id` and it still shows
+#' that task's call, guide, and reference functions (no menu); called with no argument, it prints the
+#' full [eri_task_map()] listing instead of opening an interactive browser.
+#'
+#' @param task_id `chr` or `NULL` A task id to show (see [eri_task_map()]'s `id` column, or the
+#'   generated task-index article, for valid ids). `NULL` (default) prints the full task list instead.
+#' @returns Invisibly, `NULL`.
+#' @examples
+#' \dontrun{
+#' eri_guide("check_cmr")  # show one task's call/guide/reference, no menu
+#' eri_guide()             # equivalent to eri_task_map()
+#' }
+#' @seealso [eri_do()] for the guided pipeline wizard that replaced this, [eri_task_map()] for the
+#'   full static listing.
+#' @export
+eri_guide <- function(task_id = NULL) {
+  .Deprecated("eri_do", package = "erifunctions",
+              msg = paste(
+                "eri_guide() is deprecated. Use eri_do() to run a pipeline through a guided console",
+                "flow, or eri_task_map() to browse every task's call/guide/reference."
+              ))
 
-# One task's detail screen: what it does, its call, its guide, its reference functions, and (only
-# when safe) the option to run it or open the guide right now.
-#' @keywords internal
-.eri_guide_show_task <- function(leaf) {
+  if (is.null(task_id)) {
+    eri_task_map()
+    return(invisible(NULL))
+  }
+
+  leaf <- .eri_task_find_leaf(task_id, .eri_task_map())
+  if (is.null(leaf)) {
+    cli::cli_abort(c(
+      "No task with id {.val {task_id}} in the registry.",
+      "i" = "Call {.fn eri_task_map} to see valid ids."
+    ))
+  }
+
   cli::cli_h2(leaf$title)
   cli::cli_bullets(c("*" = "Run: {.code {leaf$call}}"))
   if (!is.null(leaf$guide)) {
@@ -42,143 +73,6 @@
   }
   if (length(leaf$reference) > 0L) {
     cli::cli_bullets(c("*" = "Reference: {.fn {leaf$reference}}"))
-  }
-
-  options <- character(0)
-  if (.eri_guide_zero_arg(leaf$call)) options <- c(options, "Run it now")
-  if (!is.null(leaf$guide)) options <- c(options, "Open the guide")
-  options <- c(options, "Back")
-
-  repeat {
-    choice <- .eri_prompt_menu("What next?", options)
-    picked <- if (choice == 0L) "Back" else options[[choice]]
-
-    if (picked == "Run it now") {
-      tryCatch(
-        {
-          # withVisible() so a visibly-returned result (e.g. get_azure_storage_connection()'s
-          # container) prints here exactly as it would at the console top level, while a call
-          # that already prints its own output via cli:: (eri_data_model()) or returns
-          # invisibly doesn't print twice.
-          result <- withVisible(eval(str2lang(leaf$call)))
-          if (isTRUE(result$visible)) print(result$value)
-        },
-        error = function(e) cli::cli_alert_warning("That call failed: {conditionMessage(e)}")
-      )
-    } else if (picked == "Open the guide") {
-      tryCatch(
-        print(utils::vignette(leaf$guide, package = "erifunctions")),
-        error = function(e) cli::cli_alert_warning("Could not open the guide: {conditionMessage(e)}")
-      )
-    } else {
-      break
-    }
-  }
-  invisible(NULL)
-}
-
-# Session memory of which category the wizard last visited, so re-invoking eri_guide() can offer
-# to resume there instead of always starting from the top. Uses the same getOption()/options()
-# session-state convention as R/console.R's verbosity (not a new package-env pattern) -- resets
-# with a fresh R session, the right lifetime for "where was I browsing," nothing worth persisting
-# to disk.
-#' @keywords internal
-.eri_guide_last_branch_id <- function() getOption("erifunctions.guide_last_branch", default = NULL)
-
-#' @keywords internal
-.eri_guide_set_last_branch_id <- function(id) options(erifunctions.guide_last_branch = id)
-
-# Resolves a top-level category-menu choice to NULL (exit) or the chosen branch, accounting for
-# whether a "Continue in ..." resume option was prepended (which shifts every other index by one).
-# Isolated as its own pure function so the index arithmetic is unit-testable independent of the
-# interactive loop -- exactly the kind of off-by-one that's easy to get wrong inline.
-#' @keywords internal
-.eri_guide_resolve_branch_choice <- function(choice, tree, resume_branch) {
-  offset <- if (!is.null(resume_branch)) 1L else 0L
-  if (choice == 0L || choice == length(tree) + offset + 1L) return(NULL)
-  if (!is.null(resume_branch) && choice == 1L) return(resume_branch)
-  tree[[choice - offset]]
-}
-
-#' Find your task and get its call and guide (interactive)
-#'
-#' @description
-#' `r lifecycle::badge("experimental")`
-#'
-#' A console wizard over the task registry ([eri_task_map()]'s bundled
-#' `inst/registry/task_map.yaml`): pick a category, pick a task, see its representative call, its
-#' guide (if any), and the reference functions it touches. A zero-argument task (e.g.
-#' [eri_data_model()], [get_azure_storage_connection()]) can be run right from the menu;
-#' everything else -- which needs real argument values this wizard has no safe way to fabricate --
-#' can only be shown, with its guide opened for the full walkthrough.
-#'
-#' The wizard remembers the last category you visited this session and offers to resume there.
-#' Pass a task id to jump straight to its detail screen instead of navigating the menus (see
-#' [eri_task_map()]'s `id` column, or the generated task-index article, for valid ids).
-#'
-#' Prefer the generated [task-index article](../articles/task-index.html) or [eri_task_map()] when
-#' you don't need the back-and-forth of a menu.
-#'
-#' **Interactive only.** In a script, browse [eri_task_map()] or the task-index article instead.
-#'
-#' @param task_id `chr` or `NULL` A task id to jump straight to its detail screen, skipping the
-#'   category/task menus. `NULL` (default) starts at the top-level category menu.
-#' @returns Invisibly, `NULL`. "Run it now" prints its visibly-returned result the same way typing
-#'   the call at the console would (so e.g. [get_azure_storage_connection()]'s connection object is
-#'   shown, not silently discarded), and a failure is caught and reported rather than crashing the
-#'   wizard -- but the result itself is not kept for later use; assign it yourself if you need it
-#'   again (`con <- get_azure_storage_connection()`).
-#' @examples
-#' \dontrun{
-#' eri_guide()
-#' eri_guide("check_cmr")  # jump straight to a known task
-#' }
-#' @seealso [eri_task_map()] for the non-interactive console version, [eri_dq_review()] for the
-#'   same menu-driven wizard pattern applied to DQ triage.
-#' @export
-eri_guide <- function(task_id = NULL) {
-  if (!rlang::is_interactive()) {
-    cli::cli_abort(c(
-      "{.fn eri_guide} is interactive-only.",
-      "i" = "See the generated task-index article, or call {.fn eri_task_map} for the console version."
-    ))
-  }
-
-  tree <- .eri_task_map()
-
-  if (!is.null(task_id)) {
-    leaf <- .eri_task_find_leaf(task_id, tree)
-    if (is.null(leaf)) {
-      cli::cli_abort(c(
-        "No task with id {.val {task_id}} in the registry.",
-        "i" = "Call {.fn eri_task_map} to see valid ids, or {.fn eri_guide} with no argument to browse."
-      ))
-    }
-    .eri_guide_show_task(leaf)
-    return(invisible(NULL))
-  }
-
-  repeat {
-    resume_branch <- .eri_task_find_branch(.eri_guide_last_branch_id(), tree)
-    branch_titles <- vapply(tree, function(b) b$title, character(1))
-    menu_choices  <- if (!is.null(resume_branch)) {
-      c(sprintf('Continue in "%s"', resume_branch$title), branch_titles, "Exit")
-    } else {
-      c(branch_titles, "Exit")
-    }
-
-    branch_choice <- .eri_prompt_menu("What are you trying to do?", menu_choices)
-    branch <- .eri_guide_resolve_branch_choice(branch_choice, tree, resume_branch)
-    if (is.null(branch)) break
-
-    .eri_guide_set_last_branch_id(branch$id)
-
-    repeat {
-      leaf_titles <- vapply(branch$children, function(l) l$title, character(1))
-      leaf_choice <- .eri_prompt_menu(branch$title, c(leaf_titles, "Back"))
-      if (leaf_choice == 0L || leaf_choice == length(branch$children) + 1L) break
-      .eri_guide_show_task(branch$children[[leaf_choice]])
-    }
   }
 
   invisible(NULL)

--- a/R/task_registry.R
+++ b/R/task_registry.R
@@ -64,13 +64,6 @@
   }, error = function(e) invisible(NULL))
 }
 
-# Finds the branch with the given id anywhere in the tree, or NULL if `id` is NULL/unmatched.
-# Used by eri_guide()'s session-memory resume lookup (R/guide.R, phase 7).
-#' @keywords internal
-.eri_task_find_branch <- function(id, tree = .eri_task_map()) {
-  Find(function(b) identical(b$id, id), tree)
-}
-
 # Finds the leaf with the given id anywhere in the tree, or NULL if `id` is NULL/unmatched. Used by
 # eri_guide(task_id = )'s deep-link path (R/guide.R, phase 7).
 #' @keywords internal

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -38,7 +38,10 @@
 # already print their own "Next steps" via cli_inform, so the flow doesn't re-print or paraphrase
 # them -- one copy of that text, not two that can drift.
 #
-# Retiring eri_guide() and the doc cut are Phase C.3/D, not started.
+# Phase C.3 retired eri_guide() (deprecated + narrowed to a static lookup, R/guide.R) and re-audited
+# the doc cut against what actually shipped in A-C.2, finding it much narrower than the consult
+# estimated -- see docs/roadmap.md's Phase C.3 entry. Progress-detection polish is Phase D, not
+# started.
 #
 # Concrete R control flow, not a declarative flow schema. The original consult proposed a
 # `flow_map.yaml`/`kind:`-dispatch engine "once a second/third flow gives it real shape to

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.31 · **Status:** Active development
+**Version:** 0.9.32 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the
@@ -41,7 +41,7 @@ you work:
 
 - [What are you trying to do?](https://thecartercenter.github.io/erifunctions/articles/task-index.html):
   a generated index of ~31 common tasks — pick yours, get the call and the guide. Prefer the
-  console? `eri_guide()` walks the same list as an interactive menu.
+  console? `eri_task_map()` prints the same list.
 - [Orientation](https://thecartercenter.github.io/erifunctions/articles/orientation.html): the big
   picture: the data system, the pipeline, and where your tasks live
 - [DA cheat sheet](https://thecartercenter.github.io/erifunctions/articles/da-cheatsheet.html): the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -491,12 +491,38 @@ widened to `^[a-z]{2,15}$` with a regression test locking in the `atlantis` case
 also caught a real scope drift**: the surveillance/CMR sub-flows silently defaulted `language` to
 English, dropping the design consult's explicit "language from a pick-list" call — a real gap for
 ERI's own Francophone countries (Haiti) — fixed with a shared `.eri_wizard_prompt_language()`
-prompt before merge. **Phase C.3
-(retiring/narrowing `eri_guide()`, cutting the ~26 guide articles to ~11) and progress-detection
-polish (Phase D) remain designed in the consult document but not yet started.** Phase C.3 in
-particular carries a different risk profile from A/B/C.1/C.2's purely additive work — deletion and
-doc cuts — and is flagged for a maintainer check-in before starting rather than assumed under a
-"move on" instruction.
+prompt before merge.
+
+**Phase C.3 (retire `eri_guide()`, doc cut) shipped as v0.9.32.** `eri_guide()` is deprecated
+(`.Deprecated()`) and narrowed rather than deleted outright: `eri_guide(task_id)` still shows a
+task's call/guide/reference with no menu, and a no-argument call now just prints `eri_task_map()`'s
+full listing — the menu-driven wizard itself (`.eri_guide_show_task()`, session memory, "run it
+now") is gone, since it could only ever run 4 of ~32 tasks and everything else just described what
+the vignettes already do. Deleting the export outright was considered and rejected: it's a real,
+already-shipped tool with possible script/muscle-memory dependents, so narrowing to a working
+lookup is the gentler transition the consult itself offered as an alternative.
+
+**The documentation cut turned out far smaller than the consult estimated, and re-auditing why
+mattered more than hitting its number.** The consult (written before Phases A/B/C.1/C.2 shipped)
+assumed 7 DA pipeline guides were walkthroughs `eri_do()` fully replaces and proposed folding them
+into one ~10-vignette set (26 → ~11). Re-checking against what actually shipped: each pipeline
+guide already got a "prefer to just do it? run `eri_do()`" callout as its own phase landed, so the
+redirect the consult wanted was delivered incrementally, not deferred here; `da-odk-guide` and
+`da-onboard-guide` cover real ground the wizard doesn't automate (survey monitoring, app-user
+management, filling in/validating/submitting a schema) and cutting them would have destroyed
+non-redundant domain knowledge; `da-dq-review-guide` and `da-logs-guide` document the *exact*
+interactive loop/tools the wizard hands off into or points at, not competing walkthroughs; and
+`da-qc-feedback-guide` has no wizard overlap at all. The real, narrow redundancy was two
+quick-reference pages (`da-cheatsheet`, `orientation`) whose "which pipeline?" decision trees
+purely duplicated `eri_do()`'s menu — both trimmed to a one-line pointer, everything else in them
+kept. Added the missing wizard-context callouts to `da-dq-review-guide`/`da-logs-guide`. **Net: zero
+vignettes deleted** — forcing a cut to match a stale, pre-shipment estimate would have been solving
+to a guessed number rather than to genuine overlap, exactly the CLAUDE.md guardrail against
+designing for a hypothetical rather than a verified need. `onboarding.Rmd`'s ingestion-spine days
+now point at `eri_do()` as the primary path; its "Competency checklist" heading also dropped the
+"DA + mentor sign off" framing (a standalone DA-rules complaint raised earlier in this session,
+addressed here since the file was already being revised). **Phase D (progress-detection polish,
+`eri_do("cmr")` deep links) remains designed in the consult document but not yet started.**
 
 ---
 

--- a/inst/registry/task_map.yaml
+++ b/inst/registry/task_map.yaml
@@ -7,7 +7,9 @@
 #
 # This is the shared source three surfaces render from, so they can never disagree:
 #   - a generated static article (vignettes/task-index.Rmd, this phase)
-#   - the future eri_guide() console wizard (phase 5)
+#   - eri_task_map() and the deprecated eri_guide(task_id=)'s static lookup (R/task_registry.R,
+#     R/guide.R -- eri_guide()'s own menu-driven console wizard from phase 5 was retired in the
+#     interactive-wizard course correction's Phase C.3, in favor of eri_do())
 #   - "next step" epilogues on pipeline functions (phase 6)
 # tests/testthat/test-task-map.R checks every reference/guide/call/next value here is
 # real -- an unverifiable claim in this file is a test failure, not a stale doc.

--- a/man/eri_guide.Rd
+++ b/man/eri_guide.Rd
@@ -2,47 +2,38 @@
 % Please edit documentation in R/guide.R
 \name{eri_guide}
 \alias{eri_guide}
-\title{Find your task and get its call and guide (interactive)}
+\title{Look up a task's call and guide (deprecated; use \code{\link[=eri_do]{eri_do()}} or \code{\link[=eri_task_map]{eri_task_map()}})}
 \usage{
 eri_guide(task_id = NULL)
 }
 \arguments{
-\item{task_id}{\code{chr} or \code{NULL} A task id to jump straight to its detail screen, skipping the
-category/task menus. \code{NULL} (default) starts at the top-level category menu.}
+\item{task_id}{\code{chr} or \code{NULL} A task id to show (see \code{\link[=eri_task_map]{eri_task_map()}}'s \code{id} column, or the
+generated task-index article, for valid ids). \code{NULL} (default) prints the full task list instead.}
 }
 \value{
-Invisibly, \code{NULL}. "Run it now" prints its visibly-returned result the same way typing
-the call at the console would (so e.g. \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}'s connection object is
-shown, not silently discarded), and a failure is caught and reported rather than crashing the
-wizard -- but the result itself is not kept for later use; assign it yourself if you need it
-again (\code{con <- get_azure_storage_connection()}).
+Invisibly, \code{NULL}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-A console wizard over the task registry (\code{\link[=eri_task_map]{eri_task_map()}}'s bundled
-\code{inst/registry/task_map.yaml}): pick a category, pick a task, see its representative call, its
-guide (if any), and the reference functions it touches. A zero-argument task (e.g.
-\code{\link[=eri_data_model]{eri_data_model()}}, \code{\link[=get_azure_storage_connection]{get_azure_storage_connection()}}) can be run right from the menu;
-everything else -- which needs real argument values this wizard has no safe way to fabricate --
-can only be shown, with its guide opened for the full walkthrough.
+\code{eri_guide()} used to be a menu-driven console wizard. It's deprecated in favor of two sharper
+tools: \code{\link[=eri_do]{eri_do()}}, which actually \emph{runs} the CMR/ingest/ODK/onboarding pipelines through a guided
+console flow, and \code{\link[=eri_task_map]{eri_task_map()}} (or the generated task-index article), which browses every
+task's representative call, guide, and reference functions as a static list. \code{eri_guide()} never
+had "run it now" for more than 4 of ~32 tasks -- for anything else it could only describe, which is
+what the vignettes and \code{\link[=eri_task_map]{eri_task_map()}} already do, without a menu to navigate.
 
-The wizard remembers the last category you visited this session and offers to resume there.
-Pass a task id to jump straight to its detail screen instead of navigating the menus (see
-\code{\link[=eri_task_map]{eri_task_map()}}'s \code{id} column, or the generated task-index article, for valid ids).
-
-Prefer the generated \href{../articles/task-index.html}{task-index article} or \code{\link[=eri_task_map]{eri_task_map()}} when
-you don't need the back-and-forth of a menu.
-
-\strong{Interactive only.} In a script, browse \code{\link[=eri_task_map]{eri_task_map()}} or the task-index article instead.
+This function is kept, narrowed, rather than removed outright: pass a \code{task_id} and it still shows
+that task's call, guide, and reference functions (no menu); called with no argument, it prints the
+full \code{\link[=eri_task_map]{eri_task_map()}} listing instead of opening an interactive browser.
 }
 \examples{
 \dontrun{
-eri_guide()
-eri_guide("check_cmr")  # jump straight to a known task
+eri_guide("check_cmr")  # show one task's call/guide/reference, no menu
+eri_guide()             # equivalent to eri_task_map()
 }
 }
 \seealso{
-\code{\link[=eri_task_map]{eri_task_map()}} for the non-interactive console version, \code{\link[=eri_dq_review]{eri_dq_review()}} for the
-same menu-driven wizard pattern applied to DQ triage.
+\code{\link[=eri_do]{eri_do()}} for the guided pipeline wizard that replaced this, \code{\link[=eri_task_map]{eri_task_map()}} for the
+full static listing.
 }

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -15,8 +15,7 @@ time. No function names to memorize, no Azure path to type by hand.
 
 Not sure where to start otherwise? **[What are you trying to do?](articles/task-index.html)** is a
 generated index of ~30 common tasks; pick yours and get the call and the guide. In the console,
-`eri_guide()` walks the same list interactively — pick a category, pick a task, run it if it's safe
-to run with no arguments, or open its guide. Otherwise, read
+`eri_task_map()` prints the same list. Otherwise, read
 **[Getting started](articles/getting-started.html)** first — it's the one idea every guide assumes.
 
 ## Two roles, two paths

--- a/tests/testthat/test-guide.R
+++ b/tests/testthat/test-guide.R
@@ -1,226 +1,25 @@
-#### Tests for eri_guide() and its internal helpers ####
-#
-# scripted() (the interactive-menu mocking helper) lives in helper-scripted.R, shared with
-# test-dq_review.R.
+#### Tests for eri_guide() (deprecated, narrowed to a static lookup -- Phase C.3) ####
 
-test_that("eri_guide refuses to run non-interactively", {
-  expect_error(eri_guide(), "interactive-only")
+test_that("eri_guide() warns deprecation and points at eri_do()/eri_task_map()", {
+  expect_warning(eri_guide("learn_vocabulary"), "eri_do\\(\\)")
 })
 
-test_that(".eri_guide_zero_arg distinguishes zero-argument calls from ones with arguments", {
-  expect_true(.eri_guide_zero_arg("eri_data_model()"))
-  expect_true(.eri_guide_zero_arg("get_azure_storage_connection()"))
-  expect_false(.eri_guide_zero_arg("eri_query(sql)"))
-  expect_false(.eri_guide_zero_arg("eri_stage_cmr(country, period)"))
-})
-
-test_that("every zero-argument call in the real task registry is genuinely runnable with no args", {
-  # Cross-check against the actual bundled registry, not just synthetic examples above --
-  # .eri_guide_zero_arg()'s classification is only useful if it agrees with what's really there.
-  tree <- .eri_task_map()
-  zero_arg_calls <- Filter(
-    .eri_guide_zero_arg,
-    unlist(lapply(tree, function(b) vapply(b$children, function(l) l$call, character(1))))
-  )
-  expect_true(length(zero_arg_calls) > 0L)
-  expect_true(all(grepl("^\\w+\\(\\)$", zero_arg_calls)))
-})
-
-test_that("eri_guide exits cleanly from the top-level menu with no navigation", {
-  withr::local_options(rlang_interactive = TRUE)
-  local_mocked_bindings(
-    .eri_prompt_menu = scripted(list(0L)),  # ESC/cancel at the category menu
-    .package = "erifunctions"
-  )
-  expect_invisible(eri_guide())
-})
-
-test_that("eri_guide can navigate into a category, back out, and exit", {
-  withr::local_options(rlang_interactive = TRUE)
-  local_mocked_bindings(
-    .eri_prompt_menu = scripted(list(
-      1L,  # pick the first category
-      0L,  # back out of the leaf menu
-      0L   # exit the category menu
-    )),
-    .package = "erifunctions"
-  )
-  expect_invisible(eri_guide())
-})
-
-test_that("eri_guide's task screen runs a zero-argument task when selected", {
-  withr::local_options(rlang_interactive = TRUE)
-  ran <- FALSE
-  local_mocked_bindings(eri_data_model = function() { ran <<- TRUE }, .package = "erifunctions")
-
-  tree <- .eri_task_map()
-  # learn_vocabulary (get_set_up branch) calls eri_data_model() with no args.
-  leaf <- tree[[1]]$children[[which(vapply(tree[[1]]$children, function(l) l$id, character(1)) == "learn_vocabulary")]]
-  expect_true(.eri_guide_zero_arg(leaf$call))
-
-  local_mocked_bindings(
-    .eri_prompt_menu = scripted(list(1L, 0L)),  # "Run it now", then "Back"
-    .package = "erifunctions"
-  )
-  expect_invisible(.eri_guide_show_task(leaf))
-  expect_true(ran)
-})
-
-test_that("eri_guide's task screen opens the guide when selected, without erroring", {
-  withr::local_options(rlang_interactive = TRUE)
-  opened <- NULL
-  local_mocked_bindings(
-    vignette = function(topic, package) { opened <<- topic; NULL },
-    .package = "utils"
-  )
-
-  leaf <- list(id = "x", title = "Test task", call = "eri_query(sql)", guide = "da-adhoc-guide", reference = "eri_query")
-  local_mocked_bindings(
-    .eri_prompt_menu = scripted(list(1L, 0L)),  # "Open the guide" (no "Run it now" -- not zero-arg), then "Back"
-    .package = "erifunctions"
-  )
-  expect_invisible(.eri_guide_show_task(leaf))
-  expect_equal(opened, "da-adhoc-guide")
-})
-
-test_that("eri_guide's task screen never offers 'Run it now' for a call with arguments, nor 'Open the guide' with no guide", {
-  withr::local_options(rlang_interactive = TRUE)
-  leaf <- list(id = "x", title = "Test task", call = "eri_query(sql)", guide = NULL, reference = "eri_query")
-  local_mocked_bindings(
-    .eri_prompt_menu = function(title, choices) {
-      expect_false("Run it now" %in% choices)
-      expect_false("Open the guide" %in% choices)
-      0L
-    },
-    .package = "erifunctions"
-  )
-  expect_invisible(.eri_guide_show_task(leaf))
-})
-
-test_that("eri_guide's task screen shows the visible result of a successful zero-argument run", {
-  withr::local_options(rlang_interactive = TRUE)
-  local_mocked_bindings(get_azure_storage_connection = function() "a connection object", .package = "erifunctions")
-
-  leaf <- list(id = "x", title = "Test task", call = "get_azure_storage_connection()", guide = NULL, reference = "get_azure_storage_connection")
-  local_mocked_bindings(
-    .eri_prompt_menu = scripted(list(1L, 0L)),  # "Run it now", then "Back"
-    .package = "erifunctions"
-  )
-  expect_output(.eri_guide_show_task(leaf), "a connection object")
-})
-
-test_that("eri_guide's task screen catches a failing zero-argument run instead of crashing", {
-  withr::local_options(rlang_interactive = TRUE)
-  local_mocked_bindings(
-    get_azure_storage_connection = function() stop("auth cancelled"),
-    .package = "erifunctions"
-  )
-
-  leaf <- list(id = "x", title = "Test task", call = "get_azure_storage_connection()", guide = NULL, reference = "get_azure_storage_connection")
-  local_mocked_bindings(
-    .eri_prompt_menu = scripted(list(1L, 0L)),  # "Run it now", then "Back"
-    .package = "erifunctions"
-  )
-  expect_no_error(.eri_guide_show_task(leaf))
-})
-
-#### Phase 7: deep links (eri_guide(task_id=)) ####
-
-test_that("eri_guide(task_id=) jumps straight to a task's detail screen", {
-  withr::local_options(rlang_interactive = TRUE)
-  shown <- NULL
-  local_mocked_bindings(
-    .eri_guide_show_task = function(leaf) { shown <<- leaf$id; invisible(NULL) },
-    .package = "erifunctions"
-  )
-  expect_invisible(eri_guide("learn_vocabulary"))
-  expect_equal(shown, "learn_vocabulary")
+test_that("eri_guide(task_id=) shows that task's call/guide/reference and nothing else", {
+  suppressWarnings({
+    expect_message(eri_guide("learn_vocabulary"), "Run:")
+  })
 })
 
 test_that("eri_guide(task_id=) errors clearly for an unknown id", {
-  withr::local_options(rlang_interactive = TRUE)
-  expect_error(eri_guide("not_a_real_task_id"), "No task with id")
+  suppressWarnings(expect_error(eri_guide("not_a_real_task_id"), "No task with id"))
 })
 
-#### Phase 7: session memory (resume the last-visited category) ####
-
-test_that(".eri_guide_resolve_branch_choice handles exit/cancel, resume, and plain selection", {
-  tree   <- list(list(id = "a"), list(id = "b"), list(id = "c"))
-  resume <- list(id = "b")
-
-  # No resume option present: choices are c(a, b, c, "Exit").
-  expect_null(.eri_guide_resolve_branch_choice(0L, tree, NULL))
-  expect_null(.eri_guide_resolve_branch_choice(4L, tree, NULL))
-  expect_equal(.eri_guide_resolve_branch_choice(1L, tree, NULL)$id, "a")
-  expect_equal(.eri_guide_resolve_branch_choice(3L, tree, NULL)$id, "c")
-
-  # Resume option present: choices are c("Continue in b", a, b, c, "Exit") -- every real branch
-  # index shifts by one.
-  expect_null(.eri_guide_resolve_branch_choice(0L, tree, resume))
-  expect_null(.eri_guide_resolve_branch_choice(5L, tree, resume))
-  expect_equal(.eri_guide_resolve_branch_choice(1L, tree, resume)$id, "b")
-  expect_equal(.eri_guide_resolve_branch_choice(2L, tree, resume)$id, "a")
-  expect_equal(.eri_guide_resolve_branch_choice(4L, tree, resume)$id, "c")
-})
-
-test_that("eri_guide offers to resume the last-visited category after visiting one", {
-  withr::local_options(rlang_interactive = TRUE, erifunctions.guide_last_branch = NULL)
-  tree <- .eri_task_map()
-  first_branch_title <- tree[[1]]$title
-
-  # First invocation: navigate into the first category, back out, exit -- no resume option should
-  # be offered on the VERY FIRST top-menu display (nothing visited this session yet). A resume
-  # option legitimately appears on the SECOND top-menu display within this same call (after
-  # backing out of the leaf menu), since picking the category already recorded it as
-  # last-visited -- so this only checks the first display, not every one.
-  seen_top_menu  <- 0L
-  next_response  <- scripted(list(1L, 0L, 0L))
+test_that("eri_guide() with no argument falls through to eri_task_map()'s static listing", {
+  ran <- FALSE
   local_mocked_bindings(
-    .eri_prompt_menu = function(title, choices) {
-      if (identical(title, "What are you trying to do?")) {
-        seen_top_menu <<- seen_top_menu + 1L
-        if (seen_top_menu == 1L) expect_false(any(grepl("^Continue in", choices)))
-      }
-      next_response()
-    },
+    eri_task_map = function() { ran <<- TRUE; invisible(NULL) },
     .package = "erifunctions"
   )
-  eri_guide()
-
-  # Second invocation: the top menu should now offer to resume that category first.
-  local_mocked_bindings(
-    .eri_prompt_menu = function(title, choices) {
-      expect_match(choices[[1]], sprintf('Continue in "%s"', first_branch_title), fixed = TRUE)
-      0L
-    },
-    .package = "erifunctions"
-  )
-  eri_guide()
-})
-
-test_that("picking the resume option lands directly in the remembered category", {
-  withr::local_options(rlang_interactive = TRUE, erifunctions.guide_last_branch = NULL)
-  tree <- .eri_task_map()
-
-  local_mocked_bindings(.eri_prompt_menu = scripted(list(1L, 0L, 0L)), .package = "erifunctions")
-  eri_guide()  # records tree[[1]]$id as the last-visited branch
-
-  leaf_menu_title   <- NULL
-  visited_leaf_menu <- FALSE
-  local_mocked_bindings(
-    .eri_prompt_menu = function(title, choices) {
-      if (identical(title, "What are you trying to do?")) {
-        # "Continue in ..." the first time; once we've already seen the leaf menu, exit --
-        # otherwise this would pick "Continue" forever, since backing out of the leaf menu only
-        # returns to THIS top-level menu, not out of eri_guide()'s own loop.
-        return(if (!visited_leaf_menu) 1L else 0L)
-      }
-      leaf_menu_title   <<- title
-      visited_leaf_menu <<- TRUE
-      0L  # back out of the leaf menu
-    },
-    .package = "erifunctions"
-  )
-  eri_guide()
-  expect_equal(leaf_menu_title, tree[[1]]$title)
+  suppressWarnings(expect_invisible(eri_guide()))
+  expect_true(ran)
 })

--- a/vignettes/da-cheatsheet.Rmd
+++ b/vignettes/da-cheatsheet.Rmd
@@ -39,22 +39,10 @@ data/ {country} / {disease} / {data_source} / {data_type} / {layer} / file
 
 ## Which pipeline do I use?
 
-```
-What did you receive?
-│
-├─ A monthly country CMR Excel (eth/nga/sdn/ssd/uga/tcd/mad)
-│     → eri_stage_cmr() → eri_split_cmr() → eri_approve(..., "programmatic", <measure>)
-│
-├─ A malaria surveillance extract (line-list or aggregate, e.g. dr/ht)
-│     → eri_ingest()                      [registered countries: one call, dual-writes]
-│       or the primitives below           [sandbox / new space]
-│
-├─ ODK survey submissions
-│     → eri_odk_register() → eri_odk_sync() → (clean) → eri_approve(..., "research", ...)
-│
-└─ A brand-new country / disease / data-type space (nothing exists yet)
-      → eri_onboard_country() / eri_onboard_disease() / eri_onboard_cmr()  (do this FIRST)
-```
+**Run [`eri_do()`](../reference/eri_do.html)** and pick from its menu (CMR / surveillance ingest /
+ODK / onboard a new space / review something staged) -- it picks the right functions and calls them
+for you, in order, so you don't have to hold this decision tree in your head. The table below is for
+when you're scripting the steps yourself, not deciding which pipeline to reach for.
 
 **The general primitive pipeline** (works on any data, incl. the practice sandbox):
 

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -19,6 +19,11 @@ knitr::opts_chunk$set(
 **Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
+> **This is the screen [`eri_do()`](../reference/eri_do.html) already puts you on.** Its CMR flow
+> (and the "Review & approve something already staged" menu item) hands off directly into this same
+> `eri_dq_review()` loop -- so if you're triaging flags inside `eri_do()` right now, this guide is
+> the reference for what each menu option (fix in source, mark noted, force-approve) actually does.
+
 The [CMR guide](da-cmr-guide.html) and the [QC/feedback guide](da-qc-feedback-guide.html) both walk
 the DQ pipeline as a **sequence of functions you call yourself**: check, resolve each flag, close out
 the entry, re-run, approve. That's the scriptable core, and it has to exist for automation. But you

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -19,6 +19,12 @@ knitr::opts_chunk$set(
 **Walkthrough** &middot; ~20 min &middot; needs: Azure &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (runs on `atlantis`)
 :::
 
+> **This is what [`eri_do()`](../reference/eri_do.html) points you at.** When its surveillance-ingest
+> or ODK flow finds open log entries, it stops and tells you to run `eri_logs()` /
+> `eri_dq_flag_resolve()` / `eri_logs_resolve()` -- the exact tools this guide walks through -- rather
+> than triaging the backlog for you (unlike CMR, whose per-sheet flags have their own guided loop,
+> see the [DQ review guide](da-dq-review-guide.html)).
+
 Every operation `erifunctions` runs, an ingest, an approval, an ODK sync, **leaves a log** in
 Azure. When something fails, or a data-quality check raises issues, that log is the record. This guide
 is for a **Data Analyst** working the **backlog**: finding what failed or needs review with

--- a/vignettes/onboarding.Rmd
+++ b/vignettes/onboarding.Rmd
@@ -58,16 +58,24 @@ Get the environment standing so day one is learning, not yak-shaving. Use the
 
 ## Days 2–4, The ingestion spine (do it live)
 
-Work these guides in order, on the sandbox, running every chunk. Stop at each checkpoint.
+Run [`eri_do()`](../reference/eri_do.html) on the sandbox for each of these; it's a guided console
+wizard, pick your country, pick the file (or ODK project/form), confirm the period, no function
+names to memorize. Stop at each checkpoint, then read the matching guide for what happened
+underneath, or for scripting the steps yourself.
 
 - [ ] [Connections guide](connections-guide.html), connect to all four services.
-- [ ] [Onboard a space](da-onboard-guide.html), stand up a new `atlantis` space (schema + dirs).
+- [ ] `eri_do()` → "Onboard a new country, disease, or data type" → stand up a new `atlantis` space.
+      Then read the [onboarding guide](da-onboard-guide.html) and fill in the schema's TODOs.
       *Checkpoint: you scaffolded a space and validated its schema.*
-- [ ] [Ingest a surveillance dataset](da-ingest-guide.html), raw → DQ → staged → **approve**.
+- [ ] `eri_do()` → "Bring in a surveillance dataset" → raw → DQ → staged → **approve**.
+      See the [ingest guide](da-ingest-guide.html) for what's happening underneath.
       *Checkpoint: you approved a dataset and saw it in the catalog.*
-- [ ] [Upload & split a CMR](da-cmr-guide.html), upload → split → approve a monthly CMR.
+- [ ] `eri_do()` → "Bring this month's country report (CMR) into the system" → upload → split → approve.
+      See the [CMR guide](da-cmr-guide.html) for what's happening underneath.
       *Checkpoint: you split a CMR per disease.*
-- [ ] [Work with ODK Central](da-odk-guide.html), connect → monitor → register → sync → approve.
+- [ ] `eri_do()` → "Pull in ODK survey submissions" → connect → register → sync. Then read the
+      [ODK guide](da-odk-guide.html) for monitoring a survey and managing app users, which the
+      wizard doesn't cover.
       *Checkpoint: you synced submissions into the pipeline.*
 - [ ] [Triage the log backlog](da-logs-guide.html), triage and resolve a log.
       *Checkpoint: you closed an item in the backlog.*
@@ -86,9 +94,9 @@ Work these guides in order, on the sandbox, running every chunk. Stop at each ch
 
 ✅ **Gate:** you completed one real task under supervision and opened one PR.
 
-## Competency checklist (DA + mentor sign off)
+## Competency checklist
 
-A DA is "onboarded" when both of you can tick every box from observed work, not a quiz:
+A DA is "onboarded" when every box below reflects observed work, not a quiz:
 
 - [ ] Connects to Azure + ODK; knows where secrets live and why.
 - [ ] Reads a dataset's five axes and picks the right `data_source` / `data_type`.

--- a/vignettes/orientation.Rmd
+++ b/vignettes/orientation.Rmd
@@ -59,19 +59,16 @@ it warns, it doesn't error. The [data-model card](data-model-card.html) is the d
 
 ## Which pipeline for which data?
 
-| You received… | Pipeline |
-|---------------|----------|
-| Monthly CMR Excel | `eri_stage_cmr` → `eri_split_cmr` → `eri_approve` |
-| Surveillance extract | `eri_ingest` (or the primitives) → `eri_approve` |
-| ODK submissions | `eri_odk_register` → `eri_odk_sync` → clean → `eri_approve` |
-| A brand-new space | `eri_onboard_*` first, then one of the above |
-
-Everything ends at **`eri_approve()`** and the catalog. The [cheat sheet](da-cheatsheet.html) has the
-full decision tree.
+**Run [`eri_do()`](../reference/eri_do.html)**: a guided console wizard that picks the right
+functions for a CMR report, a surveillance extract, ODK submissions, or standing up a brand-new
+space, and calls them for you. Everything still ends at **`eri_approve()`** and the catalog.
 
 ## Your tasks → where they live
 
-- **Load CMR / surveillance** → [CMR guide](da-cmr-guide.html) · [ingest guide](da-ingest-guide.html)
+- **Bring in CMR / surveillance / ODK data, or stand up a new space** → run
+  [`eri_do()`](../reference/eri_do.html); the [CMR](da-cmr-guide.html), [ingest](da-ingest-guide.html),
+  and [ODK](da-odk-guide.html) guides are for understanding what it does underneath, or scripting it
+  yourself.
 - **Process OEPA** → the general pipeline (oncho treatment + prevalence)
 - **QC + analytic products + country feedback** → `run_dq_checks` · `dq_report` · `eri_notify_dq`
 - **Figures / routine reports** → `eri_table` · `eri_map_*` · `eri_pptx_*` · `eri_report_*`


### PR DESCRIPTION
## Summary
- **Deprecates `eri_guide()`** rather than deleting it outright: narrowed to a static lookup (`eri_guide(task_id)` still shows one task's call/guide/reference with no menu; a no-argument call now falls through to `eri_task_map()`'s full listing). The menu-driven interactive wizard (`.eri_guide_show_task()`, session memory, "run it now") is deleted -- it could only ever run 4 of ~32 tasks, everything else it could just describe, which the vignettes and `eri_task_map()` already do.
- **Re-audited the design consult's doc-cutting plan against what's actually shipped** (Phases A/B/C.1/C.2) rather than executing its pre-shipment estimate blindly. Found the consult's assumption -- 7 DA pipeline guides are walkthroughs `eri_do()` fully replaces, fold into ~11 total vignettes -- doesn't hold: each pipeline guide already got a "prefer to just do it? run `eri_do()`" callout as its own phase shipped; `da-odk-guide`/`da-onboard-guide` cover real ground the wizard doesn't automate (survey monitoring, app-user management, schema authoring); `da-dq-review-guide`/`da-logs-guide` document the *exact* interactive loop/tools the wizard hands off into or points at, not competing content; `da-qc-feedback-guide` has no wizard overlap at all. The real, narrow redundancy: two quick-reference pages (`da-cheatsheet.Rmd`, `orientation.Rmd`) whose "which pipeline?" decision trees purely duplicated `eri_do()`'s menu -- trimmed those to a one-line pointer, kept everything else in them. Added the missing wizard-context callouts to `da-dq-review-guide`/`da-logs-guide`.
- **Net: zero vignettes deleted** (still 25) -- forcing a cut to hit the consult's stale ~11 estimate would have been solving to a guessed number instead of genuine overlap.
- `onboarding.Rmd`: ingestion-spine days now point at `eri_do()` as the primary path (guides reframed as "what's happening underneath"); also drops the "Competency checklist (DA + mentor sign off)" heading's mentor-sign-off framing -- a standalone DA-rules complaint raised earlier this session, addressed now since the file was already being revised.
- `pkgdown/index.md`/`README.md`'s `eri_guide()` mentions reworded to `eri_task_map()`.

## Test plan
- [x] `tests/testthat/test-guide.R` rewritten (4 tests) for the deprecated-lookup shim: deprecation warning fires, `task_id` lookup shows call/guide/reference, unknown id errors, no-argument falls through to `eri_task_map()`.
- [x] Full suite: `devtools::test()` -- 0 failures, 2867 pass (pre-existing unrelated warnings only).
- [x] `devtools::document()` regenerated `man/eri_guide.Rd` clean.
- [x] Manually verified no unbalanced `:::` pandoc div blocks introduced in any edited vignette (local `knitr`/`pkgdown` builds segfault in this environment right now, unrelated to these changes -- reproduced the same segfault on an untouched vignette; relying on CI's pkgdown build, which has been reliable across every prior wizard PR this session).