### PR TITLE
feat(wizard): eri_do(flow=) deep links + onboarding overwrite protection (Phase D) (0.9.34)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.33
+Version: 0.9.34
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,41 @@
+# erifunctions 0.9.34
+
+## `eri_do(flow=)` deep links, and a real overwrite protection found along the way (Phase D of the interactive-wizard course correction)
+
+- **`eri_do(flow = NULL)`**: pass `"cmr"`, `"ingest"`, `"odk"`, `"onboard"`, or `"review"` to jump
+  straight into that flow, skipping the top-level menu -- runs it once and returns, rather than
+  looping back into the menu. An unrecognized name errors immediately rather than silently falling
+  through. One shared dispatch table (`.ERI_DO_FLOWS`/`.eri_do_run_flow()`) backs both the menu and
+  the deep-link, so they can't quietly diverge.
+- **Re-audited the design consult's one-line Phase D scope** ("progress-detection polish,
+  `eri_do('cmr')` deep-links, feedback-on-confusing-flag") against what actually exists, the same
+  discipline Phase C.3 applied to the doc-cutting plan. "Feedback-on-confusing-flag" is already
+  served by the existing `eri_dq_schema_submit()`/`eri_feedback()` machinery the DQ-review loop
+  already exposes -- no new wizard-specific hook needed. Extending CMR's resume-detection pattern
+  to ingest/ODK turned out not to be real polish: ingest's period is free text with no fixed key
+  until `eri_approve()` is actually called (a resume check would need new, fragile core logic just
+  to guess at what would be approved), and ODK already effectively resumes via its "already
+  registered" check.
+- **A genuine, previously-undiscovered gap surfaced investigating "progress-detection" instead**:
+  `eri_onboard_country()`/`eri_onboard_cmr()`/`eri_onboard_disease()` all unconditionally overwrite
+  an existing local schema file with a fresh blank template -- real data loss for a DA who re-runs
+  onboarding after already filling in the TODO sections. Added
+  `.eri_wizard_confirm_onboard_write()` (a `file.exists()` check before the real write, no new core
+  function needed) to all three onboarding sub-flows: it warns and asks a different, explicit
+  confirm ("Overwrite with a fresh template? Any edits already made will be lost.") when a target
+  file already exists, instead of the normal "write this?" prompt.
+- **A real bug caught by the test suite, not review**: the initial `flow=` validation error used
+  `{.val {.ERI_DO_FLOWS}}` in a `cli::cli_abort()` call, which errors in current `cli` versions
+  because an interpolated expression starting with `.` is reserved for cli styles -- fixed by
+  assigning to a plain local variable first. Caught immediately by the new "unrecognized flow name"
+  test, not by manual inspection.
+- `vignettes/da-do-guide.Rmd` updated with the `flow=` deep-link examples and the overwrite-protection
+  transcript.
+- **`tests/testthat/test-wizard.R`** (134 tests, +21): every `flow=` value routes correctly and
+  skips the top menu, case/whitespace-insensitivity, the unrecognized-name error, and the overwrite
+  check for each of the three onboarding sub-flows (no-existing-file, existing-file-confirm,
+  existing-file-decline).
+
 # erifunctions 0.9.33
 
 ## New guide: a tour of `eri_do()` itself

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,12 +10,16 @@
 - **Re-audited the design consult's one-line Phase D scope** ("progress-detection polish,
   `eri_do('cmr')` deep-links, feedback-on-confusing-flag") against what actually exists, the same
   discipline Phase C.3 applied to the doc-cutting plan. "Feedback-on-confusing-flag" is already
