### PR TITLE
docs(wizard): add a dedicated guide for eri_do() itself (0.9.33)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.32
+Version: 0.9.33
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# erifunctions 0.9.33
+
+## New guide: a tour of `eri_do()` itself
+
+- **`vignettes/da-do-guide.Rmd`**: the interactive-wizard course correction (Phases A-C.3) built four
+  flows into `eri_do()` incrementally, each getting a "prefer to just do it?" callout in its own
+  pipeline guide, but nothing ever documented the wizard's own menu as a whole. This new guide is
+  that missing piece: the top-level menu, then each of the five paths (CMR, surveillance ingest,
+  ODK, onboarding, and the DQ-review shortcut) with its actual prompts and decision points, verified
+  directly against `R/wizard.R`'s source (every menu title, confirmation prompt, and message string
+  checked against the real code, the same accuracy discipline the guide-authoring recipe calls for).
+  It deliberately stays a *tour*, not a redo of the domain-knowledge walkthroughs, each section
+  points at its pipeline's own guide (CMR, ingest, ODK, onboarding, DQ review) for the real captured
+  output and field-level detail this one skips.
+- `eri_do()` is interactive-only and refuses to run from a script, so none of this guide's
+  transcripts could be executed inside the document the way an ordinary function call could; every
+  one is illustrated rather than live-captured, the same honest convention `da-cmr-guide.Rmd` and
+  `da-odk-guide.Rmd` already use for their own non-sandbox-safe steps, and stated as such up front.
+- Cross-linked from `_pkgdown.yml` (new "Quick reference & onboarding" entry), `docs/guides.md`,
+  `getting-started.Rmd`, and every existing pipeline guide's own `eri_do()` callout
+  (`da-cmr-guide`, `da-ingest-guide`, `da-odk-guide`, `da-onboard-guide`, `da-dq-review-guide`,
+  `da-logs-guide`, `da-cheatsheet`, `orientation`).
+
 # erifunctions 0.9.32
 
 ## `eri_guide()` retired to a static lookup; doc cut turned out much smaller than planned (Phase C.3 of the interactive-wizard course correction)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.32 · **Status:** Active development
+**Version:** 0.9.33 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -59,11 +59,12 @@ articles:
 - title: Quick reference & onboarding
   navbar: Quick reference
   desc: >
-    Desk references and the new-analyst path: what are you trying to do, the big-picture
-    orientation, the paced onboarding track, the one-page cheat sheet, the channel-vs-measure
-    data-model card, and the troubleshooting card.
+    Desk references and the new-analyst path: what are you trying to do, a tour of the eri_do()
+    wizard, the big-picture orientation, the paced onboarding track, the one-page cheat sheet, the
+    channel-vs-measure data-model card, and the troubleshooting card.
   contents:
   - task-index
