### PR TITLE
fix(odk): eri_odk_sync overwrites raw on zero-submission pulls (0.9.7) (#304)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.6
+Version: 0.9.7
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,13 @@
 - Set `overwrite = FALSE` to restore the old skip-and-warn behavior, e.g. if
   a 0-row pull might be a transient ODK API failure rather than a genuine
   deletion at the source.
+- **For forms with repeat groups, a zero-submission pull also deletes any
+  repeat table already in `raw/` that the pull didn't return** (ODK Central
+  can omit a repeat group's export CSV entirely once its parent has no
+  submissions). Without this, a repeat table's rows would keep pointing at
+  parent submissions that no longer exist. See
+  [ADR-0017](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0017-odk-zero-row-parent-clears-raw-set.md),
+  which amends ADR-0010 point 4.
 
 # erifunctions 0.9.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# erifunctions 0.9.7
+
+## Fix: eri_odk_sync() no longer leaves stale test data in Azure after a real ODK deletion
+
+- **`eri_odk_sync()` now overwrites the raw blob on a zero-submission pull by
+  default (`overwrite = TRUE`).** Previously, a 0-row ODK pull was always
+  treated as "nothing to do" and skipped writing to Azure entirely — the raw
+  Parquet from the last non-empty sync stayed in place. That meant a DA
+  deleting test/bad submissions in ODK Central and re-syncing would see
+  "Downloaded 0 records" but the dashboard/raw blob would keep showing the
+  deleted data, because nothing ever cleared it. Reported by a DA working
+  Uganda TAS-3, where a deleted-test-data re-sync silently left the stale
+  data in place (#303).
+- Set `overwrite = FALSE` to restore the old skip-and-warn behavior, e.g. if
+  a 0-row pull might be a transient ODK API failure rather than a genuine
+  deletion at the source.
+
 # erifunctions 0.9.6
 
 ## Docs: explain why Uganda's CMR routing has no CDD/CS/STH sheets

--- a/R/odk_sync.R
+++ b/R/odk_sync.R
@@ -12,7 +12,9 @@
 #' and each is written as its own Parquet (`{form_id}.parquet`,
 #' `{form_id}-{repeat}.parquet`, ...); a flat form writes a single
 #' `{form_id}.parquet`. The registry entry's `last_synced` timestamp is updated
-#' on success.
+#' on success. A pull that now returns zero submissions (e.g. all test data was
+#' deleted from ODK Central) overwrites raw with the empty result by default, so
+#' raw never silently goes stale relative to the source -- see `overwrite`.
 #'
 #' @param project_id `int` ODK Central project ID.
 #' @param form_id `str` ODK Central form ID (xmlFormId).
@@ -20,11 +22,15 @@
 #'   If `NULL`, falls back to the `ODK_URL` and `ODK_TOKEN` environment variables.
 #' @param data_con Azure container object for the `data/` blob. If `NULL`, connects
 #'   automatically using `ERIFUNCTIONS_*` environment variables.
-#' @param overwrite `lgl` Whether to overwrite an existing Parquet file in Azure.
-#'   Defaults to `TRUE`.
+#' @param overwrite `lgl` Whether a zero-submission pull overwrites (clears) an
+#'   existing raw Parquet file in Azure. Defaults to `TRUE`, so raw faithfully
+#'   mirrors the ODK source -- including a genuine deletion of all submissions
+#'   at the source. Set `FALSE` to instead skip the write and leave whatever is
+#'   already in Azure untouched, e.g. if a 0-row pull might be a transient ODK
+#'   API failure rather than a real deletion.
 #' @returns Invisibly, the downloaded tibble (single-table forms) or a named list
 #'   of tibbles (forms with repeat groups); `invisible(NULL)` when zero
-#'   submissions are found.
+#'   submissions are found and `overwrite = FALSE`.
 #' @examples
 #' \dontrun{
 #' con      <- init_odk_connection()
@@ -61,10 +67,10 @@ eri_odk_sync <- function(
   )
   main <- tabs[[1L]]
 
-  if (nrow(main) == 0L) {
+  if (nrow(main) == 0L && !overwrite) {
     cli::cli_warn(c(
       "No submissions found for {.val {form_id}}.",
-      "i" = "Nothing written to Azure."
+      "i" = "Nothing written to Azure ({.arg overwrite} = FALSE)."
     ))
     return(invisible(NULL))
   }
@@ -101,7 +107,11 @@ eri_odk_sync <- function(
   )
   .eri_write_log(op_log, data_con, paste0(country, "/", disease, "/research/logs"))
 
-  if (length(tabs) == 1L) {
+  if (nrow(main) == 0L) {
+    cli::cli_alert_warning(
+      "{.val {form_id}} now has 0 submissions in ODK -- raw blob at {.path {blob_paths[[1L]]}} cleared to match."
+    )
+  } else if (length(tabs) == 1L) {
     cli::cli_alert_success(
       "Synced {nrow(main)} record{?s} from {.val {form_id}} to {.path {blob_paths[[1L]]}}."
     )

--- a/R/odk_sync.R
+++ b/R/odk_sync.R
@@ -14,7 +14,11 @@
 #' `{form_id}.parquet`. The registry entry's `last_synced` timestamp is updated
 #' on success. A pull that now returns zero submissions (e.g. all test data was
 #' deleted from ODK Central) overwrites raw with the empty result by default, so
-#' raw never silently goes stale relative to the source -- see `overwrite`.
+#' raw never silently goes stale relative to the source -- see `overwrite`. Per
+#' [ADR-0010](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0010-odk-repeat-group-tables.md)
+#' point 3 (amended by ADR-0017), a form's tables move as one set: any repeat
+#' table already in `raw/` that a zero-row pull did not return is deleted too,
+#' so no orphaned child survives pointing at submissions that no longer exist.
 #'
 #' @param project_id `int` ODK Central project ID.
 #' @param form_id `str` ODK Central form ID (xmlFormId).
@@ -22,12 +26,17 @@
 #'   If `NULL`, falls back to the `ODK_URL` and `ODK_TOKEN` environment variables.
 #' @param data_con Azure container object for the `data/` blob. If `NULL`, connects
 #'   automatically using `ERIFUNCTIONS_*` environment variables.
-#' @param overwrite `lgl` Whether a zero-submission pull overwrites (clears) an
-#'   existing raw Parquet file in Azure. Defaults to `TRUE`, so raw faithfully
-#'   mirrors the ODK source -- including a genuine deletion of all submissions
-#'   at the source. Set `FALSE` to instead skip the write and leave whatever is
-#'   already in Azure untouched, e.g. if a 0-row pull might be a transient ODK
-#'   API failure rather than a real deletion.
+#' @param overwrite `lgl` Whether a zero-submission pull overwrites (clears) the
+#'   form's existing raw Parquet file(s) in Azure -- including deleting any
+#'   repeat table this pull did not return. Defaults to `TRUE`, so raw
+#'   faithfully mirrors the ODK source, including a genuine deletion of all
+#'   submissions at the source. Set `FALSE` to instead skip the write/delete
+#'   entirely and leave whatever is already in Azure untouched, e.g. if a 0-row
+#'   pull might be a transient ODK API failure rather than a real deletion.
+#'   Unlike `overwrite` elsewhere in the package (e.g. [eri_stage()], which
+#'   gates collision handling on a *non-empty* write), this `overwrite` only
+#'   ever fires on a *zero-row* pull -- a normal non-empty sync always writes
+#'   through regardless of this argument.
 #' @returns Invisibly, the downloaded tibble (single-table forms) or a named list
 #'   of tibbles (forms with repeat groups); `invisible(NULL)` when zero
 #'   submissions are found and `overwrite = FALSE`.
@@ -86,6 +95,24 @@ eri_odk_sync <- function(
     blob_paths <- c(blob_paths, bp)
   }
 
+  # ADR-0017: a zero-row parent means the whole set is now empty, but ODK
+  # Central's export may omit a repeat group's CSV entirely once its parent
+  # has no rows -- `tabs` would then never mention it. Sweep for any Parquet
+  # already in raw/ for this form_id that this pull did NOT return and delete
+  # it, so no orphaned child (PARENT_KEYs pointing at submissions that no
+  # longer exist) survives the clear.
+  deleted_paths <- character(0)
+  if (nrow(main) == 0L) {
+    existing <- eri_list(raw_dir, azure = TRUE, azcontainer = data_con)
+    own_table <- function(nm) {
+      identical(nm, paste0(form_id, ".parquet")) || startsWith(nm, paste0(form_id, "-"))
+    }
+    existing_own    <- existing$name[vapply(basename(existing$name), own_table, logical(1L))]
+    orphaned_own    <- setdiff(existing_own, blob_paths)
+    for (op in orphaned_own) eri_delete(op, azure = TRUE, azcontainer = data_con)
+    deleted_paths <- orphaned_own
+  }
+
   .odk_sync_update_last_synced(reg, data_con, project_id, form_id)
 
   op_log <- list(
@@ -99,18 +126,27 @@ eri_odk_sync <- function(
       disease     = disease,
       data_source = "research",
       format      = "odk",
-      n_records   = nrow(main),
-      n_tables    = length(tabs),
-      blob_paths  = as.list(blob_paths)
+      n_records     = nrow(main),
+      n_tables      = length(tabs),
+      blob_paths    = as.list(blob_paths),
+      deleted_paths = as.list(deleted_paths)
     ),
     status = "success"
   )
   .eri_write_log(op_log, data_con, paste0(country, "/", disease, "/research/logs"))
 
   if (nrow(main) == 0L) {
-    cli::cli_alert_warning(
-      "{.val {form_id}} now has 0 submissions in ODK -- raw blob at {.path {blob_paths[[1L]]}} cleared to match."
-    )
+    if (length(deleted_paths) > 0L) {
+      cli::cli_alert_warning(c(
+        "{.val {form_id}} now has 0 submissions in ODK -- raw cleared to match.",
+        "i" = "{length(blob_paths)} table{?s} written empty: {.path {blob_paths}}.",
+        "i" = "{length(deleted_paths)} orphaned repeat table{?s} removed: {.path {deleted_paths}}."
+      ))
+    } else {
+      cli::cli_alert_warning(
+        "{.val {form_id}} now has 0 submissions in ODK -- raw blob{?s} at {.path {blob_paths}} cleared to match."
+      )
+    }
   } else if (length(tabs) == 1L) {
     cli::cli_alert_success(
       "Synced {nrow(main)} record{?s} from {.val {form_id}} to {.path {blob_paths[[1L]]}}."

--- a/R/odk_sync.R
+++ b/R/odk_sync.R
@@ -16,8 +16,8 @@
 #' deleted from ODK Central) overwrites raw with the empty result by default, so
 #' raw never silently goes stale relative to the source -- see `overwrite`. Per
 #' [ADR-0010](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0010-odk-repeat-group-tables.md)
-#' point 3 (amended by ADR-0017), a form's tables move as one set: any repeat
-#' table already in `raw/` that a zero-row pull did not return is deleted too,
+#' point 4 (amended by ADR-0017), a zero-row parent clears the whole set: any
+#' repeat table already in `raw/` that this pull did not return is deleted too,
 #' so no orphaned child survives pointing at submissions that no longer exist.
 #'
 #' @param project_id `int` ODK Central project ID.

--- a/docs/adr/0010-odk-repeat-group-tables.md
+++ b/docs/adr/0010-odk-repeat-group-tables.md
@@ -1,6 +1,6 @@
 # ADR-0010 — ODK repeat groups land as a relational set of tables, approved together
 
-- **Status:** Accepted
+- **Status:** Accepted — point 4 amended by [ADR-0017](0017-odk-zero-row-parent-clears-raw-set.md)
 - **Date:** 2026-06-26
 
 ## Context
@@ -47,7 +47,9 @@ Parquet per ODK export table — and that set is the unit that moves through the
 
 4. **No parents, no set.** If the parent table has zero rows, nothing is written (the existing
    warn-and-return behavior) — children cannot exist without parents, so an empty parent means an
-   empty sync.
+   empty sync. *(Amended by [ADR-0017](0017-odk-zero-row-parent-clears-raw-set.md): this is now the
+   `overwrite = FALSE` behavior only. By default (`overwrite = TRUE`), a zero-row parent instead
+   clears the whole raw set — parent and any orphaned children — to match the source.)*
 
 ## Consequences
 

--- a/docs/adr/0017-odk-zero-row-parent-clears-raw-set.md
+++ b/docs/adr/0017-odk-zero-row-parent-clears-raw-set.md
@@ -14,8 +14,9 @@ In practice it has the opposite failure mode: it also treats a **genuine deletio
 source** as nothing-to-do. A DA who deletes test/bad submissions in ODK Central and re-syncs sees
 "0 records downloaded" (proof the deletion worked), but `eri_odk_sync()` skips the Azure write
 entirely — the raw Parquet(s) from the last non-empty sync stay in place, silently feeding stale
-data to anything reading `raw/` (a survey dashboard, in the reported case: Uganda TAS-3, where a
-DA's confirmed-empty resync left 23/19/16/27 stale rows sitting in Azure across four tables).
+data to anything reading `raw/` (a survey dashboard, in the reported case: issue #303, Uganda
+TAS-3 — a live-blob audit during remediation confirmed 23/19/16/27 stale rows still sitting in
+Azure across four tables, despite the DA's resync having confirmed 0 records at the source).
 `overwrite = TRUE` was already a parameter on `eri_odk_sync()`, documented as "whether to
 overwrite an existing Parquet file," but was never wired to this decision.
 

--- a/docs/adr/0017-odk-zero-row-parent-clears-raw-set.md
+++ b/docs/adr/0017-odk-zero-row-parent-clears-raw-set.md
@@ -1,0 +1,62 @@
+# ADR-0017 — A zero-row ODK parent clears the whole raw set, by default
+
+- **Status:** Accepted — amends [ADR-0010](0010-odk-repeat-group-tables.md) point 4
+- **Date:** 2026-07-14
+
+## Context
+
+ADR-0010 point 4 says: *"If the parent table has zero rows, nothing is written (the existing
+warn-and-return behavior) — children cannot exist without parents, so an empty parent means an
+empty sync."* That was written to guard against a transient ODK Central API failure being
+mistaken for real data loss and silently wiping a good raw set.
+
+In practice it has the opposite failure mode: it also treats a **genuine deletion at the ODK
+source** as nothing-to-do. A DA who deletes test/bad submissions in ODK Central and re-syncs sees
+"0 records downloaded" (proof the deletion worked), but `eri_odk_sync()` skips the Azure write
+entirely — the raw Parquet(s) from the last non-empty sync stay in place, silently feeding stale
+data to anything reading `raw/` (a survey dashboard, in the reported case: Uganda TAS-3, where a
+DA's confirmed-empty resync left 23/19/16/27 stale rows sitting in Azure across four tables).
+`overwrite = TRUE` was already a parameter on `eri_odk_sync()`, documented as "whether to
+overwrite an existing Parquet file," but was never wired to this decision.
+
+## Decision
+
+`eri_odk_sync(..., overwrite = TRUE)` (the default) now treats a zero-row parent pull as **the
+current true state of the source**, not a suspected failure, and clears the entire raw set for
+that form to match:
+
+1. Every table returned by the pull (normally just the parent, since a form with a 0-row parent
+   has no submissions to have repeat instances) is written through as-is, including empty.
+2. **Any table already in `raw/` for this `form_id` that the pull did *not* return — a repeat
+   group whose export CSV ODK Central omits once its parent is empty — is deleted**, not left
+   behind. This is the direct extension of ADR-0010 point 3 ("the parent and all its children move
+   together... you never approve a parent without its children, or vice versa") into the
+   zero-row case: a surviving child Parquet with `PARENT_KEY`s pointing at submissions that no
+   longer exist is exactly the orphaned-relational-set state ADR-0010 exists to prevent, just
+   reached from the empty-parent direction instead of a partial-sync failure.
+3. `overwrite = FALSE` restores ADR-0010 point 4's original behavior verbatim (skip and warn,
+   touch nothing in Azure) for a DA who has reason to suspect a transient API failure rather than
+   a real deletion, and wants to protect the existing raw set until they've confirmed which it is.
+
+Points 1–3 of ADR-0010 (lossless relational shape, relationship lives in `PARENT_KEY`/`KEY` not
+file order, a form's tables approve as one set) are unchanged and still govern the non-empty case.
+
+## Consequences
+
+- **Easier:** `raw/` no longer silently diverges from ODK Central. A DA's delete-and-resync
+  workflow (cleaning up test data, correcting a bad submission batch) now does what it looks like
+  it does, without a manual blob cleanup step.
+- **Harder / accepted:** a transient ODK Central failure that happens to return 0 rows will, under
+  the new default, clear a real raw set. This is the tradeoff ADR-0010 point 4 was written to
+  avoid; `overwrite = FALSE` is the escape hatch for a DA who wants the old guard, but it is opt-in
+  now rather than the default. Azure blob deletes are not soft — there is no undo below whatever
+  retention/versioning the storage account itself provides.
+- **Not doing:** validating *why* the pull returned zero rows (e.g. distinguishing "ODK confirms 0
+  submissions" from "the API call degraded to an empty response") — ODK Central's submissions
+  export does not currently give `download_odk_form()` a signal to tell those apart. If that
+  changes, this ADR should be revisited rather than the distinction bolted on top of `overwrite`.
+
+## References
+
+- ADR-0010 — the relational-set model this amends point 4 of.
+- Issue #303 / PR #304 — the reported bug and fix.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,9 +47,11 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0007](0007-research-aware-spatial-sourcing.md) | Research-aware spatial sourcing via a `cache` flag | Accepted |
 | [0008](0008-baked-azure-auth-defaults.md) | Baked-in Azure auth defaults; interactive AAD as the zero-config default | Accepted |
 | [0009](0009-research-data-lifecycle.md) | Research-data lifecycle: Azure is the source, the project is the versioned working copy | Accepted |
-| [0010](0010-odk-repeat-group-tables.md) | ODK repeat groups land as a relational set of tables, approved together | Accepted |
+| [0010](0010-odk-repeat-group-tables.md) | ODK repeat groups land as a relational set of tables, approved together | Accepted — point 4 amended by ADR-0017 |
 | [0011](0011-unified-schema-naming.md) | One vocabulary for addressing data and schemas (unified schema naming) | Superseded by ADR-0012 |
 | [0012](0012-source-measure-data-model.md) | Data is addressed by source *and* measure (the 5-axis path model) | Accepted |
 | [0013](0013-odk-submission-backfill.md) | Submission backfill: erifunctions writes records *into* ODK Central | Accepted |
 | [0014](0014-feedback-ticket-log.md) | In-package feedback / ticket log in the `data/` blob | Accepted |
 | [0015](0015-hsp-mal-cutover-criteria.md) | hsp-mal cutover criteria: N consecutive periods of equivalence | Accepted |
+| [0016](0016-metadata-conditional-writes-blob-endpoint.md) | Conditional metadata writes go through the blob endpoint | Accepted |
+| [0017](0017-odk-zero-row-parent-clears-raw-set.md) | A zero-row ODK parent clears the whole raw set, by default | Accepted — amends ADR-0010 point 4 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,7 +14,7 @@ Each record is a numbered file, `NNNN-short-title.md`, with these sections:
 ```markdown
 # ADR-NNNN — Title
 
-- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX | Accepted — point N amended by ADR-XXXX
 - **Date:** YYYY-MM-DD
 
 ## Context
@@ -31,7 +31,13 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 
 - One decision per file. Keep it short.
 - ADRs are append-only: don't rewrite an accepted ADR to change its meaning — add a new ADR
-  that supersedes it and update the old one's status.
+  that supersedes or amends it, and update the old one's status.
+  - **Supersede** when the new ADR replaces the old decision wholesale (the old one's status
+    becomes `Superseded by ADR-XXXX`).
+  - **Amend** when the new ADR revises a single point within an otherwise-still-valid ADR (the
+    old one's status becomes `Accepted — point N amended by ADR-XXXX`, and that point gets an
+    inline note pointing to the amendment). Prefer this over a full supersession when most of the
+    original ADR still holds.
 - Link the ADR from the roadmap when it shapes a phase.
 
 ## Index

--- a/man/eri_odk_sync.Rd
+++ b/man/eri_odk_sync.Rd
@@ -55,8 +55,8 @@ on success. A pull that now returns zero submissions (e.g. all test data was
 deleted from ODK Central) overwrites raw with the empty result by default, so
 raw never silently goes stale relative to the source -- see \code{overwrite}. Per
 \href{https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0010-odk-repeat-group-tables.md}{ADR-0010}
-point 3 (amended by ADR-0017), a form's tables move as one set: any repeat
-table already in \verb{raw/} that a zero-row pull did not return is deleted too,
+point 4 (amended by ADR-0017), a zero-row parent clears the whole set: any
+repeat table already in \verb{raw/} that this pull did not return is deleted too,
 so no orphaned child survives pointing at submissions that no longer exist.
 }
 \examples{

--- a/man/eri_odk_sync.Rd
+++ b/man/eri_odk_sync.Rd
@@ -23,13 +23,17 @@ If \code{NULL}, falls back to the \code{ODK_URL} and \code{ODK_TOKEN} environmen
 \item{data_con}{Azure container object for the \verb{data/} blob. If \code{NULL}, connects
 automatically using \verb{ERIFUNCTIONS_*} environment variables.}
 
-\item{overwrite}{\code{lgl} Whether to overwrite an existing Parquet file in Azure.
-Defaults to \code{TRUE}.}
+\item{overwrite}{\code{lgl} Whether a zero-submission pull overwrites (clears) an
+existing raw Parquet file in Azure. Defaults to \code{TRUE}, so raw faithfully
+mirrors the ODK source -- including a genuine deletion of all submissions
+at the source. Set \code{FALSE} to instead skip the write and leave whatever is
+already in Azure untouched, e.g. if a 0-row pull might be a transient ODK
+API failure rather than a real deletion.}
 }
 \value{
 Invisibly, the downloaded tibble (single-table forms) or a named list
 of tibbles (forms with repeat groups); \code{invisible(NULL)} when zero
-submissions are found.
+submissions are found and \code{overwrite = FALSE}.
 }
 \description{
 Downloads all submissions for a registered ODK form and writes them as
@@ -42,7 +46,9 @@ tables -- the main submission table plus one child table per repeat group --
 and each is written as its own Parquet (\verb{\{form_id\}.parquet},
 \verb{\{form_id\}-\{repeat\}.parquet}, ...); a flat form writes a single
 \verb{\{form_id\}.parquet}. The registry entry's \code{last_synced} timestamp is updated
-on success.
+on success. A pull that now returns zero submissions (e.g. all test data was
+deleted from ODK Central) overwrites raw with the empty result by default, so
+raw never silently goes stale relative to the source -- see \code{overwrite}.
 }
 \examples{
 \dontrun{

--- a/man/eri_odk_sync.Rd
+++ b/man/eri_odk_sync.Rd
@@ -23,12 +23,17 @@ If \code{NULL}, falls back to the \code{ODK_URL} and \code{ODK_TOKEN} environmen
 \item{data_con}{Azure container object for the \verb{data/} blob. If \code{NULL}, connects
 automatically using \verb{ERIFUNCTIONS_*} environment variables.}
 
-\item{overwrite}{\code{lgl} Whether a zero-submission pull overwrites (clears) an
-existing raw Parquet file in Azure. Defaults to \code{TRUE}, so raw faithfully
-mirrors the ODK source -- including a genuine deletion of all submissions
-at the source. Set \code{FALSE} to instead skip the write and leave whatever is
-already in Azure untouched, e.g. if a 0-row pull might be a transient ODK
-API failure rather than a real deletion.}
+\item{overwrite}{\code{lgl} Whether a zero-submission pull overwrites (clears) the
+form's existing raw Parquet file(s) in Azure -- including deleting any
+repeat table this pull did not return. Defaults to \code{TRUE}, so raw
+faithfully mirrors the ODK source, including a genuine deletion of all
+submissions at the source. Set \code{FALSE} to instead skip the write/delete
+entirely and leave whatever is already in Azure untouched, e.g. if a 0-row
+pull might be a transient ODK API failure rather than a real deletion.
+Unlike \code{overwrite} elsewhere in the package (e.g. \code{\link[=eri_stage]{eri_stage()}}, which
+gates collision handling on a \emph{non-empty} write), this \code{overwrite} only
+ever fires on a \emph{zero-row} pull -- a normal non-empty sync always writes
+through regardless of this argument.}
 }
 \value{
 Invisibly, the downloaded tibble (single-table forms) or a named list
@@ -48,7 +53,11 @@ and each is written as its own Parquet (\verb{\{form_id\}.parquet},
 \verb{\{form_id\}.parquet}. The registry entry's \code{last_synced} timestamp is updated
 on success. A pull that now returns zero submissions (e.g. all test data was
 deleted from ODK Central) overwrites raw with the empty result by default, so
-raw never silently goes stale relative to the source -- see \code{overwrite}.
+raw never silently goes stale relative to the source -- see \code{overwrite}. Per
+\href{https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0010-odk-repeat-group-tables.md}{ADR-0010}
+point 3 (amended by ADR-0017), a form's tables move as one set: any repeat
+table already in \verb{raw/} that a zero-row pull did not return is deleted too,
+so no orphaned child survives pointing at submissions that no longer exist.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-odk_sync.R
+++ b/tests/testthat/test-odk_sync.R
@@ -71,8 +71,9 @@ test_that("eri_odk_sync overwrites raw with the empty result on zero submissions
   store <- new_yaml_store(make_sync_reg(entry))
   local_yaml_store(store)
 
-  written_path <- NULL
-  written_obj  <- NULL
+  written_path  <- NULL
+  written_obj   <- NULL
+  deleted_paths <- character(0)
 
   local_mocked_bindings(
     .eri_log_session   = function(...) invisible(NULL),
@@ -83,6 +84,8 @@ test_that("eri_odk_sync overwrites raw with the empty result on zero submissions
       written_path <<- file_loc
       invisible(NULL)
     },
+    eri_list = function(...) tibble::tibble(name = "uga/oncho/research/raw/RiverProspection.parquet"),
+    eri_delete = function(file_loc, ...) { deleted_paths <<- c(deleted_paths, file_loc) },
     .eri_write_log = function(...) invisible(NULL),
     .package = "erifunctions"
   )
@@ -96,6 +99,38 @@ test_that("eri_odk_sync overwrites raw with the empty result on zero submissions
   expect_equal(nrow(written_obj), 0L)
   expect_false(is.null(store$data$forms[[1]]$last_synced))
   expect_equal(nrow(result), 0L)
+  # the only existing raw file is the one this pull just re-wrote -- nothing orphaned
+  expect_length(deleted_paths, 0L)
+})
+
+test_that("eri_odk_sync deletes an orphaned repeat table when the parent goes to zero rows", {
+  entry <- make_sync_entry(form_id = "RiverRepeat")
+  store <- new_yaml_store(make_sync_reg(entry))
+  local_yaml_store(store)
+
+  written_paths <- character(0)
+  deleted_paths <- character(0)
+
+  local_mocked_bindings(
+    .eri_log_session   = function(...) invisible(NULL),
+    .odk_registry_read = function(data_con) store$data,
+    # simulate ODK Central omitting the repeat group's CSV once the parent is empty
+    download_odk_form  = function(...) list(RiverRepeat = tibble::tibble()),
+    eri_write = function(obj, file_loc, ...) { written_paths <<- c(written_paths, file_loc) },
+    # the repeat table from the last non-empty sync is still sitting in raw/
+    eri_list = function(...) tibble::tibble(name = c(
+      "uga/oncho/research/raw/RiverRepeat.parquet",
+      "uga/oncho/research/raw/RiverRepeat-larva_sample.parquet"
+    )),
+    eri_delete = function(file_loc, ...) { deleted_paths <<- c(deleted_paths, file_loc) },
+    .eri_write_log = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+
+  eri_odk_sync(project_id = 7L, form_id = "RiverRepeat", data_con = "mock")
+
+  expect_equal(written_paths, "uga/oncho/research/raw/RiverRepeat.parquet")
+  expect_equal(deleted_paths, "uga/oncho/research/raw/RiverRepeat-larva_sample.parquet")
 })
 
 test_that("eri_odk_sync(overwrite = FALSE) warns and leaves Azure untouched on zero submissions", {

--- a/tests/testthat/test-odk_sync.R
+++ b/tests/testthat/test-odk_sync.R
@@ -66,7 +66,39 @@ test_that("eri_odk_sync errors when matching entry is inactive", {
 
 # --- zero submissions ---------------------------------------------------------
 
-test_that("eri_odk_sync warns and returns invisible NULL on zero submissions", {
+test_that("eri_odk_sync overwrites raw with the empty result on zero submissions (default)", {
+  entry <- make_sync_entry()
+  store <- new_yaml_store(make_sync_reg(entry))
+  local_yaml_store(store)
+
+  written_path <- NULL
+  written_obj  <- NULL
+
+  local_mocked_bindings(
+    .eri_log_session   = function(...) invisible(NULL),
+    .odk_registry_read = function(data_con) store$data,
+    download_odk_form  = function(...) list(RiverProspection = tibble::tibble()),
+    eri_write = function(obj, file_loc, ...) {
+      written_obj  <<- obj
+      written_path <<- file_loc
+      invisible(NULL)
+    },
+    .eri_write_log = function(...) invisible(NULL),
+    .package = "erifunctions"
+  )
+
+  result <- eri_odk_sync(
+    project_id = 7L, form_id = "RiverProspection",
+    data_con = "mock"
+  )
+
+  expect_equal(written_path, "uga/oncho/research/raw/RiverProspection.parquet")
+  expect_equal(nrow(written_obj), 0L)
+  expect_false(is.null(store$data$forms[[1]]$last_synced))
+  expect_equal(nrow(result), 0L)
+})
+
+test_that("eri_odk_sync(overwrite = FALSE) warns and leaves Azure untouched on zero submissions", {
   entry       <- make_sync_entry()
   reg         <- make_sync_reg(entry)
   eri_written <- FALSE
@@ -87,7 +119,7 @@ test_that("eri_odk_sync warns and returns invisible NULL on zero submissions", {
   expect_warning(
     result <- eri_odk_sync(
       project_id = 7L, form_id = "RiverProspection",
-      data_con = "mock"
+      data_con = "mock", overwrite = FALSE
     ),
     "No submissions"
   )


### PR DESCRIPTION
## Summary
- `eri_odk_sync()` previously skipped writing to Azure entirely on a 0-row ODK pull, so a real deletion at the ODK source never propagated to the raw blob — only a transient-failure guard, but it silently left stale data in place downstream.
- `overwrite = TRUE` (new default) now writes the empty result through to raw, so raw faithfully mirrors the source. `overwrite = FALSE` restores the old skip-and-warn behavior for a suspected transient API failure.
- Wires up the `overwrite` param, which was previously declared in the signature/docs but never referenced in the function body.

Fixes #303 — reported by a DA who deleted test submissions for Uganda TAS-3 in ODK Central, re-synced (confirmed 0 records downloaded), but the dashboard kept showing the deleted test data because the stale raw Parquet was never cleared.

## Test plan
- [x] `devtools::test()` — full suite green (0 fail), including new `test-odk_sync.R` coverage for both `overwrite = TRUE` (writes empty result, updates last_synced) and `overwrite = FALSE` (old skip-and-warn behavior preserved)
- [x] `devtools::document()` — man page regenerated for the updated `overwrite`/`@returns` docs
- [ ] review-agent pass