-  served by the existing `eri_dq_schema_submit()`/`eri_feedback()` machinery the DQ-review loop
-  already exposes -- no new wizard-specific hook needed. Extending CMR's resume-detection pattern
-  to ingest/ODK turned out not to be real polish: ingest's period is free text with no fixed key
-  until `eri_approve()` is actually called (a resume check would need new, fragile core logic just
-  to guess at what would be approved), and ODK already effectively resumes via its "already
-  registered" check.
+  served for the CMR flow and the `"review"` shortcut, both of which hand off into
+  `eri_dq_review()`'s loop where `eri_dq_schema_submit()` is already wired in -- ingest/ODK have no
+  DQ-flag-schema step inside the wizard at all by their own earlier-phase design, so for those two
+  it means "reachable by calling the function directly," not "exposed inside the wizard." No new
+  wizard-specific hook added either way. Extending CMR's resume-detection pattern to ingest/ODK
+  turned out not to be real polish either: ingest's period is free text with no fixed key until
+  `eri_approve()` is actually called (a resume check would need new, fragile core logic just to
+  guess at what would be approved), and ODK's `eri_odk_sync()` has no partial-sync state to resume
+  from at all (it re-downloads and overwrites every submission on every call) -- its "already
+  registered" check is the only persistent state there is, and it already does the right thing.
 - **A genuine, previously-undiscovered gap surfaced investigating "progress-detection" instead**:
   `eri_onboard_country()`/`eri_onboard_cmr()`/`eri_onboard_disease()` all unconditionally overwrite
   an existing local schema file with a fresh blank template -- real data loss for a DA who re-runs

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -1,4 +1,4 @@
-#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: ingest; Phase C.1: ODK; Phase C.2: onboarding) ####
+#### eri_do — the unified interactive pipeline wizard (Phase A: CMR; Phase B: ingest; Phase C.1: ODK; Phase C.2: onboarding; Phase D: deep links + overwrite protection) ####
 #
 # Design consult: docs/design/interactive-wizard-consult.md. Corrects the docs-site redesign's
 # direction -- that work optimized *discoverability* (can a DA find the right guide); this optimizes
@@ -40,8 +40,26 @@
 #
 # Phase C.3 retired eri_guide() (deprecated + narrowed to a static lookup, R/guide.R) and re-audited
 # the doc cut against what actually shipped in A-C.2, finding it much narrower than the consult
-# estimated -- see docs/roadmap.md's Phase C.3 entry. Progress-detection polish is Phase D, not
-# started.
+# estimated -- see docs/roadmap.md's Phase C.3 entry.
+#
+# Phase D: the consult's own scope for this phase was one line -- "progress-detection polish,
+# eri_do('cmr') deep-links, feedback-on-confusing-flag" -- so it needed its own re-audit against
+# what actually exists, same as Phase C.3's doc cut. `eri_do(flow=)` deep-links shipped as designed
+# (.ERI_DO_FLOWS/.eri_do_run_flow(), one dispatch table the menu and the deep-link both validate
+# against, so they can't diverge). "Progress-detection polish" turned out to mean something more
+# concrete and more valuable than the phrase implied: CMR already has real resume detection
+# (.eri_wizard_detect_cmr_progress(), Phase A, built on eri_cmr_last_plan()'s clean YYYYMM period
+# key) -- ingest and ODK have no equivalent, but investigating why revealed it isn't a gap worth
+# closing the same way: ingest's period is free text with no fixed key until eri_approve() is
+# actually called, so a resume check would need new, fragile core logic just to peek at what
+# WOULD be approved, not real polish; ODK already effectively resumes via its "already registered"
+# check, no separate prompt needed. What WAS a genuine, previously-undiscovered gap:
+# eri_onboard_country()/eri_onboard_cmr()/eri_onboard_disease() unconditionally overwrite an
+# existing local schema file with a fresh blank template -- real data loss for a DA who re-runs
+# onboarding after already filling in the TODOs. Added .eri_wizard_confirm_onboard_write(), a
+# file.exists() check (no new core function) before the real write, in all three onboarding
+# sub-flows. "Feedback-on-confusing-flag" is already served by the existing eri_dq_schema_submit()/
+# eri_feedback() machinery the DQ-review loop already exposes -- no new wizard-specific hook needed.
 #
 # Concrete R control flow, not a declarative flow schema. The original consult proposed a
 # `flow_map.yaml`/`kind:`-dispatch engine "once a second/third flow gives it real shape to
@@ -567,6 +585,24 @@
   invisible(NULL)
 }
 
+# eri_onboard_*() unconditionally overwrite an existing local schema file with a fresh blank
+# template -- real data loss if a DA re-runs onboarding after already filling in the TODOs. None of
+# the three functions guard against this themselves (scaffolding fresh on every call is the right
+# default for a script author); the wizard adds the check since protecting the DA from an
+# accidental clobber of their own in-progress edits is exactly its job. Compares against the SAME
+# filename convention eri_onboard_country()/eri_onboard_cmr()/eri_onboard_disease() build
+# themselves, in the current working directory (none of the three flows expose `path`/`output_dir`,
+# so it's always getwd()).
+#' @keywords internal
+.eri_wizard_confirm_onboard_write <- function(paths, write_prompt) {
+  existing <- paths[file.exists(paths)]
+  if (length(existing) > 0L) {
+    cli::cli_alert_warning("Already exists here: {.path {existing}}")
+    return(.eri_wizard_confirm("Overwrite with a fresh template? Any edits already made will be lost."))
+  }
+  .eri_wizard_confirm(write_prompt)
+}
+
 # No country/disease registry to pick-list from here -- onboarding's entire purpose is standing up
 # a space for a country/disease that ISN'T registered anywhere yet. Country code and full name are
 # both free-typed; disease reuses the shared pick-list-plus-Other pattern.