+  - da-do-guide
   - orientation
   - onboarding
   - da-cheatsheet

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -18,6 +18,8 @@ This page is the **menu and the backlog**: what exists today, and what is still 
 
 **New Data Analysts:** follow the paced **[onboarding path](https://thecartercenter.github.io/erifunctions/articles/onboarding.html)**
 (Week 0 → Week 2), and keep the quick-reference articles open, the
+**[eri_do() tour](https://thecartercenter.github.io/erifunctions/articles/da-do-guide.html)** (the
+guided console wizard that runs the pipelines below for you),
 [orientation](https://thecartercenter.github.io/erifunctions/articles/orientation.html),
 [DA cheat sheet](https://thecartercenter.github.io/erifunctions/articles/da-cheatsheet.html),
 [data-model card](https://thecartercenter.github.io/erifunctions/articles/data-model-card.html), and
@@ -53,6 +55,7 @@ Grouped the same way as the [documentation site's Articles menu](https://thecart
 
 | Task | Guide | Status |
 |------|-------|--------|
+| A tour of the eri_do() console wizard (menu by menu) | [`da-do-guide`](https://thecartercenter.github.io/erifunctions/articles/da-do-guide.html) | ✅ Shipped |
 | The big picture (data system, pipeline, where tasks live) | [`orientation`](https://thecartercenter.github.io/erifunctions/articles/orientation.html) | ✅ Shipped |
 | Paced new-analyst path (Week 0 → Week 2 + competency checklist) | [`onboarding`](https://thecartercenter.github.io/erifunctions/articles/onboarding.html) | ✅ Shipped |
 | One-page cheat sheet (functions, path, "which pipeline?") | [`da-cheatsheet`](https://thecartercenter.github.io/erifunctions/articles/da-cheatsheet.html) | ✅ Shipped |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -524,6 +524,19 @@ now point at `eri_do()` as the primary path; its "Competency checklist" heading 
 addressed here since the file was already being revised). **Phase D (progress-detection polish,
 `eri_do("cmr")` deep links) remains designed in the consult document but not yet started.**
 
+**Follow-up, same session: `vignettes/da-do-guide.Rmd` shipped as v0.9.33.** A gap noticed only
+after Phase C.3 closed the loop: each of the four flows got its own "prefer to just do it? run
+`eri_do()`" callout in its pipeline guide as it shipped, but nothing ever documented the wizard's
+own menu as a whole, a tour of `eri_do()` itself, the way `eri_dq_review()` has
+`da-dq-review-guide.Rmd`. New guide walks the top-level menu and all five paths (CMR, ingest, ODK,
+onboarding, DQ-review shortcut) with their real prompts, verified directly against `R/wizard.R`'s
+source since `eri_do()` is interactive-only and none of it could be executed inside the document
+(illustrated, not live-captured, the same honest convention `da-cmr-guide.Rmd`/`da-odk-guide.Rmd`
+already use). Deliberately stays a tour, not a redo of the domain-knowledge walkthroughs — each
+section points at its pipeline's own guide for real captured output and depth. Cross-linked from
+`_pkgdown.yml`, `docs/guides.md`, `getting-started.Rmd`, and every existing pipeline guide's own
+`eri_do()` callout.
+
 ---
 
 ## Phase 4: ODK live pilot (Uganda survey)

--- a/vignettes/da-cheatsheet.Rmd
+++ b/vignettes/da-cheatsheet.Rmd
@@ -41,8 +41,9 @@ data/ {country} / {disease} / {data_source} / {data_type} / {layer} / file
 
 **Run [`eri_do()`](../reference/eri_do.html)** and pick from its menu (CMR / surveillance ingest /
 ODK / onboard a new space / review something staged) -- it picks the right functions and calls them
-for you, in order, so you don't have to hold this decision tree in your head. The table below is for
-when you're scripting the steps yourself, not deciding which pipeline to reach for.
+for you, in order, so you don't have to hold this decision tree in your head (see the
+[eri_do() tour](da-do-guide.html)). The table below is for when you're scripting the steps
+yourself, not deciding which pipeline to reach for.
 
 **The general primitive pipeline** (works on any data, incl. the practice sandbox):
 

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -22,7 +22,8 @@ knitr::opts_chunk$set(
 > **Prefer to just do it?** Run [`eri_do()`](../reference/eri_do.html) in the console and pick
 > "bring this month's country report in" — it walks the whole upload → stage → split → review →
 > approve pipeline below through a few prompts (which country, which file, confirm the month), no
-> function names to memorize and no Azure path to type by hand. This guide is for understanding
+> function names to memorize and no Azure path to type by hand. See the
+> [eri_do() tour](da-do-guide.html) for what its menu looks like. This guide is for understanding
 > what's happening underneath, or for scripting the steps yourself.
 
 Every month, country programmes file a **Case Management Report (CMR)**, a filled Excel template of

--- a/vignettes/da-do-guide.Rmd
+++ b/vignettes/da-do-guide.Rmd
@@ -75,9 +75,10 @@ eri_do()
 
 ## The top-level menu {#top-menu}
 
-Every prompt in the wizard is a numbered menu, type the number and press Enter, or **`0` to go
-back or cancel** at any point, nothing is written until you reach a final "Go ahead?" confirmation.
-The top menu is five real tasks plus a shortcut into DQ review:
+Most prompts in the wizard are numbered menus, type the number and press Enter, `0` goes back or
+cancels; a few (a country name, a period) are typed instead, blank cancels there. Either way,
+nothing is written until you reach a final "Go ahead?" confirmation, see [Cancelling out](#cancelling)
+for the full convention. The top menu is five real tasks plus a shortcut into DQ review:
 
 ```
 ── What are you trying to do?
@@ -135,9 +136,9 @@ If a period wasn't detected, or you say no, it asks directly (`Reporting period,
 ```
 ── Ready to bring this in
 
-* Country: UGA
-* Month:   202406
-* File:    uga_cmr_2024_06.xlsx
+• Country: UGA
+• Month: 202406
+• File: uga_cmr_2024_06.xlsx
 ℹ I'll upload it, stage it, and split it into per-disease measures. Then we'll review data quality.
 
 ── Go ahead?
@@ -214,10 +215,10 @@ Which country is this data for? (e.g. sdn; blank to cancel): atlantis
 ```
 ── Ready to bring this in
 
-* Country: ATLANTIS
-* Disease: malaria
-* Channel: surveillance / Measure: case
-* File:    atlantis_malaria_2024-01.csv
+• Country: ATLANTIS
+• Disease: malaria
+• Channel: surveillance / Measure: case
+• File: atlantis_malaria_2024-01.csv
 ℹ I'll archive it, check data quality, and stage it for approval.
 
 ── Go ahead?
@@ -234,7 +235,7 @@ shape):
 
 ```
 ! 1 log entry need review before this can be approved.
-ℹ Run eri_logs() to see them, eri_dq_flag_resolve() to triage each flag, then eri_logs_resolve() to close the entry out.
+ℹ Run `eri_logs()` to see them, `eri_dq_flag_resolve()` to triage each flag, then `eri_logs_resolve()` to close the entry out.
 
 ── Approve anyway? (only if you've already reviewed this)
 
@@ -246,7 +247,7 @@ Say no (the safer default unless you've genuinely already reviewed it), and it l
 staged rather than approving:
 
 ```
-ℹ Left staged -- run eri_do() again once you've triaged the flags.
+ℹ Left staged -- run `eri_do()` again once you've triaged the flags.
 ```
 
 Otherwise, it asks for the period (free text matched against the staged filename, no fixed
@@ -287,6 +288,20 @@ then registers:
 ```
 
 ```
+── Which country?
+
+1: DR
+2: HT
+3: ETH
+4: NGA
+5: SDN
+6: SSD
+7: UGA
+8: MAD
+9: TCD
+```
+
+```
 ── Register this form as uga/oncho?
 
 1: Yes
@@ -303,7 +318,7 @@ then registers:
 ```
 ✔ Done. Submissions are synced to research/raw/.
 ℹ Next: quality-check and stage this the same way as a surveillance extract -- see the surveillance ingest guide -- then eri_approve() it in.
-ℹ Run eri_do() again any time to sync new submissions.
+ℹ Run `eri_do()` again any time to sync new submissions.
 ```
 
 This is where the wizard **honestly stops**: there is no single stage-then-approve function for
@@ -346,10 +361,11 @@ Full country name (e.g. Uganda; blank to cancel): Atlantis
 2: French
 ```
 
-Every path previews with a dry run before writing anything, then confirms:
+Every path previews with a dry run before writing anything, then confirms (surveillance and CMR
+each have their own confirm wording; CMR's is shown):
 
 ```
-── Write this schema template and create the Azure folders?
+── Write this CMR schema template and create the Azure folders?
 
 1: Yes
 2: No

--- a/vignettes/da-do-guide.Rmd
+++ b/vignettes/da-do-guide.Rmd
@@ -1,0 +1,426 @@
+---
+title: "eri_do(): a tour of the guided console wizard (for data analysts)"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{eri_do(): a tour of the guided console wizard (for data analysts)}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment  = "#>",
+  eval     = FALSE
+)
+```
+
+::: {.eri-guide-meta}
+**Desk reference** &middot; ~15 min &middot; needs: n/a to read, Azure/ODK to actually run &middot; sandbox-safe: [yes]{.eri-sandbox-yes} (illustrated on `atlantis`)
+:::
+
+`eri_do()` is the guided console wizard: run it, pick what you're doing from a menu, and answer a
+few prompts, names you already know, files you already have, yes/no decisions, never a function
+name or an Azure path. This is a **tour of the wizard itself**: what its menu looks like, what each
+of its five paths asks you, and where they hand off. It is not a substitute for the role guides,
+each pipeline still has its own guide for the domain knowledge (field codes, schema authoring, ODK
+app-user management) and real captured output that a short tour like this doesn't cover.
+
+> **A note on the transcripts below.** `eri_do()` is interactive-only, it refuses to run from a
+> script, so none of it can execute inside this document the way an ordinary function call could.
+> Every menu prompt and message shown here is verified directly against `eri_do()`'s own source
+> (`R/wizard.R`), not run live, the same honest convention the [CMR guide](da-cmr-guide.html) and
+> [ODK guide](da-odk-guide.html) already use for their non-sandbox-safe steps.
+
+## Why this exists
+
+Earlier, bringing in a monthly report meant memorizing an ordered sequence of function calls and
+hand-constructing an Azure path, more to learn than the actual job, which analysts already did by
+hand for years. `eri_do()` is the fix: **one guided front door**, decisions instead of syntax. It
+never reimplements pipeline logic, every step is one already-tested function
+([`eri_upload()`](../reference/eri_upload.html), [`eri_ingest()`](../reference/eri_ingest.html),
+[`eri_odk_sync()`](../reference/eri_odk_sync.html), [`eri_onboard_country()`](../reference/eri_onboard_country.html),
+and friends), so it is never the *only* way in. Every one of those functions stays fully usable
+directly, in a script, in CI, or from the console yourself.
+
+```{=html}
+<div class="mermaid">
+flowchart TD
+    A["eri_do()"] --> B{"What are you trying to do?"}
+    B --> C["Bring in this month's CMR"]
+    B --> D["Bring in a surveillance dataset"]
+    B --> E["Pull in ODK submissions"]
+    B --> F["Onboard a new space"]
+    B --> G["Review something already staged"]
+    C --> H["upload -> stage -> split -> DQ review -> approve"]
+    D --> I["archive + DQ + stage (one call) -> approve"]
+    E --> J["connect -> register -> sync -> research/raw/"]
+    F --> K["dry-run preview -> confirm -> write schema + folders"]
+    G --> L["hands off into eri_dq_review()"]
+</div>
+```
+
+## Before you start {#before-you-start}
+
+```{r library}
+library(erifunctions)
+```
+
+Just run it from a live R console or RStudio, `eri_do()` refuses to run from `Rscript` or CI (see
+[Troubleshooting](troubleshooting.html) if you hit that error unexpectedly):
+
+```{r launch}
+eri_do()
+```
+
+## The top-level menu {#top-menu}
+
+Every prompt in the wizard is a numbered menu, type the number and press Enter, or **`0` to go
+back or cancel** at any point, nothing is written until you reach a final "Go ahead?" confirmation.
+The top menu is five real tasks plus a shortcut into DQ review:
+
+```
+── What are you trying to do?
+
+1: Bring this month's country report (CMR) into the system
+2: Bring in a surveillance dataset (a CSV/Excel line-list)
+3: Pull in ODK survey submissions
+4: Onboard a new country, disease, or data type
+5: Review & approve something already staged (DQ review)
+6: Exit
+```
+
+Pick a number, or `6` (or `0`) to leave the wizard entirely. The rest of this guide walks each
+path.
+
+## 1. Bring this month's country report (CMR) {#cmr}
+
+```
+── Bring this month's country report into the system ────────────────────────────
+```
+
+Picks up right where a country's monthly Excel report needs to go: which country (a pick-list of
+every registered RB-expansion country, never typed), which file (your OS's native file picker),
+then it reads the filename for the reporting month and asks you to confirm rather than typing it:
+
+```
+── Which country filed the report?
+
+1: ETH
+2: NGA
+3: SDN
+4: SSD
+5: UGA
+6: MAD
+7: TCD
+```
+
+```
+ℹ Where is the filled Excel on your computer?
+```
+
+An OS file dialog opens next (RStudio's own picker, or the plain OS one). No dialog available
+(e.g. a headless session)? It falls back to a typed path instead.
+
+```
+── I read the period as 202406 from the file. Is that the reporting month?
+
+1: Yes
+2: No
+```
+
+If a period wasn't detected, or you say no, it asks directly (`Reporting period, as YYYYMM (e.g.
+202406; blank to cancel)`). Then a summary and one confirmation before anything is written:
+
+```
+── Ready to bring this in
+
+* Country: UGA
+* Month:   202406
+* File:    uga_cmr_2024_06.xlsx
+ℹ I'll upload it, stage it, and split it into per-disease measures. Then we'll review data quality.
+
+── Go ahead?
+
+1: Yes
+2: No
+```
+
+Say yes, and it uploads, stages, and splits the workbook per disease/measure, all in one run,
+auto-detecting whether this country's data also needs mirroring to the legacy pipeline (never
+asked, see [`eri_cutover_status()`](../reference/eri_cutover_status.html)). Then it hands off
+directly into the same DQ review screen [§5's shortcut](#dq-shortcut) uses, work through any flags,
+and it approves for you once everything is clean. If UGA/202406 was already split in an earlier
+session, it offers to skip straight to reviewing it instead of starting over.
+
+**The [CMR guide](da-cmr-guide.html)** has the domain knowledge this tour skips: what the field-code
+row looks like, why `rblf`/`cmr` is a transitional staging code (not the canonical per-disease
+home), and the force-approve escape hatch for a flag that will never resolve cleanly.
+
+## 2. Bring in a surveillance dataset {#ingest}
+
+```
+── Bring in a surveillance dataset ───────────────────────────────────────────────
+```
+
+Unlike CMR, ingest isn't locked to a registered country list, so country is a typed, validated
+code (`sdn`, or the `atlantis` sandbox) rather than a pick-list. Disease, channel (`data_source`),
+and measure (`data_type`) are each a pick-list with a typed "Other" escape hatch, since new
+combinations are a normal, expected gap, not an error:
+
+```
+Which country is this data for? (e.g. sdn; blank to cancel): atlantis
+```
+
+```
+── Which disease?
+
+1: malaria
+2: oncho
+3: lf
+4: sch
+5: sth
+6: Other (type it)
+```
+
+```
+── How did this data arrive?
+
+1: surveillance
+2: programmatic
+3: research
+4: Other (type it)
+```
+
+```
+── What does each row count?
+
+1: case
+2: aggregate
+3: treatment
+4: mmdp
+5: training
+6: survey
+7: tas
+8: prevalence
+9: entomology
+10: Other (type it)
+```
+
+```
+ℹ Where is the file on your computer?
+```
+
+```
+── Ready to bring this in
+
+* Country: ATLANTIS
+* Disease: malaria
+* Channel: surveillance / Measure: case
+* File:    atlantis_malaria_2024-01.csv
+ℹ I'll archive it, check data quality, and stage it for approval.
+
+── Go ahead?
+
+1: Yes
+2: No
+```
+
+One call, [`eri_ingest()`](../reference/eri_ingest.html), does the archive + DQ-check + stage in a
+single shot, unlike CMR's multi-step upload/stage/split. If it finds open log entries afterward, it
+tells you and asks whether to approve anyway, rather than triaging them for you (surveillance's DQ
+flags land in the general [`eri_logs()`](../reference/eri_logs.html) backlog, not CMR's per-sheet
+shape):
+
+```
+! 1 log entry need review before this can be approved.
+ℹ Run eri_logs() to see them, eri_dq_flag_resolve() to triage each flag, then eri_logs_resolve() to close the entry out.
+
+── Approve anyway? (only if you've already reviewed this)
+
+1: Yes
+2: No
+```
+
+Say no (the safer default unless you've genuinely already reviewed it), and it leaves the data
+staged rather than approving:
+
+```
+ℹ Left staged -- run eri_do() again once you've triaged the flags.
+```
+
+Otherwise, it asks for the period (free text matched against the staged filename, no fixed
+convention the way CMR has one) and approves.
+
+**The [ingest guide](da-ingest-guide.html)** walks the same pipeline by hand, including a full
+worked example of a schema catching real problems (an impossible age, an unrecognized district) and
+the corrections/flags distinction that drives it.
+
+## 3. Pull in ODK survey submissions {#odk}
+
+```
+── Pull in ODK survey submissions ────────────────────────────────────────────────
+```
+
+Connects, then turns "which project" and "which form" into pick-lists built from what's actually
+visible on your account, never a numeric project id or exact form id typed from memory:
+
+```
+── Which ODK project?
+
+1: Uganda
+2: testing
+```
+
+```
+── Which form?
+
+1: ERI Test, River Prospection
+```
+
+If this form isn't registered yet, it asks for country (a pick-list of known ERI countries) and
+disease, the server URL comes from the connection you already made, never asked again, confirms,
+then registers:
+
+```
+ℹ This form isn't registered yet -- I need a country and disease to file it under.
+```
+
+```
+── Register this form as uga/oncho?
+
+1: Yes
+2: No
+```
+
+```
+── Sync submissions now?
+
+1: Yes
+2: No
+```
+
+```
+✔ Done. Submissions are synced to research/raw/.
+ℹ Next: quality-check and stage this the same way as a surveillance extract -- see the surveillance ingest guide -- then eri_approve() it in.
+ℹ Run eri_do() again any time to sync new submissions.
+```
+
+This is where the wizard **honestly stops**: there is no single stage-then-approve function for
+ODK data, the real guide's own next step is a manual [`eri_write()`](../reference/eri_write.html)
+after ad hoc quality-checking, so rather than fabricate an approve step the tooling doesn't
+support, it hands off here.
+
+**The [ODK guide](da-odk-guide.html)** covers everything the wizard doesn't: standing up a form,
+monitoring a survey, and managing who can collect on it.
+
+## 4. Onboard a new country, disease, or data type {#onboard}
+
+```
+── Onboard a new country, disease, or data type ──────────────────────────────────
+```
+
+Three genuinely different shapes behind one menu, a surveillance space, a CMR space, or an NTD
+disease's schemas:
+
+```
+── What are you setting up?
+
+1: Surveillance country/disease (case or aggregate reporting)
+2: CMR country (monthly Case Management Report)
+3: NTD disease (MDA + prevalence schemas, no country folders yet)
+```
+
+Picking **surveillance** or **CMR** asks for a country code (typed, since onboarding's whole point
+is a country nothing else has registered yet), the full country name, disease (surveillance only),
+and a schema-comment language:
+
+```
+Full country name (e.g. Uganda; blank to cancel): Atlantis
+```
+
+```
+── Schema comments in which language?
+
+1: English
+2: French
+```
+
+Every path previews with a dry run before writing anything, then confirms:
+
+```
+── Write this schema template and create the Azure folders?
+
+1: Yes
+2: No
+```
+
+Picking **NTD disease** skips the Azure folders entirely (local-only, by
+[`eri_onboard_disease()`](../reference/eri_onboard_disease.html)'s own design) and asks which
+schema(s) you need:
+
+```
+── Which schema(s) do you need?
+
+1: Both (MDA + prevalence)
+2: MDA only
+3: Prevalence only
+```
+
+Say yes, and the wizard stops right where it should: the schema template is written (and, for
+surveillance/CMR, the Azure folders exist), but filling in the disease-specific columns, validating
+the schema, and submitting it via pull request are real domain judgment calls, no wizard should
+fabricate those for you.
+
+**The [onboarding guide](da-onboard-guide.html)** picks up from exactly there: what the template
+looks like, how to fill in the `TODO` sections, and how to validate and submit it.
+
+## 5. Review & approve something already staged {#dq-shortcut}
+
+The fifth menu item is a shortcut, not its own flow: pick a country and a period, and it hands you
+straight into [`eri_dq_review()`](../reference/eri_dq_review.html), the same guided menu the CMR
+flow above ends in.
+
+```
+── Which country?
+
+1: ETH
+2: NGA
+3: SDN
+4: SSD
+5: UGA
+6: MAD
+7: TCD
+```
+
+```
+Reporting period, as YYYYMM (e.g. 202406; blank to cancel):
+```
+
+**The [DQ review guide](da-dq-review-guide.html)** is the reference for this whole screen, what
+each option (fix in source, adjust the schema, mark not important, mark noted, force-approve) does
+and why.
+
+## Cancelling out {#cancelling}
+
+Every prompt in the wizard shares one convention: **`0`, or blank on a typed prompt, backs out**.
+Nothing is written until you reach a flow's own "Go ahead?"/"Write this...?" confirmation, so you
+can explore any menu, back out at any point, and re-run `eri_do()` later with nothing left half
+done. A flow that stops partway (declined a confirmation, or the DA cancelled) leaves whatever was
+already written in place and tells you so, run `eri_do()` again any time to pick up where you left
+off.
+
+## What's next
+
+- **Pick the pipeline for your actual task**: [CMR](da-cmr-guide.html) ·
+  [surveillance ingest](da-ingest-guide.html) · [ODK](da-odk-guide.html) ·
+  [onboarding](da-onboard-guide.html) · [DQ review](da-dq-review-guide.html).
+- **New here?** Start with [Getting started](getting-started.html) and the
+  [connections guide](connections-guide.html) before running `eri_do()` for real.
+- **Scripting or CI?** `eri_do()` is interactive-only by design, use the scriptable core it calls
+  directly: [`eri_upload()`](../reference/eri_upload.html), [`eri_ingest()`](../reference/eri_ingest.html),
+  [`eri_odk_sync()`](../reference/eri_odk_sync.html), [`eri_onboard_country()`](../reference/eri_onboard_country.html),
+  and the rest of the [pipeline reference](../reference/index.html).
+
+See the [guide index](https://github.com/thecartercenter/erifunctions/blob/main/docs/guides.md) for
+the full set of guides.

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -20,9 +20,10 @@ knitr::opts_chunk$set(
 :::
 
 > **This is the screen [`eri_do()`](../reference/eri_do.html) already puts you on.** Its CMR flow
-> (and the "Review & approve something already staged" menu item) hands off directly into this same
-> `eri_dq_review()` loop -- so if you're triaging flags inside `eri_do()` right now, this guide is
-> the reference for what each menu option (fix in source, mark noted, force-approve) actually does.
+> (and the "Review & approve something already staged" menu item, see the
+> [eri_do() tour](da-do-guide.html)) hands off directly into this same `eri_dq_review()` loop -- so
+> if you're triaging flags inside `eri_do()` right now, this guide is the reference for what each
+> menu option (fix in source, mark noted, force-approve) actually does.
 
 The [CMR guide](da-cmr-guide.html) and the [QC/feedback guide](da-qc-feedback-guide.html) both walk
 the DQ pipeline as a **sequence of functions you call yourself**: check, resolve each flag, close out

--- a/vignettes/da-ingest-guide.Rmd
+++ b/vignettes/da-ingest-guide.Rmd
@@ -22,8 +22,8 @@ knitr::opts_chunk$set(
 > **Prefer to just do it?** Run [`eri_do()`](../reference/eri_do.html) in the console and pick
 > "bring in a surveillance dataset" — it walks the whole archive → check → stage → approve
 > pipeline below through a few prompts (which country, which disease, which file), no function
-> names to memorize. This guide is for understanding what's happening underneath, or for
-> scripting the steps yourself.
+> names to memorize. See the [eri_do() tour](da-do-guide.html) for what its menu looks like. This
+> guide is for understanding what's happening underneath, or for scripting the steps yourself.
 
 This is a hands-on, **start-to-finish walkthrough** of getting a surveillance dataset into the
 Carter Center data system, the daily work of a **Data Analyst (DA)**. It is written for domain

--- a/vignettes/da-logs-guide.Rmd
+++ b/vignettes/da-logs-guide.Rmd
@@ -23,7 +23,8 @@ knitr::opts_chunk$set(
 > or ODK flow finds open log entries, it stops and tells you to run `eri_logs()` /
 > `eri_dq_flag_resolve()` / `eri_logs_resolve()` -- the exact tools this guide walks through -- rather
 > than triaging the backlog for you (unlike CMR, whose per-sheet flags have their own guided loop,
-> see the [DQ review guide](da-dq-review-guide.html)).
+> see the [DQ review guide](da-dq-review-guide.html)). See the [eri_do() tour](da-do-guide.html) for
+> what its menu looks like.
 
 Every operation `erifunctions` runs, an ingest, an approval, an ODK sync, **leaves a log** in
 Azure. When something fails, or a data-quality check raises issues, that log is the record. This guide

--- a/vignettes/da-odk-guide.Rmd
+++ b/vignettes/da-odk-guide.Rmd
@@ -22,9 +22,10 @@ knitr::opts_chunk$set(
 > **Just need to pull in this month's submissions?** Run [`eri_do()`](../reference/eri_do.html) in
 > the console and pick "pull in ODK survey submissions" — it connects, lets you pick the project
 > and form from what's actually visible on your account, registers it if needed, and syncs, no
-> project/form IDs to memorize. It stops once submissions land in `research/raw/`; this guide is
-> still where you learn the parts the wizard doesn't cover — standing up a form, monitoring it,
-> managing who collects on it, and quality-checking + staging what comes back.
+> project/form IDs to memorize (see the [eri_do() tour](da-do-guide.html) for what its menu looks
+> like). It stops once submissions land in `research/raw/`; this guide is still where you learn the
+> parts the wizard doesn't cover — standing up a form, monitoring it, managing who collects on it,
+> and quality-checking + staging what comes back.
 
 **ODK Central** is where field data is born, survey teams collect submissions on phones, and they
 land on an ODK Central server. This is a hands-on walkthrough for a **Data Analyst (DA)** of the whole

--- a/vignettes/da-onboard-guide.Rmd
+++ b/vignettes/da-onboard-guide.Rmd
@@ -22,9 +22,9 @@ knitr::opts_chunk$set(
 > **Just need to scaffold the space, not learn the functions?** Run
 > [`eri_do()`](../reference/eri_do.html) in the console and pick "onboard a new country, disease,
 > or data type" — it walks you through the dry-run preview and writes the schema template + Azure
-> folders for you. It stops there: filling in the schema's disease-specific columns, validating it,
-> and submitting it via pull request are still yours to do, and this guide is where you learn that
-> part.
+> folders for you (see the [eri_do() tour](da-do-guide.html) for what its menu looks like). It stops
+> there: filling in the schema's disease-specific columns, validating it, and submitting it via
+> pull request are still yours to do, and this guide is where you learn that part.
 
 Before any data can flow through `erifunctions`, the **space for it has to exist**: a data-quality
 schema that describes the data, and the `raw → staged → processed` folders it will move through. This

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -80,7 +80,9 @@ The guides are short, copy-paste, run-it-live walkthroughs on safe sandbox data.
 
 For the paced version of this with checkpoints, follow the [**onboarding path**](onboarding.html), and
 keep the [**DA cheat sheet**](da-cheatsheet.html) and the [data-model card](data-model-card.html) open as
-you work.
+you work. Once you're connected, **[`eri_do()`](../reference/eri_do.html)** is a guided console
+wizard that runs each pipeline below for you, decisions instead of function names, see the
+[eri_do() tour](da-do-guide.html) for what its menu looks like.
 
 1. [Connecting to the services](connections-guide.html)
 2. [Onboarding a new country / disease / data type](da-onboard-guide.html): stand up the space

--- a/vignettes/orientation.Rmd
+++ b/vignettes/orientation.Rmd
@@ -61,7 +61,8 @@ it warns, it doesn't error. The [data-model card](data-model-card.html) is the d
 
 **Run [`eri_do()`](../reference/eri_do.html)**: a guided console wizard that picks the right
 functions for a CMR report, a surveillance extract, ODK submissions, or standing up a brand-new
-space, and calls them for you. Everything still ends at **`eri_approve()`** and the catalog.
+space, and calls them for you. Everything still ends at **`eri_approve()`** and the catalog. See
+the [eri_do() tour](da-do-guide.html) for what its menu looks like.
 
 ## Your tasks → where they live
 


### PR DESCRIPTION
## Summary
- New `vignettes/da-do-guide.Rmd`: the missing piece of the interactive-wizard course correction's documentation. Each of the four flows got a "prefer to just do it? run `eri_do()`" callout in its own pipeline guide as it shipped (Phases A-C.2), but nothing ever documented `eri_do()`'s own menu as a whole -- unlike `eri_dq_review()`, which has its own dedicated `da-dq-review-guide.Rmd`.
- Walks the top-level menu and all five paths (CMR, surveillance ingest, ODK, onboarding, DQ-review shortcut) with their actual prompts and decision points. Every menu title, confirmation prompt, and message string verified directly against `R/wizard.R`'s source (including exact `cli_h1()`-vs-`cli_h3()` rendering, confirmed via a live test render rather than guessed).
- `eri_do()` is interactive-only and refuses to run from a script, so none of this guide's transcripts can execute inside the document -- every one is illustrated and source-verified rather than live-captured, the same honest convention `da-cmr-guide.Rmd`/`da-odk-guide.Rmd` already use for their own non-sandbox-safe steps (stated explicitly up front in the guide).
- Deliberately stays a *tour*, not a redo of the domain-knowledge walkthroughs -- each section points at its pipeline's own guide (CMR, ingest, ODK, onboarding, DQ review) for real captured output and depth this one skips.
- Cross-linked from `_pkgdown.yml` (new entry under "Quick reference & onboarding"), `docs/guides.md`, `getting-started.Rmd`, and every existing pipeline guide's own `eri_do()` callout (`da-cmr-guide`, `da-ingest-guide`, `da-odk-guide`, `da-onboard-guide`, `da-dq-review-guide`, `da-logs-guide`, `da-cheatsheet`, `orientation`).

## Test plan
- [x] `pkgdown::check_pkgdown()` validates the updated `_pkgdown.yml`/article list cleanly.
- [x] Manually verified balanced `:::` div blocks in the new vignette.
- [x] Full suite: `devtools::test()` -- 0 failures, 2867 pass (no R code changed; pre-existing unrelated warnings only).
- [x] Local pandoc/knitr rendering segfaults in this environment right now for ANY vignette (reproduced on an untouched file too, unrelated to this change) -- relying on CI's pkgdown build, which has been reliable across every prior wizard PR this session.