### PR TITLE
fix(wizard): fix issues found by a live fresh-user trial of eri_do() (0.9.35)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.34
+Version: 0.9.35
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,38 @@
+# erifunctions 0.9.35
+
+## Fixes from a live fresh-user trial of eri_do()
+
+- After Phase D shipped, ran the `da-fresh-user` subagent ("Dana") live against the real `atlantis`
+  sandbox to actually exercise `eri_do()` and `vignettes/da-do-guide.Rmd`, not just re-read them --
+  the same "run it, don't just review it" discipline used for `da-dq-review-guide.Rmd` earlier this
+  session. Found real gaps a source-read alone hadn't surfaced:
+  - **The top-level menu reappears after every flow** (finished or cancelled) -- never stated
+    plainly in the guide, only implied by contrast in the deep-link section. A first-timer seeing
+    the menu again could reasonably wonder if something broke. Added a direct sentence.
+  - **Ingest's "Approve anyway?" gate checks the whole outstanding backlog for that
+    country/disease/channel/measure, not just the file you just brought in** -- live-confirmed a
+    perfectly clean ingest can still trigger it, because of an unrelated flag left over from an
+    earlier ingest into the same dataset. Clarified in both the wizard's own warning message and
+    the guide.
+  - **A real grammar bug**, faithfully reproduced in the guide because it came straight from live
+    output: `"1 log entry need review"` (should be "needs"). `cli`'s `{?y/ies}` pluralizes the noun
+    but not the verb -- fixed with `need{?s/}`.
+  - **The "Cancelling out" section over-promised**: it claimed every stopped flow "tells you so,"
+    but cancelling an early prompt (before anything's been staged/written) is silent by design --
+    nothing to report yet. Reworded to distinguish early (silent) cancels from later ones (which do
+    narrate what was left in place).
+  - Two comma-spliced opening sentences (in `getting-started.Rmd` and `da-do-guide.Rmd` itself)
+    copy-edited for a faster first read.
+  - `_pkgdown.yml`'s "Start here" reference group description now explicitly notes `eri_guide()` is
+    deprecated in favor of `eri_do()`, rather than relying solely on the lifecycle badge on its own
+    page rendering visibly in the group listing (unverified locally -- this machine's local
+    `pkgdown`/`knitr` article rendering segfaults regardless of content).
+- What Dana confirmed held up well, worth noting since it's the actual point of writing a guide
+  from source rather than live capture: every menu/prompt/confirmation transcript she checked live
+  (top menu, CMR country list, disease/channel/measure pick-lists, onboarding menus, `flow=`
+  deep-links, the invalid-flow error, the onboarding overwrite-protection prompt) matched
+  `da-do-guide.Rmd` almost verbatim.
+
 # erifunctions 0.9.34
 
 ## `eri_do(flow=)` deep links, and a real overwrite protection found along the way (Phase D of the interactive-wizard course correction)

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -454,7 +454,7 @@
     error = function(e) NULL
   )
   if (!is.null(open_logs) && nrow(open_logs) > 0L) {
-    cli::cli_alert_warning("{nrow(open_logs)} log entr{?y/ies} need review before this can be approved.")
+    cli::cli_alert_warning("{nrow(open_logs)} log entr{?y/ies} in the backlog for this dataset need{?s/} review before this can be approved.")
     cli::cli_bullets(c(
       "i" = "Run {.fn eri_logs} to see them, {.fn eri_dq_flag_resolve} to triage each flag, then {.fn eri_logs_resolve} to close the entry out."
     ))

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.34 · **Status:** Active development
+**Version:** 0.9.35 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -122,7 +122,8 @@ reference:
   desc: >
     Run these first, and reach for them whenever you're not sure what to call next. eri_do() is
     the guided front door -- pick a country and a file, answer a few prompts, and it runs the
-    pipeline for you; the rest are for browsing or for when you're calling the pieces yourself.
+    pipeline for you. eri_guide() is deprecated in its favor (see its own page); eri_task_map() is
+    the plain browsing list, for when you're calling the pieces yourself.
   contents:
   - eri_do
   - eri_guide

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -566,6 +566,22 @@ assigning to a plain local variable first, caught immediately by the "unrecogniz
 transcript. **This closes out the interactive-wizard course correction end to end — Phases A
 through D are all shipped.**
 
+**Post-ship validation, same session: the `da-fresh-user` subagent ran `eri_do()` live against the
+real `atlantis` sandbox, shipped as v0.9.35.** The same "run it, don't just re-read it" discipline
+`da-dq-review-guide.Rmd` got earlier this session, applied to the whole wizard + its new tour guide
+post-Phase-D. Found real gaps a hand-verified-from-source guide hadn't surfaced: the top menu
+reappearing after every flow was never stated plainly (only implied by contrast); ingest's "Approve
+anyway?" gate checks the whole outstanding backlog for a dataset, not just the file just brought
+in, live-confirmed to fire on a clean ingest because of an unrelated earlier flag; a real grammar
+bug (`cli`'s `{?y/ies}` pluralizes the noun but not the verb — "1 log entry need review" should be
+"needs") that the guide had faithfully reproduced straight from live output; and the "Cancelling
+out" section over-promising that every stopped flow narrates, when an early cancel (nothing staged
+yet) is silent by design. All fixed, plus two copy-edits and an explicit deprecation note on
+`eri_guide()` in `_pkgdown.yml`'s reference group description. What held up well and is worth
+protecting: every menu/prompt/confirmation transcript Dana checked live matched the guide almost
+verbatim — real validation that writing an interactive-function guide from source, then correcting
+with a live render pass, produces an accurate result.
+
 ---
 
 ## Phase 4: ODK live pilot (Uganda survey)