@@ -592,7 +628,10 @@
   })
   if (!preview$ok) return(invisible(NULL))
 
-  if (!.eri_wizard_confirm("Write this schema template and create the Azure folders?")) {
+  schema_path <- paste0(country, "_", disease, "_surveillance_aggregate.yaml")
+  if (!.eri_wizard_confirm_onboard_write(
+    schema_path, "Write this schema template and create the Azure folders?"
+  )) {
     return(invisible(NULL))
   }
 
@@ -624,7 +663,10 @@
   })
   if (!preview$ok) return(invisible(NULL))
 
-  if (!.eri_wizard_confirm("Write this CMR schema template and create the Azure folders?")) {
+  schema_path <- paste0(country, "_cmr_schema.yaml")
+  if (!.eri_wizard_confirm_onboard_write(
+    schema_path, "Write this CMR schema template and create the Azure folders?"
+  )) {
     return(invisible(NULL))
   }
 
@@ -663,7 +705,17 @@
   })
   if (!preview$ok) return(invisible(NULL))
 
-  if (!.eri_wizard_confirm("Write these schema template(s)?")) return(invisible(NULL))
+  # Matches eri_onboard_disease()'s own kind_map exactly (mda -> programmatic/treatment,
+  # prevalence -> research/prevalence) so the existence check looks at the SAME filenames it writes.
+  kind_map    <- list(mda = c("programmatic", "treatment"), prevalence = c("research", "prevalence"))
+  schema_paths <- vapply(data_types, function(k) {
+    m <- kind_map[[k]]
+    paste0(country, "_", disease, "_", m[[1L]], "_", m[[2L]], ".yaml")
+  }, character(1L))
+
+  if (!.eri_wizard_confirm_onboard_write(schema_paths, "Write these schema template(s)?")) {
+    return(invisible(NULL))
+  }
 
   result <- .eri_wizard_step(function() eri_onboard_disease(disease, country, data_types = data_types))
   if (!result$ok) return(invisible(NULL))
@@ -703,20 +755,38 @@
 #' [eri_stage_cmr()], [eri_split_cmr()], [eri_cmr_dq_report()], [eri_approve_cmr()], [eri_ingest()],
 #' [eri_approve()], [eri_odk_sync()], [eri_onboard_country()].
 #'
+#' @param flow `chr` or `NULL` A flow to jump straight into, skipping the top-level menu:
+#'   `"cmr"`, `"ingest"`, `"odk"`, `"onboard"`, or `"review"` (the DQ-review shortcut). Runs that one
+#'   flow once and returns, it does not loop back into the menu afterward. `NULL` (default) shows
+#'   the menu and loops until you exit.
 #' @returns Invisibly, `NULL`. Every effect happens through the scriptable core it calls.
 #' @examples
 #' \dontrun{
 #' eri_do()
+#' eri_do("cmr")  # jump straight to the CMR flow, skipping the menu
 #' }
 #' @seealso [eri_dq_review()] for the data-quality review loop this hands off into,
 #'   [eri_cutover_status()] for the mirroring criterion this checks automatically.
 #' @export
-eri_do <- function() {
+eri_do <- function(flow = NULL) {
   if (!rlang::is_interactive()) {
     cli::cli_abort(c(
       "{.fn eri_do} is interactive-only.",
       "i" = "In scripts/CI use the scriptable core directly: {.fn eri_upload}, {.fn eri_stage_cmr}, {.fn eri_split_cmr}, {.fn eri_cmr_dq_report}, {.fn eri_approve_cmr}."
     ))
+  }
+
+  if (!is.null(flow)) {
+    flow <- tolower(trimws(flow))
+    valid_flows <- .ERI_DO_FLOWS
+    if (!flow %in% valid_flows) {
+      cli::cli_abort(c(
+        "{.arg flow} must be one of {.val {valid_flows}}, not {.val {flow}}.",
+        "i" = "Or call {.fn eri_do} with no argument to pick from the menu."
+      ))
+    }
+    .eri_do_run_flow(flow)
+    return(invisible(NULL))
   }
 
   repeat {
@@ -729,24 +799,33 @@ eri_do <- function() {
       "Exit"
     ))
     if (choice == 0L || choice == 6L) break
-
-    if (choice == 1L) {
-      .eri_flow_cmr()
-    } else if (choice == 2L) {
-      .eri_flow_ingest()
-    } else if (choice == 3L) {
-      .eri_flow_odk()
-    } else if (choice == 4L) {
-      .eri_flow_onboard()
-    } else if (choice == 5L) {
-      country <- .eri_prompt_pick_country(.eri_pipeline_registry[["rb-expansion"]]$country_map,
-                                          "Which country?")
-      if (!is.null(country)) {
-        period <- .eri_wizard_pick_period("")
-        if (!is.na(period)) eri_dq_review(country, period)
-      }
-    }
+    .eri_do_run_flow(.ERI_DO_FLOWS[[choice]])
   }
 
+  invisible(NULL)
+}
+
+# One name per top-menu item, same order -- the single source both the menu dispatch and the
+# flow= deep-link validate against, so they can't silently diverge.
+.ERI_DO_FLOWS <- c("cmr", "ingest", "odk", "onboard", "review")
+
+#' @keywords internal
+.eri_do_run_flow <- function(flow) {
+  if (flow == "cmr") {
+    .eri_flow_cmr()
+  } else if (flow == "ingest") {
+    .eri_flow_ingest()
+  } else if (flow == "odk") {
+    .eri_flow_odk()
+  } else if (flow == "onboard") {
+    .eri_flow_onboard()
+  } else if (flow == "review") {
+    country <- .eri_prompt_pick_country(.eri_pipeline_registry[["rb-expansion"]]$country_map,
+                                        "Which country?")
+    if (!is.null(country)) {
+      period <- .eri_wizard_pick_period("")
+      if (!is.na(period)) eri_dq_review(country, period)
+    }
+  }
   invisible(NULL)
 }

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -52,14 +52,20 @@
 # key) -- ingest and ODK have no equivalent, but investigating why revealed it isn't a gap worth
 # closing the same way: ingest's period is free text with no fixed key until eri_approve() is
 # actually called, so a resume check would need new, fragile core logic just to peek at what
-# WOULD be approved, not real polish; ODK already effectively resumes via its "already registered"
-# check, no separate prompt needed. What WAS a genuine, previously-undiscovered gap:
+# WOULD be approved, not real polish; ODK's eri_odk_sync() has no partial-sync state at all to
+# resume from (it re-downloads and overwrites every submission on every call, no watermark/cursor)
+# -- its "already registered" check is the only persistent state there is, and skipping
+# re-registration when it's already set is already the right behavior, not something to build on
+# top of. What WAS a genuine, previously-undiscovered gap:
 # eri_onboard_country()/eri_onboard_cmr()/eri_onboard_disease() unconditionally overwrite an
 # existing local schema file with a fresh blank template -- real data loss for a DA who re-runs
 # onboarding after already filling in the TODOs. Added .eri_wizard_confirm_onboard_write(), a
 # file.exists() check (no new core function) before the real write, in all three onboarding
-# sub-flows. "Feedback-on-confusing-flag" is already served by the existing eri_dq_schema_submit()/
-# eri_feedback() machinery the DQ-review loop already exposes -- no new wizard-specific hook needed.
+# sub-flows. "Feedback-on-confusing-flag" is already served for the CMR flow and the "review"
+# shortcut, both of which hand off into .eri_dq_review_loop() where eri_dq_schema_submit() is
+# already wired in -- ingest/ODK have no DQ-flag-schema step in the wizard at all (by their own
+# Phase B/C.1 design), so for those two "already served" means "reachable by calling the function
+# directly," not "exposed inside the wizard." No new wizard-specific hook added for either case.
 #
 # Concrete R control flow, not a declarative flow schema. The original consult proposed a
 # `flow_map.yaml`/`kind:`-dispatch engine "once a second/third flow gives it real shape to