--- a/vignettes/da-do-guide.Rmd
+++ b/vignettes/da-do-guide.Rmd
@@ -20,9 +20,9 @@ knitr::opts_chunk$set(
 :::
 
 `eri_do()` is the guided console wizard: run it, pick what you're doing from a menu, and answer a
-few prompts, names you already know, files you already have, yes/no decisions, never a function
+few prompts -- names you already know, files you already have, yes/no decisions -- never a function
 name or an Azure path. This is a **tour of the wizard itself**: what its menu looks like, what each
-of its five paths asks you, and where they hand off. It is not a substitute for the role guides,
+of its five paths asks you, and where they hand off. It is not a substitute for the role guides --
 each pipeline still has its own guide for the domain knowledge (field codes, schema authoring, ODK
 app-user management) and real captured output that a short tour like this doesn't cover.
 
@@ -104,8 +104,10 @@ for the full convention. The top menu is five real tasks plus a shortcut into DQ
 6: Exit
 ```
 
-Pick a number, or `6` (or `0`) to leave the wizard entirely. The rest of this guide walks each
-path.
+Pick a number, or `6` (or `0`) to leave the wizard entirely. **This menu reappears after every
+flow** -- whether it finished, or you cancelled partway through -- so seeing it again isn't a
+sign anything went wrong; pick `6`/`0` again when you're actually done. The rest of this guide
+walks each path.
 
 ## 1. Bring this month's country report (CMR) {#cmr}
 
@@ -241,13 +243,15 @@ Which country is this data for? (e.g. sdn; blank to cancel): atlantis
 ```
 
 One call, [`eri_ingest()`](../reference/eri_ingest.html), does the archive + DQ-check + stage in a
-single shot, unlike CMR's multi-step upload/stage/split. If it finds open log entries afterward, it
-tells you and asks whether to approve anyway, rather than triaging them for you (surveillance's DQ
-flags land in the general [`eri_logs()`](../reference/eri_logs.html) backlog, not CMR's per-sheet
-shape):
+single shot, unlike CMR's multi-step upload/stage/split. Before approving, it checks the **whole**
+outstanding backlog for this country/disease/channel/measure, not just what you just brought in --
+so this can fire even on a perfectly clean file, if an earlier ingest into the same dataset left
+something unresolved. It tells you and asks whether to approve anyway, rather than triaging for you
+(surveillance's DQ flags land in the general [`eri_logs()`](../reference/eri_logs.html) backlog,
+not CMR's per-sheet shape):
 
 ```
-! 1 log entry need review before this can be approved.
+! 1 log entry in the backlog for this dataset needs review before this can be approved.
 ℹ Run `eri_logs()` to see them, `eri_dq_flag_resolve()` to triage each flag, then `eri_logs_resolve()` to close the entry out.
 
 ── Approve anyway? (only if you've already reviewed this)
@@ -447,9 +451,11 @@ and why.
 Every prompt in the wizard shares one convention: **`0`, or blank on a typed prompt, backs out**.
 Nothing is written until you reach a flow's own "Go ahead?"/"Write this...?" confirmation, so you
 can explore any menu, back out at any point, and re-run `eri_do()` later with nothing left half
-done. A flow that stops partway (declined a confirmation, or the DA cancelled) leaves whatever was
-already written in place and tells you so, run `eri_do()` again any time to pick up where you left
-off.
+done. Cancelling out of an early prompt (a country pick, a file dialog) is silent, there's nothing
+to report yet, so don't expect a message there. Once a flow has actually done something (staged a
+file, synced submissions) and then stops, either because you declined a later confirmation or a
+step failed, it tells you plainly what state things were left in and that running `eri_do()` again
+will pick up from there.
 
 ## What's next
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -81,7 +81,7 @@ The guides are short, copy-paste, run-it-live walkthroughs on safe sandbox data.
 For the paced version of this with checkpoints, follow the [**onboarding path**](onboarding.html), and
 keep the [**DA cheat sheet**](da-cheatsheet.html) and the [data-model card](data-model-card.html) open as
 you work. Once you're connected, **[`eri_do()`](../reference/eri_do.html)** is a guided console
-wizard that runs each pipeline below for you, decisions instead of function names, see the
+wizard that runs each pipeline below for you -- decisions instead of function names. See the
 [eri_do() tour](da-do-guide.html) for what its menu looks like.
 
 1. [Connecting to the services](connections-guide.html)


### PR DESCRIPTION
## Summary
Ran the `da-fresh-user` subagent ("Dana") live against the real `atlantis` sandbox to actually exercise `eri_do()` and `da-do-guide.Rmd` post-Phase-D, rather than just re-reading them -- the same discipline `da-dq-review-guide.Rmd` got earlier this session. Fixes what she found:

- **Document the top-menu loop-back**: the menu reappears after every flow (finished or cancelled) -- previously only implied by contrast in the deep-link section, which could read as something breaking.
- **Clarify ingest's "Approve anyway?" gate scope**: it checks the whole outstanding backlog for a country/disease/channel/measure, not just the file just brought in -- live-confirmed a clean ingest can still trigger it because of an unrelated earlier flag. Reworded in both `R/wizard.R`'s own message and the guide.
- **Fix a real grammar bug**: `cli`'s `{?y/ies}` pluralizes "log entry"/"log entries" but not the verb, so the singular case read "1 log entry need review" -- fixed with `need{?s/}`.
- **Soften an over-promise** in "Cancelling out": an early cancel (nothing staged yet) is silent by design, not narrated.
- Two copy-edits (comma-spliced `eri_do()` intro sentences), and an explicit deprecation note for `eri_guide()` in `_pkgdown.yml`'s reference group description.

What held up well, worth noting: every menu/prompt/confirmation transcript Dana checked live matched the guide almost verbatim -- real validation that source-verification + a live cli-render pass produces an accurate guide even without full live capture.

## Test plan
- [x] Full suite: `devtools::test()` -- 0 failures, 2888 pass (pre-existing unrelated warnings only).
- [x] Verified the corrected `cli` pluralization (`need{?s/}`) renders "needs"/"need" correctly for n=1/n=2 via a real render test.
- [x] `pkgdown::check_pkgdown()` validates cleanly; balanced `:::` divs confirmed in touched vignettes.