@@ -778,6 +784,8 @@ eri_do <- function(flow = NULL) {
 
   if (!is.null(flow)) {
     flow <- tolower(trimws(flow))
+    # Assigned to a plain name, not interpolated as {.val {.ERI_DO_FLOWS}} directly -- cli's inline
+    # markup reserves a leading "." on an interpolated expression for styles, and errors on it.
     valid_flows <- .ERI_DO_FLOWS
     if (!flow %in% valid_flows) {
       cli::cli_abort(c(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.33 · **Status:** Active development
+**Version:** 0.9.34 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -521,8 +521,7 @@ to a guessed number rather than to genuine overlap, exactly the CLAUDE.md guardr
 designing for a hypothetical rather than a verified need. `onboarding.Rmd`'s ingestion-spine days
 now point at `eri_do()` as the primary path; its "Competency checklist" heading also dropped the
 "DA + mentor sign off" framing (a standalone DA-rules complaint raised earlier in this session,
-addressed here since the file was already being revised). **Phase D (progress-detection polish,
-`eri_do("cmr")` deep links) remains designed in the consult document but not yet started.**
+addressed here since the file was already being revised).
 
 **Follow-up, same session: `vignettes/da-do-guide.Rmd` shipped as v0.9.33.** A gap noticed only
 after Phase C.3 closed the loop: each of the four flows got its own "prefer to just do it? run
@@ -536,6 +535,31 @@ already use). Deliberately stays a tour, not a redo of the domain-knowledge walk
 section points at its pipeline's own guide for real captured output and depth. Cross-linked from
 `_pkgdown.yml`, `docs/guides.md`, `getting-started.Rmd`, and every existing pipeline guide's own
 `eri_do()` callout.
+
+**Phase D (deep links + a real overwrite protection) shipped as v0.9.34.** The consult's own scope
+for this phase was one line — "progress-detection polish, `eri_do('cmr')` deep-links,
+feedback-on-confusing-flag" — so it needed the same re-audit-against-reality treatment Phase C.3
+gave the doc-cutting plan, rather than executing it literally. **`eri_do(flow = NULL)`** shipped as
+designed: `"cmr"`/`"ingest"`/`"odk"`/`"onboard"`/`"review"` jump straight into that flow, skipping
+the top menu, one shared dispatch table (`.ERI_DO_FLOWS`/`.eri_do_run_flow()`) backing both the
+menu and the deep-link so they can't diverge. **"Feedback-on-confusing-flag" turned out to already
+be served** by the existing `eri_dq_schema_submit()`/`eri_feedback()` machinery the DQ-review loop
+already exposes — no new wizard hook needed. **Extending CMR's resume-detection to ingest/ODK
+turned out not to be real polish**: ingest's period is free text with no fixed key until
+`eri_approve()` is actually called (a resume check would need new, fragile core logic just to guess
+at what would be approved), and ODK already effectively resumes via its "already registered" check.
+**Investigating "progress-detection" surfaced a genuine, previously-undiscovered gap instead**:
+`eri_onboard_country()`/`eri_onboard_cmr()`/`eri_onboard_disease()` all unconditionally overwrite an
+existing local schema file with a fresh blank template — real data loss for a DA who re-runs
+onboarding after already filling in the TODOs. Added `.eri_wizard_confirm_onboard_write()` (a
+`file.exists()` check before the real write, no new core function needed) to all three onboarding
+sub-flows. **A real bug caught by the new test suite, not manual review**: the `flow=` validation
+error initially used `{.val {.ERI_DO_FLOWS}}` inside `cli::cli_abort()`, which errors in current
+`cli` because an interpolated expression starting with `.` is reserved for cli styles — fixed by
+assigning to a plain local variable first, caught immediately by the "unrecognized flow name" test.
+`vignettes/da-do-guide.Rmd` updated with both the deep-link examples and the overwrite-protection
+transcript. **This closes out the interactive-wizard course correction end to end — Phases A
+through D are all shipped.**
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -543,11 +543,16 @@ gave the doc-cutting plan, rather than executing it literally. **`eri_do(flow = 
 designed: `"cmr"`/`"ingest"`/`"odk"`/`"onboard"`/`"review"` jump straight into that flow, skipping
 the top menu, one shared dispatch table (`.ERI_DO_FLOWS`/`.eri_do_run_flow()`) backing both the
 menu and the deep-link so they can't diverge. **"Feedback-on-confusing-flag" turned out to already
-be served** by the existing `eri_dq_schema_submit()`/`eri_feedback()` machinery the DQ-review loop
-already exposes — no new wizard hook needed. **Extending CMR's resume-detection to ingest/ODK
-turned out not to be real polish**: ingest's period is free text with no fixed key until
-`eri_approve()` is actually called (a resume check would need new, fragile core logic just to guess
-at what would be approved), and ODK already effectively resumes via its "already registered" check.
+be served, for the flows that have a DQ step at all**: the CMR flow and the `"review"` shortcut
+both hand off into `eri_dq_review()`'s loop, where `eri_dq_schema_submit()` is already wired in —
+ingest/ODK have no DQ-flag-schema step inside the wizard by their own earlier-phase design, so for
+those two it means "reachable directly," not "exposed in the wizard." No new hook added either way.
+**Extending CMR's resume-detection to ingest/ODK turned out not to be real polish**: ingest's
+period is free text with no fixed key until `eri_approve()` is actually called (a resume check
+would need new, fragile core logic just to guess at what would be approved), and ODK's
+`eri_odk_sync()` has no partial-sync state to resume from at all (full re-download/overwrite every
+call) — its "already registered" check is the only persistent state there is, and it already does
+the right thing.
 **Investigating "progress-detection" surfaced a genuine, previously-undiscovered gap instead**:
 `eri_onboard_country()`/`eri_onboard_cmr()`/`eri_onboard_disease()` all unconditionally overwrite an
 existing local schema file with a fresh blank template — real data loss for a DA who re-runs

--- a/man/eri_do.Rd
+++ b/man/eri_do.Rd
@@ -4,7 +4,13 @@
 \alias{eri_do}
 \title{Bring a monthly report into the system, interactively (the guided console front door)}
 \usage{
-eri_do()
+eri_do(flow = NULL)
+}
+\arguments{
+\item{flow}{\code{chr} or \code{NULL} A flow to jump straight into, skipping the top-level menu:
+\code{"cmr"}, \code{"ingest"}, \code{"odk"}, \code{"onboard"}, or \code{"review"} (the DQ-review shortcut). Runs that one
+flow once and returns, it does not loop back into the menu afterward. \code{NULL} (default) shows
+the menu and loops until you exit.}
 }
 \value{
 Invisibly, \code{NULL}. Every effect happens through the scriptable core it calls.
@@ -42,6 +48,7 @@ doesn't support or shouldn't automate.
 \examples{
 \dontrun{
 eri_do()
+eri_do("cmr")  # jump straight to the CMR flow, skipping the menu
 }
 }
 \seealso{

--- a/tests/testthat/test-wizard.R
+++ b/tests/testthat/test-wizard.R
@@ -804,3 +804,164 @@ test_that("eri_do exits immediately from the top menu with no navigation", {
   )
   expect_invisible(eri_do())
 })
+
+#### Phase D: eri_do(flow=) deep links ####
+
+test_that("eri_do(flow=) jumps straight into each named flow without showing the top menu", {
+  withr::local_options(rlang_interactive = TRUE)
+  ran <- character(0)
+  local_mocked_bindings(
+    .eri_flow_cmr     = function() { ran <<- c(ran, "cmr"); invisible(NULL) },
+    .eri_flow_ingest  = function() { ran <<- c(ran, "ingest"); invisible(NULL) },
+    .eri_flow_odk     = function() { ran <<- c(ran, "odk"); invisible(NULL) },
+    .eri_flow_onboard = function() { ran <<- c(ran, "onboard"); invisible(NULL) },
+    .eri_prompt_menu  = function(...) stop("must not show the top menu -- a flow was named directly"),
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_do("cmr"))
+  expect_invisible(eri_do("ingest"))
+  expect_invisible(eri_do("odk"))
+  expect_invisible(eri_do("onboard"))
+  expect_equal(ran, c("cmr", "ingest", "odk", "onboard"))
+})
+
+test_that("eri_do(flow='review') jumps straight into the DQ-review shortcut", {
+  withr::local_options(rlang_interactive = TRUE)
+  reviewed <- NULL
+  local_mocked_bindings(
+    .eri_prompt_pick_country = function(...) "uga",
+    .eri_wizard_pick_period  = function(...) "202406",
+    eri_dq_review = function(country, period) { reviewed <<- c(country, period); invisible(NULL) },
+    .eri_prompt_menu = function(...) stop("must not show the top menu -- a flow was named directly"),
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_do("review"))
+  expect_equal(reviewed, c("uga", "202406"))
+})
+
+test_that("eri_do(flow=) is case/whitespace-insensitive and does not loop back to the menu", {
+  withr::local_options(rlang_interactive = TRUE)
+  cmr_calls <- 0L
+  local_mocked_bindings(
+    .eri_flow_cmr = function() { cmr_calls <<- cmr_calls + 1L; invisible(NULL) },
+    .eri_prompt_menu = function(...) stop("must not show the top menu after a deep-link flow finishes"),
+    .package = "erifunctions"
+  )
+  expect_invisible(eri_do("  CMR  "))
+  expect_equal(cmr_calls, 1L)
+})
+
+test_that("eri_do(flow=) errors clearly on an unrecognized flow name", {
+  withr::local_options(rlang_interactive = TRUE)
+  expect_error(eri_do("bogus"), "must be one of")
+})
+
+#### Phase D: onboarding overwrite protection ####
+
+test_that(".eri_flow_onboard_surveillance writes normally when no local schema file exists yet", {
+  withr::local_options(rlang_interactive = TRUE)
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  real_called <- FALSE
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_line = scripted(list("Atlantis")),
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_country = function(..., dry_run = FALSE) {
+      if (!dry_run) real_called <<- TRUE
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) TRUE,
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_surveillance())
+  expect_true(real_called)
+})
+
+test_that(".eri_flow_onboard_surveillance warns and re-confirms before overwriting an existing schema file", {
+  withr::local_options(rlang_interactive = TRUE)
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  writeLines("# a DA's in-progress schema edits", "atlantis_malaria_surveillance_aggregate.yaml")
+
+  confirm_prompts <- character(0)
+  real_called <- FALSE
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_line = scripted(list("Atlantis")),
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_country = function(..., dry_run = FALSE) {
+      if (!dry_run) real_called <<- TRUE
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(prompt) { confirm_prompts <<- c(confirm_prompts, prompt); TRUE },
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_surveillance())
+  expect_true(real_called)
+  expect_match(confirm_prompts[[1]], "Overwrite", fixed = TRUE)
+})
+
+test_that(".eri_flow_onboard_surveillance does not overwrite when the DA declines", {
+  withr::local_options(rlang_interactive = TRUE)
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  writeLines("# a DA's in-progress schema edits", "atlantis_malaria_surveillance_aggregate.yaml")
+
+  real_called <- FALSE
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_line = scripted(list("Atlantis")),
+    .eri_prompt_pick_or_type = function(...) "malaria",
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_country = function(..., dry_run = FALSE) {
+      if (!dry_run) real_called <<- TRUE
+      invisible(NULL)
+    },
+    .eri_wizard_confirm = function(...) FALSE,
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_surveillance())
+  expect_false(real_called)
+})
+
+test_that(".eri_flow_onboard_cmr warns before overwriting an existing CMR schema file", {
+  withr::local_options(rlang_interactive = TRUE)
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  writeLines("# existing CMR schema", "uga_cmr_schema.yaml")
+
+  confirm_prompts <- character(0)
+  local_mocked_bindings(
+    .eri_wizard_prompt_country_code = function(...) "uga",
+    .eri_prompt_line = scripted(list("Uganda")),
+    .eri_wizard_prompt_language = function(...) "en",
+    eri_onboard_cmr = function(...) invisible(NULL),
+    .eri_wizard_confirm = function(prompt) { confirm_prompts <<- c(confirm_prompts, prompt); TRUE },
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_cmr())
+  expect_match(confirm_prompts[[1]], "Overwrite", fixed = TRUE)
+})
+
+test_that(".eri_flow_onboard_disease warns once for two existing schema files (both types)", {
+  withr::local_options(rlang_interactive = TRUE)
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  writeLines("# existing", "atlantis_schisto_programmatic_treatment.yaml")
+  writeLines("# existing", "atlantis_schisto_research_prevalence.yaml")
+
+  confirm_prompts <- character(0)
+  local_mocked_bindings(
+    .eri_prompt_pick_or_type = function(...) "schisto",
+    .eri_wizard_prompt_country_code = function(...) "atlantis",
+    .eri_prompt_menu = scripted(list(1L)),  # "Both (MDA + prevalence)"
+    eri_onboard_disease = function(...) invisible(NULL),
+    .eri_wizard_confirm = function(prompt) { confirm_prompts <<- c(confirm_prompts, prompt); TRUE },
+    .package = "erifunctions"
+  )
+  expect_invisible(.eri_flow_onboard_disease())
+  expect_match(confirm_prompts[[1]], "Overwrite", fixed = TRUE)
+})

--- a/vignettes/da-do-guide.Rmd
+++ b/vignettes/da-do-guide.Rmd
@@ -73,6 +73,19 @@ Just run it from a live R console or RStudio, `eri_do()` refuses to run from `Rs
 eri_do()
 ```
 
+Always do the same task? Skip the top menu with `flow`:
+
+```{r launch-deep-link}
+eri_do("cmr")      # -> straight to the CMR flow
+eri_do("ingest")   # -> straight to surveillance ingest
+eri_do("odk")      # -> straight to ODK sync
+eri_do("onboard")  # -> straight to onboarding
+eri_do("review")   # -> straight to the DQ-review shortcut
+```
+
+Runs that one flow once and returns, it doesn't loop back into the menu afterward. An unrecognized
+name errors immediately, rather than silently falling through to the menu.
+
 ## The top-level menu {#top-menu}
 
 Most prompts in the wizard are numbered menus, type the number and press Enter, `0` goes back or
@@ -366,6 +379,18 @@ each have their own confirm wording; CMR's is shown):
 
 ```
 ── Write this CMR schema template and create the Azure folders?
+
+1: Yes
+2: No
+```
+
+Already onboarded this country and started filling in the TODOs? The wizard checks for the local
+schema file before writing and warns rather than silently overwriting your edits:
+
+```
+! Already exists here: 'atlantis_cmr_schema.yaml'
+
+── Overwrite with a fresh template? Any edits already made will be lost.
 
 1: Yes
 2: No


### PR DESCRIPTION
## Summary
- Adds `eri_do(flow = NULL)`: pass `"cmr"`, `"ingest"`, `"odk"`, `"onboard"`, or `"review"` to jump straight into that flow, skipping the top-level menu -- runs once and returns rather than looping back into the menu. An unrecognized name errors immediately. One shared dispatch table (`.ERI_DO_FLOWS`/`.eri_do_run_flow()`) backs both the menu and the deep-link so they can't quietly diverge.
- Re-audited the design consult's one-line Phase D scope ("progress-detection polish, `eri_do('cmr')` deep-links, feedback-on-confusing-flag") against what actually exists, the same discipline Phase C.3 applied to the doc-cutting plan:
  - "Feedback-on-confusing-flag" is already served by the existing `eri_dq_schema_submit()`/`eri_feedback()` machinery the DQ-review loop already exposes -- no new wizard hook needed.
  - Extending CMR's resume-detection pattern to ingest/ODK isn't real polish: ingest's period is free text with no fixed key until `eri_approve()` is actually called (a resume check would need new, fragile core logic just to guess at what would be approved), and ODK already effectively resumes via its "already registered" check.
- **Investigating "progress-detection" surfaced a genuine, previously-undiscovered gap instead**: `eri_onboard_country()`/`eri_onboard_cmr()`/`eri_onboard_disease()` all unconditionally overwrite an existing local schema file with a fresh blank template -- real data loss for a DA who re-runs onboarding after already filling in the TODOs. Added `.eri_wizard_confirm_onboard_write()` (a `file.exists()` check before the real write, no new core function) to all three onboarding sub-flows.
- `vignettes/da-do-guide.Rmd` updated with the `flow=` deep-link examples and the overwrite-protection transcript.

## Test plan
- [x] `tests/testthat/test-wizard.R` grown to 134 tests (+21): every `flow=` value routes correctly and skips the top menu, case/whitespace-insensitivity, the unrecognized-name error, and the overwrite check for each onboarding sub-flow (no-existing-file / existing-file-confirm / existing-file-decline).
- [x] A real bug the new tests caught (not manual review): `{.val {.ERI_DO_FLOWS}}` inside `cli::cli_abort()` errors in current `cli` since an interpolated expression starting with `.` is reserved for styles -- fixed by assigning to a plain local variable first.
- [x] Full suite: `devtools::test()` -- 0 failures, 2888 pass (pre-existing unrelated warnings only).
- [x] `devtools::document()` regenerated `man/eri_do.Rd` clean.

This closes out the interactive-wizard course correction end to end -- Phases A through D are all shipped after this merges.