### PR TITLE
feat(data-model): enforce canonical lowercase country/disease codes (0.9.37) (#306)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.36
+Version: 0.9.37
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# erifunctions 0.9.37
+
+## Enforce canonical, lowercase country/disease codes (ADR-0020)
+
+- **`country`/`disease` are now normalized (lowercase + trim) and validated against a
+  registry, closing the gap that let `uga/LF`/`eth/RB` (legacy-cased paths) get
+  created in the first place (#303).** `inst/registry/data_model.yaml` gains
+  `countries:`/`diseases:` sections, matching the existing extensible `data_sources:`/
+  `data_types:` pattern (an unregistered value warns, never blocks).
+- **`eri_data_path()`** — the shared chokepoint nearly every write in the package
+  routes through — now normalizes `country`/`disease` before building the path, so
+  `"UGA"`/`"uga"`/`" Uga "` all produce the same canonical path.
+- **`eri_odk_register()`** normalizes both before validating: `country` keeps its
+  hard-abort on a genuinely unknown code (now case-insensitive, so `"UGA"` is
+  silently corrected instead of erroring on case alone); `disease` gets a soft
+  warning, not a hard error, since new disease programs can legitimately appear
+  over time.
+- Removed two independent, hardcoded country/disease lists (`R/odk_registry.R`'s
+  `.KNOWN_COUNTRY_CODES`, `R/wizard.R`'s `.KNOWN_DISEASES`) that could already drift
+  from each other; `eri_data_model()` now shows `country`/`disease` alongside the
+  other three axes.
+- See [ADR-0020](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0020-canonical-country-disease-codes.md).
+
 # erifunctions 0.9.36
 
 ## Fix: eri_odk_sync() no longer leaves stale test data in Azure after a real ODK deletion

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,20 @@
   `.KNOWN_COUNTRY_CODES`, `R/wizard.R`'s `.KNOWN_DISEASES`) that could already drift
   from each other; `eri_data_model()` now shows `country`/`disease` alongside the
   other three axes.
-- See [ADR-0020](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0020-canonical-country-disease-codes.md).
+- **`eri_approve()`, `eri_stage()`, `eri_ingest()`, `eri_dq_log()`, `eri_split_cmr()`,
+  `eri_stage_cmr()`, and `eri_approve_cmr()` also normalize `country`/`disease` at
+  their own entry point**, not just via `eri_data_path()`. Each of these hand-builds
+  a log directory alongside the `eri_data_path()`-derived staged/processed/raw dir in
+  the same call; without normalizing both from the same value, the log could still
+  land at a differently-cased sibling path (e.g. `UGA/LF/.../logs/` next to
+  `uga/lf/.../processed/`) — the same failure class as #303, one hop away.
+- The `atlantis` training sandbox (needed for `eri_data_path()`'s general validation,
+  used by CMR/DQ sandbox testing) is excluded from `eri_odk_register()`'s
+  hard-validated country set and the ODK wizard's country picker — ODK registration
+  is production-only and already has its own sandbox convention (`uga`/`demo`).
+- See [ADR-0020](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0020-canonical-country-disease-codes.md)
+  (amends [ADR-0012](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0012-source-measure-data-model.md)
+  point 5).
 
 # erifunctions 0.9.36
 

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -283,6 +283,10 @@ eri_split_cmr <- function(path, country, data_con = NULL,
                           mirror_pipeline = NULL, period = NULL,
                           projects_con = NULL, supersede_staged = FALSE) {
   if (!dry_run) .eri_log_session()
+  # ADR-0020: normalize once, up front -- the country_map/schema lookups and
+  # the hand-built log_dir (there's no per-disease data path here; the run
+  # splits into several) all need to agree.
+  country <- .eri_normalize_geo_axis("country", country, .eri_known_countries())
   if (!file.exists(path)) {
     cli::cli_abort("File not found: {.path {path}}")
   }
@@ -776,6 +780,10 @@ eri_cmr_last_plan <- function(country, period, data_con = NULL) {
 #' @export
 eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
                             force = FALSE, justification = NULL) {
+  # ADR-0020: normalize once, up front -- eri_cmr_last_plan()'s lookup and
+  # the hand-built log_dir below both need to agree.
+  country <- .eri_normalize_geo_axis("country", country, .eri_known_countries())
+
   if (isTRUE(force) &&
       (is.null(justification) || length(justification) != 1L ||
        is.na(justification) || !nzchar(trimws(justification)))) {
@@ -1085,6 +1093,9 @@ eri_stage_cmr <- function(country,
                            projects_con = NULL,
                            data_con     = NULL) {
   .eri_log_session()
+  # ADR-0020: normalize once, up front -- the country_map lookup below,
+  # eri_data_path(), and the hand-built log_dir all need to agree.
+  country <- .eri_normalize_geo_axis("country", country, .eri_known_countries())
 
   reg <- .eri_pipeline_registry[["rb-expansion"]]
 

--- a/R/dal.R
+++ b/R/dal.R
@@ -998,6 +998,12 @@ eri_data_path <- function(country, disease, data_source, data_type, layer, filen
 eri_approve <- function(country, disease, data_source, period, data_type = NULL, azcontainer = NULL) {
   .eri_log_session()
   .eri_note_no_measure(data_type)
+  # ADR-0020: normalize once, up front, so every path built below from these
+  # locals -- eri_data_path() calls AND the hand-built log_dir -- agrees.
+  # eri_data_path() would otherwise normalize only its own internal copy.
+  model   <- .eri_data_model()
+  country <- .eri_normalize_geo_axis("country", country, names(model$countries))
+  disease <- .eri_normalize_geo_axis("disease", disease, names(model$diseases))
   if (is.null(azcontainer)) {
     azcontainer <- suppressMessages(
       get_azure_storage_connection(
@@ -1254,6 +1260,11 @@ eri_stage <- function(pipeline, country, disease,
                       projects_con = NULL,
                       data_con = NULL) {
   .eri_log_session()
+  # ADR-0020: normalize once, up front -- the country_map lookup below,
+  # eri_data_path(), and the hand-built log_dir all need to agree.
+  model   <- .eri_data_model()
+  country <- .eri_normalize_geo_axis("country", country, names(model$countries))
+  disease <- .eri_normalize_geo_axis("disease", disease, names(model$diseases))
 
   reg <- .eri_pipeline_registry[[pipeline]]
   if (is.null(reg)) {
@@ -1442,6 +1453,11 @@ eri_ingest <- function(path, country, disease,
                        mirror_pipeline = NULL,
                        projects_con = NULL) {
   .eri_log_session()
+  # ADR-0020: normalize once, up front -- the mirror's country_map lookup
+  # below, eri_data_path(), and the hand-built log_dir all need to agree.
+  model   <- .eri_data_model()
+  country <- .eri_normalize_geo_axis("country", country, names(model$countries))
+  disease <- .eri_normalize_geo_axis("disease", disease, names(model$diseases))
 
   if (!file.exists(path)) {
     cli::cli_abort("File not found: {.path {path}}")

--- a/R/dal.R
+++ b/R/dal.R
@@ -865,8 +865,15 @@ eri_upload <- function(local_path, file_loc, azcontainer = NULL) {
 #' measure-less `{country}/{disease}/{data_source}/{layer}/` path — detected because
 #' its fourth argument is a `layer` keyword (a `data_type` measure never is).
 #'
-#' @param country `str` Country code (e.g. `"dr"`, `"ht"`, `"uga"`).
-#' @param disease `str` Disease name (e.g. `"malaria"`, `"lf"`, `"oncho"`).
+#' `country` and `disease` are normalized (lowercase + trim) before the path is
+#' built, so `"UGA"`/`"uga"`/`" Uga "` all produce the same canonical path
+#' (ADR-0020) — this is what prevents legacy-cased paths like the `LF`/`lf`
+#' drift found and fixed in issue #303 from recurring.
+#'
+#' @param country `str` Country code (e.g. `"dr"`, `"ht"`, `"uga"`; extensible —
+#'   see [eri_data_model()]; unknown values warn, not error).
+#' @param disease `str` Disease name (e.g. `"malaria"`, `"lf"`, `"oncho"`; extensible;
+#'   unknown values warn).
 #' @param data_source `str` The channel: `"surveillance"`, `"programmatic"`,
 #'   `"research"` (extensible — see [eri_data_model()]; unknown values warn).
 #' @param data_type `str` The measure: `"case"`, `"aggregate"`, `"treatment"`,
@@ -886,6 +893,11 @@ eri_data_path <- function(country, disease, data_source, data_type, layer, filen
   model         <- .eri_data_model()
   valid_layers  <- .eri_layers()
   known_sources <- names(model$data_sources)
+
+  # ADR-0020: always build the path from the canonical lowercase country/disease
+  # form, regardless of input casing -- the fix for the `LF`/`lf` drift (#303).
+  country <- .eri_normalize_geo_axis("country", country, names(model$countries))
+  disease <- .eri_normalize_geo_axis("disease", disease, names(model$diseases))
 
   # Capture which arguments were actually supplied before any reassignment.
   # An explicit NULL `data_type` is treated as "no measure" (the 4-axis form), so

--- a/R/data_model.R
+++ b/R/data_model.R
@@ -31,6 +31,28 @@
   invisible(value)
 }
 
+# Known country codes, from the bundled registry. A function (not a top-level
+# constant) so no file I/O happens at package-load time -- .eri_data_model()
+# is deliberately "read on demand."
+#' @keywords internal
+.eri_known_countries <- function() names(.eri_data_model()$countries)
+
+# Known disease codes, from the bundled registry. Same lazy-read rationale.
+#' @keywords internal
+.eri_known_diseases <- function() names(.eri_data_model()$diseases)
+
+# Normalize a country/disease code (lowercase + trim) and soft-warn via
+# .eri_check_axis() if the normalized value isn't in the known registry list
+# (ADR-0020). Returns the normalized value, so a path is always built from the
+# canonical form regardless of input casing -- this is what prevents the
+# `LF`/`lf` legacy-casing drift (#303) from recurring.
+#' @keywords internal
+.eri_normalize_geo_axis <- function(axis, value, known) {
+  normalized <- tolower(trimws(value))
+  .eri_check_axis(axis, normalized, known)
+  normalized
+}
+
 #' Show the data-addressing model: known sources, measures and formats
 #'
 #' @description
@@ -38,9 +60,11 @@
 #'
 #' Prints (and returns invisibly) the registry of known values for the five-axis
 #' canonical path `data/{country}/{disease}/{data_source}/{data_type}/{layer}/`
-#' (ADR-0012): the `data_source` channels, the `data_type` measures, the input
-#' `format`s, and the pipeline `layer`s. New sources/measures are added to the
-#' registry by onboarding; an unregistered value warns rather than errors.
+#' (ADR-0012): the `country` codes, `disease` codes, `data_source` channels,
+#' `data_type` measures, input `format`s, and pipeline `layer`s. New
+#' countries/sources/measures are added to the registry by onboarding; an
+#' unregistered value warns rather than errors. `country`/`disease` are also
+#' normalized to lowercase wherever a path is built (ADR-0020).
 #'
 #' @returns Invisibly, the registry as a named list.
 #' @examples
@@ -51,6 +75,12 @@ eri_data_model <- function() {
 
   cli::cli_h1("Data-addressing model (ADR-0012)")
   cli::cli_text("Path: {.path data/{{country}}/{{disease}}/{{data_source}}/{{data_type}}/{{layer}}/}")
+
+  cli::cli_h2("country")
+  for (nm in names(m$countries)) cli::cli_bullets(c("*" = "{.strong {nm}} -- {m$countries[[nm]]}"))
+
+  cli::cli_h2("disease")
+  for (nm in names(m$diseases)) cli::cli_bullets(c("*" = "{.strong {nm}} -- {m$diseases[[nm]]}"))
 
   cli::cli_h2("data_source {.emph (channel / how the data arrives)}")
   for (nm in names(m$data_sources)) cli::cli_bullets(c("*" = "{.strong {nm}} -- {m$data_sources[[nm]]}"))

--- a/R/data_model.R
+++ b/R/data_model.R
@@ -33,9 +33,16 @@
 
 # Known country codes, from the bundled registry. A function (not a top-level
 # constant) so no file I/O happens at package-load time -- .eri_data_model()
-# is deliberately "read on demand."
+# is deliberately "read on demand." `include_sandbox = FALSE` drops `atlantis`
+# for contexts that are production-only and already have their own sandbox
+# convention -- e.g. ODK registration, which never included `atlantis` before
+# this registry was unified (ODK's own sandbox is the uga/demo namespace).
 #' @keywords internal
-.eri_known_countries <- function() names(.eri_data_model()$countries)
+.eri_known_countries <- function(include_sandbox = TRUE) {
+  codes <- names(.eri_data_model()$countries)
+  if (!include_sandbox) codes <- setdiff(codes, "atlantis")
+  codes
+}
 
 # Known disease codes, from the bundled registry. Same lazy-read rationale.
 #' @keywords internal

--- a/R/logs.R
+++ b/R/logs.R
@@ -251,6 +251,12 @@ eri_dq_log <- function(result, country, disease, data_source,
   if (!inherits(result, "dq_result")) {
     cli::cli_abort("{.arg result} must be a {.cls dq_result} from {.fn run_dq_checks}.")
   }
+  # ADR-0020: this function never calls eri_data_path(), so without this it
+  # would never normalize at all -- a DQ log's path could drift from the
+  # data path it's logging about.
+  model   <- .eri_data_model()
+  country <- .eri_normalize_geo_axis("country", country, names(model$countries))
+  disease <- .eri_normalize_geo_axis("disease", disease, names(model$diseases))
   data_con <- .eri_logs_con(data_con)
 
   flags   <- result$flags

--- a/R/odk_registry.R
+++ b/R/odk_registry.R
@@ -1,9 +1,5 @@
 #### ODK form registry — Azure-backed YAML ####
 
-.KNOWN_COUNTRY_CODES <- c(
-  "dr", "ht", "eth", "nga", "sdn", "ssd", "uga", "mad", "tcd"
-)
-
 .ODK_REGISTRY_PATH <- "odk/registry.yaml"
 
 # Read registry from Azure; returns list with $forms element (may be empty).
@@ -46,10 +42,15 @@
 #' Appends a new entry to `odk/registry.yaml` in the `data/` Azure blob.
 #' Errors if the `(server_url, project_id, form_id)` triple is already active.
 #'
+#' Both `country` and `disease` are normalized (lowercase + trim) before being
+#' stored, so casing typos like `"UGA"` are silently corrected rather than
+#' erroring or drifting into a differently-cased path later (ADR-0020).
+#'
 #' @param project_id `int` ODK Central project ID.
 #' @param form_id `str` ODK Central form ID (xmlFormId).
-#' @param country `str` Country code (e.g. `"uga"`). Must be a known ERI country.
-#' @param disease `str` Disease name (e.g. `"oncho"`).
+#' @param country `str` Country code (e.g. `"uga"`). Must be a known ERI country
+#'   (see [eri_data_model()]) -- unknown values error.
+#' @param disease `str` Disease name (e.g. `"oncho"`; extensible -- unknown values warn).
 #' @param server_url `str` ODK Central server URL (e.g. `"https://odk.example.org"`).
 #' @param form_display_name `str` or `NULL` Human-readable form name. Defaults to `form_id`.
 #' @param con `odk_connection` or `NULL` ODK connection from [init_odk_connection()].
@@ -76,13 +77,21 @@ eri_odk_register <- function(
     con       = NULL,
     data_con  = NULL
 ) {
-  if (!country %in% .KNOWN_COUNTRY_CODES) {
-    known <- .KNOWN_COUNTRY_CODES
+  # ADR-0020: normalize case before validating, so a typo like "UGA" is
+  # silently corrected instead of erroring on case alone. country stays a hard
+  # abort (a small, curated set); disease only warns (extensible -- new
+  # disease programs are expected to appear over time).
+  country <- tolower(trimws(country))
+  disease <- tolower(trimws(disease))
+
+  known_countries <- .eri_known_countries()
+  if (!country %in% known_countries) {
     cli::cli_abort(c(
       "{.arg country} {.val {country}} is not a known ERI country code.",
-      "i" = "Valid codes: {.val {known}}"
+      "i" = "Valid codes: {.val {known_countries}}"
     ))
   }
+  .eri_check_axis("disease", disease, .eri_known_diseases())
 
   data_con  <- .odk_data_con(data_con)
   analyst   <- .eri_analyst_id(data_con)

--- a/R/odk_registry.R
+++ b/R/odk_registry.R
@@ -79,19 +79,19 @@ eri_odk_register <- function(
 ) {
   # ADR-0020: normalize case before validating, so a typo like "UGA" is
   # silently corrected instead of erroring on case alone. country stays a hard
-  # abort (a small, curated set); disease only warns (extensible -- new
-  # disease programs are expected to appear over time).
+  # abort (a small, curated set -- production-only, so the atlantis training
+  # sandbox is excluded here; ODK's own sandbox is the uga/demo namespace);
+  # disease only warns (extensible -- new disease programs are expected to
+  # appear over time), via the same normalize helper eri_data_path() uses.
   country <- tolower(trimws(country))
-  disease <- tolower(trimws(disease))
-
-  known_countries <- .eri_known_countries()
+  known_countries <- .eri_known_countries(include_sandbox = FALSE)
   if (!country %in% known_countries) {
     cli::cli_abort(c(
       "{.arg country} {.val {country}} is not a known ERI country code.",
       "i" = "Valid codes: {.val {known_countries}}"
     ))
   }
-  .eri_check_axis("disease", disease, .eri_known_diseases())
+  disease <- .eri_normalize_geo_axis("disease", disease, .eri_known_diseases())
 
   data_con  <- .odk_data_con(data_con)
   analyst   <- .eri_analyst_id(data_con)

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -78,11 +78,6 @@
 # not a generic step sequence. That's the right level of reuse; a schema forcing these flows into
 # one shape would be reuse for its own sake, not because the flows are actually alike.
 
-# Shared disease pick-list for flows whose country/disease space has no backing registry
-# (ADR-0012 deliberately leaves disease unregistered). One constant so the ingest and ODK flows
-# can't silently diverge from each other.
-.KNOWN_DISEASES <- c("malaria", "oncho", "lf", "sch", "sth")
-
 # Both onboarding schema templates (eri_onboard_country()/eri_onboard_cmr()) take a language for
 # their comments -- ERI's own countries include Francophone ones (Haiti), and the consult itself
 # calls for "language from a pick-list" (interactive-wizard-consult.md). Returns "en"/"fr", or NA on
@@ -402,7 +397,7 @@
   if (is.na(country)) return(invisible(NULL))
 
   disease <- .eri_prompt_pick_or_type(
-    "Which disease?", .KNOWN_DISEASES,
+    "Which disease?", .eri_known_diseases(),
     "Disease (blank to cancel): "
   )
   if (is.na(disease)) return(invisible(NULL))
@@ -489,8 +484,8 @@
 # The ODK flow: connect, discover the project/form (a DA rarely knows the numeric project id or
 # exact xmlFormId by heart -- list_odk_projects()/list_odk_forms() turn that into two pick-lists),
 # register if this form isn't already tracked (using con$url as server_url -- init_odk_connection()
-# already has it, no need to ask again -- and .KNOWN_COUNTRY_CODES, R/odk_registry.R's own
-# registration-validation list, as the country pick-list -- ODK registration is genuinely
+# already has it, no need to ask again -- and .eri_known_countries(), the shared data-model
+# registry's country list (ADR-0020), as the country pick-list -- ODK registration is genuinely
 # country-locked, unlike ingest), then sync. Stops there: there is no single stage-then-approve
 # function for ODK data (da-odk-guide.Rmd's own next step is a manual eri_write() after ad hoc
 # quality-checking), so this flow honestly ends at "synced to raw/," not a fabricated approve step.
@@ -528,13 +523,13 @@
 
   if (!isTRUE(already)) {
     cli::cli_alert_info("This form isn't registered yet -- I need a country and disease to file it under.")
-    country_map <- .KNOWN_COUNTRY_CODES
-    names(country_map) <- .KNOWN_COUNTRY_CODES
+    country_map <- .eri_known_countries()
+    names(country_map) <- .eri_known_countries()
     country <- .eri_prompt_pick_country(country_map, "Which country?")
     if (is.null(country)) return(invisible(NULL))
 
     disease <- .eri_prompt_pick_or_type(
-      "Which disease?", .KNOWN_DISEASES,
+      "Which disease?", .eri_known_diseases(),
       "Disease (blank to cancel): "
     )
     if (is.na(disease)) return(invisible(NULL))
@@ -621,7 +616,7 @@
   if (!nzchar(trimws(country_name))) return(invisible(NULL))
 
   disease <- .eri_prompt_pick_or_type(
-    "Which disease?", .KNOWN_DISEASES,
+    "Which disease?", .eri_known_diseases(),
     "Disease (blank to cancel): "
   )
   if (is.na(disease)) return(invisible(NULL))
@@ -690,7 +685,7 @@
 #' @keywords internal
 .eri_flow_onboard_disease <- function() {
   disease <- .eri_prompt_pick_or_type(
-    "Which disease?", .KNOWN_DISEASES,
+    "Which disease?", .eri_known_diseases(),
     "Disease (blank to cancel): "
   )
   if (is.na(disease)) return(invisible(NULL))

--- a/R/wizard.R
+++ b/R/wizard.R
@@ -523,8 +523,11 @@
 
   if (!isTRUE(already)) {
     cli::cli_alert_info("This form isn't registered yet -- I need a country and disease to file it under.")
-    country_map <- .eri_known_countries()
-    names(country_map) <- .eri_known_countries()
+    # Production-only (ADR-0020): ODK registration excludes the atlantis
+    # training sandbox, matching eri_odk_register()'s own hard validation --
+    # ODK's own sandbox is the uga/demo namespace, not atlantis.
+    country_map <- .eri_known_countries(include_sandbox = FALSE)
+    names(country_map) <- country_map
     country <- .eri_prompt_pick_country(country_map, "Which country?")
     if (is.null(country)) return(invisible(NULL))
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.36 · **Status:** Active development
+**Version:** 0.9.37 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/adr/0012-source-measure-data-model.md
+++ b/docs/adr/0012-source-measure-data-model.md
@@ -1,6 +1,7 @@
 # ADR-0012 — Data is addressed by source *and* measure (the 5-axis model)
 
-- **Status:** Accepted — supersedes [ADR-0011](0011-unified-schema-naming.md)
+- **Status:** Accepted — supersedes [ADR-0011](0011-unified-schema-naming.md); point 5 amended by
+  [ADR-0020](0020-canonical-country-disease-codes.md)
 - **Date:** 2026-06-27
 
 ## Context
@@ -88,7 +89,10 @@ data/{country}/{disease}/{data_source}/{data_type}/{layer}/
 5. **`data_source` and `data_type` are extensible by data, not code.** Validation is driven by a small
    registry / the schema set, so onboarding a new source or measure is a **data** change — not a core
    edit (roadmap Phase 5; CLAUDE.md global-vs-local guardrail). "This country/disease/source/measure
-   doesn't exist yet" is a normal, expected gap.
+   doesn't exist yet" is a normal, expected gap. *(Amended by
+   [ADR-0020](0020-canonical-country-disease-codes.md): this same registry-and-warn mechanism now
+   actually governs `country`/`disease` too, not just illustratively — they were named here in spirit
+   but never wired to a registry or validated until ADR-0020.)*
 6. **General primitives; legacy/production specifics are thin adapters.** Every core operation works
    over the five axes on *any* data, including a sandbox. `eri_ingest()` becomes the single general
    ingest core; the `projects`-blob **dual-write** becomes an opt-in `mirror_pipeline = NULL` parameter

--- a/docs/adr/0020-canonical-country-disease-codes.md
+++ b/docs/adr/0020-canonical-country-disease-codes.md
@@ -1,0 +1,73 @@
+# ADR-0020 — Canonical, normalized country and disease codes
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+
+## Context
+
+The five-axis data model (ADR-0012) validates `data_source`/`data_type`/`format`/`layer` against
+`inst/registry/data_model.yaml` (`.eri_check_axis()` — unknown values warn, never block). ADR-0012
+point 5 states the same extensible-by-data philosophy for `country`/`disease` in spirit ("This
+country/disease/source/measure doesn't exist yet" is a normal, expected gap) — but it was never
+actually wired up. `eri_data_path()` (`R/dal.R`) built every path segment from `country`/`disease`
+verbatim, any case, with zero registry backing.
+
+This is exactly how legacy-cased paths — `uga/LF`, `eth/RB` — were created and silently diverged
+from the rest of the data lake (found and fixed in #303; the existing data was migrated by hand).
+The actual entry point was `eri_odk_register()` (`R/odk_registry.R`), which hard-validated
+`country` against a local `.KNOWN_COUNTRY_CODES` constant (case-sensitive membership — an
+uppercase typo already errored, just unhelpfully) but had **no check at all** on `disease`. A
+second, independent `.KNOWN_DISEASES` constant lived in `R/wizard.R`, used only to populate the
+interactive picker's suggestions — never validated against, and free to drift from the first list.
+
+## Decision
+
+Extend the ADR-0012 registry pattern to `country` and `disease`, completing what point 5 already
+called for:
+
+1. **`inst/registry/data_model.yaml` gains `countries:`/`diseases:` sections**, same shape and
+   same non-blocking philosophy as `data_sources:`/`data_types:`. Includes `atlantis` (the
+   synthetic training sandbox, already a real `country_code` elsewhere in the package) and `rblf`
+   (the transitional combined RB+LF programmatic code, retired at the hsp-mal Phase-3 cutover) —
+   both real, intentional, existing usages that must not start warning spuriously.
+2. **`.eri_normalize_geo_axis()` (`R/data_model.R`)**: lowercase + trim, then soft-warn via the
+   existing `.eri_check_axis()` if the normalized value isn't in the registry. Returns the
+   normalized value. Wired into `eri_data_path()` — the shared chokepoint nearly every write in the
+   package routes through — so a path is always built from the canonical form regardless of input
+   casing.
+3. **`eri_odk_register()`** — the actual point where a human first types a country/disease —
+   normalizes both before validating. `country` keeps its hard abort (a small, curated,
+   organizationally-fixed set); `disease` gets the same soft warn as everywhere else (diseases can
+   legitimately expand as new programs launch, so blocking would fight ADR-0012's own philosophy).
+4. **`.KNOWN_COUNTRY_CODES`/`.KNOWN_DISEASES`, two independent hardcoded lists that could already
+   drift from each other, are removed.** `.eri_known_countries()`/`.eri_known_diseases()` read the
+   one registry instead — `R/wizard.R`'s picker, `R/odk_registry.R`'s validation, and
+   `eri_data_path()`'s normalization now share a single source of truth by construction, not by
+   convention.
+
+## Consequences
+
+- **Easier:** a case typo (`"UGA"`, `"LF"`) is silently corrected instead of either erroring
+  (country, previously) or drifting into a permanent, differently-cased path (disease,
+  previously) — the specific failure mode #303 was.
+- **Easier:** `eri_data_model()` (the package's own "what do I know about?" introspection command)
+  now shows `country`/`disease` alongside the other three axes, instead of omitting two of the
+  five.
+- **Harder / accepted:** `country`/`disease` normalization only fires for callers that go through
+  `eri_data_path()` or `eri_odk_register()`. A caller that hand-builds a path by string
+  concatenation (as `eri_odk_sync()`'s log-path write already did, reading `disease` straight from
+  a — now-normalized-at-write-time — registry entry) is unaffected by this ADR directly; it inherits
+  correctness because the *stored* value is now canonical, not because every consumer re-normalizes.
+  A future hand-built path from an *unnormalized* source would still need to route through
+  `eri_data_path()` to get this protection.
+- **Not doing:** making `country`/`disease` a closed/hard-validated set like `layer`. Both remain
+  extensible-by-data per ADR-0012 point 5 — a genuinely new country or disease is still a data
+  change (add a registry entry), not a core-code edit, and a warn (not an abort) is what keeps that
+  true for `eri_data_path()`'s general chokepoint.
+
+## References
+
+- ADR-0012 point 5 — the extensible-by-data philosophy this completes for `country`/`disease`.
+- ADR-0010 / ADR-0019 — the ODK repeat-group set model and its zero-row-parent amendment; unrelated
+  axis, same registry-and-chokepoint pattern.
+- Issue #303 / PR #304 / PR #305 — the `LF`/`RB` legacy-casing bug this prevents from recurring.

--- a/docs/adr/0020-canonical-country-disease-codes.md
+++ b/docs/adr/0020-canonical-country-disease-codes.md
@@ -1,16 +1,16 @@
 # ADR-0020 — Canonical, normalized country and disease codes
 
-- **Status:** Accepted
+- **Status:** Accepted — amends [ADR-0012](0012-source-measure-data-model.md) point 5
 - **Date:** 2026-07-14
 
 ## Context
 
 The five-axis data model (ADR-0012) validates `data_source`/`data_type`/`format`/`layer` against
 `inst/registry/data_model.yaml` (`.eri_check_axis()` — unknown values warn, never block). ADR-0012
-point 5 states the same extensible-by-data philosophy for `country`/`disease` in spirit ("This
-country/disease/source/measure doesn't exist yet" is a normal, expected gap) — but it was never
-actually wired up. `eri_data_path()` (`R/dal.R`) built every path segment from `country`/`disease`
-verbatim, any case, with zero registry backing.
+point 5's bolded decision names only `data_source`/`data_type` as extensible-by-data; `country`/
+`disease` appear only in an illustrative aside ("This country/disease/source/measure doesn't exist
+yet" is a normal, expected gap) — never actually wired to a registry or validated. `eri_data_path()`
+(`R/dal.R`) built every path segment from `country`/`disease` verbatim, any case, with zero backing.
 
 This is exactly how legacy-cased paths — `uga/LF`, `eth/RB` — were created and silently diverged
 from the rest of the data lake (found and fixed in #303; the existing data was migrated by hand).
@@ -22,8 +22,8 @@ interactive picker's suggestions — never validated against, and free to drift 
 
 ## Decision
 
-Extend the ADR-0012 registry pattern to `country` and `disease`, completing what point 5 already
-called for:
+Amend ADR-0012 point 5 so its stated philosophy actually governs `country`/`disease`, not just
+`data_source`/`data_type`:
 
 1. **`inst/registry/data_model.yaml` gains `countries:`/`diseases:` sections**, same shape and
    same non-blocking philosophy as `data_sources:`/`data_types:`. Includes `atlantis` (the
@@ -35,11 +35,27 @@ called for:
    normalized value. Wired into `eri_data_path()` — the shared chokepoint nearly every write in the
    package routes through — so a path is always built from the canonical form regardless of input
    casing.
-3. **`eri_odk_register()`** — the actual point where a human first types a country/disease —
-   normalizes both before validating. `country` keeps its hard abort (a small, curated,
-   organizationally-fixed set); `disease` gets the same soft warn as everywhere else (diseases can
+3. **Every governed pipeline entry point that also hand-builds a *sibling* path** — a log directory
+   built separately from the `staged_dir`/`processed_dir`/`raw_dir` that `eri_data_path()` computes,
+   in the same function call — **normalizes `country`/`disease` once, at its own top, before either
+   path is built.** `eri_data_path()` normalizing its own internal copy is not enough on its own:
+   R is pass-by-value, so that normalization never reaches a caller's own `country`/`disease`
+   locals used elsewhere in the same call. Without this, `eri_approve("UGA", "LF", ...)` would
+   promote data to `uga/lf/.../processed/` (via `eri_data_path()`) while logging the operation to
+   `UGA/LF/.../logs/` (via hand-built `paste()`) — the exact #303 failure class, one hop away, still
+   reachable through the package's own most-used entry points. Fixed in: `eri_approve()`,
+   `eri_stage()`, `eri_ingest()`, `.eri_dq_log_write()` (which never called `eri_data_path()` at
+   all), `eri_split_cmr()`, `eri_stage_cmr()`, `eri_approve_cmr()`.
+4. **`eri_odk_register()`** — the actual point where a human first types a country/disease —
+   normalizes both before validating. `country` keeps its hard abort, now against a
+   **production-only** list (`.eri_known_countries(include_sandbox = FALSE)`) that excludes
+   `atlantis` — ODK registration never offered the training sandbox before this registry was
+   unified, and it already has its own sandbox convention (the `uga`/`demo` namespace), so nothing
+   about that should change. `disease` gets the same soft warn as everywhere else (diseases can
    legitimately expand as new programs launch, so blocking would fight ADR-0012's own philosophy).
-4. **`.KNOWN_COUNTRY_CODES`/`.KNOWN_DISEASES`, two independent hardcoded lists that could already
+   The wizard's ODK country picker (`R/wizard.R`, `.eri_flow_odk()`) uses the same production-only
+   list, so it never *offers* `atlantis` as a choice a DA would then have rejected anyway.
+5. **`.KNOWN_COUNTRY_CODES`/`.KNOWN_DISEASES`, two independent hardcoded lists that could already
    drift from each other, are removed.** `.eri_known_countries()`/`.eri_known_diseases()` read the
    one registry instead — `R/wizard.R`'s picker, `R/odk_registry.R`'s validation, and
    `eri_data_path()`'s normalization now share a single source of truth by construction, not by
@@ -49,25 +65,31 @@ called for:
 
 - **Easier:** a case typo (`"UGA"`, `"LF"`) is silently corrected instead of either erroring
   (country, previously) or drifting into a permanent, differently-cased path (disease,
-  previously) — the specific failure mode #303 was.
+  previously) — the specific failure mode #303 was, including in the sibling-log-path form
+  (point 3 above) that isn't visible just from reading `eri_data_path()`'s own diff.
 - **Easier:** `eri_data_model()` (the package's own "what do I know about?" introspection command)
   now shows `country`/`disease` alongside the other three axes, instead of omitting two of the
   five.
-- **Harder / accepted:** `country`/`disease` normalization only fires for callers that go through
-  `eri_data_path()` or `eri_odk_register()`. A caller that hand-builds a path by string
-  concatenation (as `eri_odk_sync()`'s log-path write already did, reading `disease` straight from
-  a — now-normalized-at-write-time — registry entry) is unaffected by this ADR directly; it inherits
-  correctness because the *stored* value is now canonical, not because every consumer re-normalizes.
-  A future hand-built path from an *unnormalized* source would still need to route through
-  `eri_data_path()` to get this protection.
-- **Not doing:** making `country`/`disease` a closed/hard-validated set like `layer`. Both remain
-  extensible-by-data per ADR-0012 point 5 — a genuinely new country or disease is still a data
-  change (add a registry entry), not a core-code edit, and a warn (not an abort) is what keeps that
-  true for `eri_data_path()`'s general chokepoint.
+- **Harder / accepted:** normalization only fires for code paths that actually call
+  `.eri_normalize_geo_axis()`/`eri_data_path()`/`eri_odk_register()`. A pure *read* lookup keyed on
+  `country`/`disease` (`load_cmr_schema()`, `load_dq_schema()`'s legacy stem form) is untouched —
+  a case mismatch there fails loudly (file/schema not found) rather than silently diverging, which
+  is a different and lower-severity failure mode than the one this ADR targets, so it's left alone.
+  A caller reading an already-normalized *stored* value (`eri_odk_sync()`'s log path, sourced from
+  a registry entry `eri_odk_register()` already normalized at write time) is safe by construction,
+  not because it re-normalizes itself.
+- **Not doing:** making `country`/`disease` a closed/hard-validated set like `layer` in the general
+  case. Both remain extensible-by-data per ADR-0012 point 5 — a genuinely new country or disease is
+  still a data change (add a registry entry), not a core-code edit, and a warn (not an abort) is
+  what keeps that true for `eri_data_path()`'s general chokepoint. `eri_odk_register()`'s
+  country hard-abort is the one deliberate exception, unchanged from before this ADR except for
+  case-insensitivity and the `atlantis` exclusion.
 
 ## References
 
-- ADR-0012 point 5 — the extensible-by-data philosophy this completes for `country`/`disease`.
+- ADR-0012 point 5 — the extensible-by-data decision this amends to actually cover `country`/
+  `disease`.
 - ADR-0010 / ADR-0019 — the ODK repeat-group set model and its zero-row-parent amendment; unrelated
-  axis, same registry-and-chokepoint pattern.
+  axis, same amend-in-place / registry-and-chokepoint conventions.
 - Issue #303 / PR #304 / PR #305 — the `LF`/`RB` legacy-casing bug this prevents from recurring.
+- Issue #306 / PR #307 — this ADR's own implementation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,3 +63,4 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0017](0017-cmr-staged-file-supersession.md) | Superseding staged CMR files: opt-in delete, anchored match | Accepted |
 | [0018](0018-dq-schema-local-overrides.md) | DQ schema local overrides: three-tier resolution, hash-based expiry | Accepted |
 | [0019](0019-odk-zero-row-parent-clears-raw-set.md) | A zero-row ODK parent clears the whole raw set, by default | Accepted — amends ADR-0010 point 4 |
+| [0020](0020-canonical-country-disease-codes.md) | Canonical, normalized country and disease codes | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,7 +55,7 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0009](0009-research-data-lifecycle.md) | Research-data lifecycle: Azure is the source, the project is the versioned working copy | Accepted |
 | [0010](0010-odk-repeat-group-tables.md) | ODK repeat groups land as a relational set of tables, approved together | Accepted — point 4 amended by ADR-0019 |
 | [0011](0011-unified-schema-naming.md) | One vocabulary for addressing data and schemas (unified schema naming) | Superseded by ADR-0012 |
-| [0012](0012-source-measure-data-model.md) | Data is addressed by source *and* measure (the 5-axis path model) | Accepted |
+| [0012](0012-source-measure-data-model.md) | Data is addressed by source *and* measure (the 5-axis path model) | Accepted — point 5 amended by ADR-0020 |
 | [0013](0013-odk-submission-backfill.md) | Submission backfill: erifunctions writes records *into* ODK Central | Accepted |
 | [0014](0014-feedback-ticket-log.md) | In-package feedback / ticket log in the `data/` blob | Accepted |
 | [0015](0015-hsp-mal-cutover-criteria.md) | hsp-mal cutover criteria: N consecutive periods of equivalence | Accepted |
@@ -63,4 +63,4 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0017](0017-cmr-staged-file-supersession.md) | Superseding staged CMR files: opt-in delete, anchored match | Accepted |
 | [0018](0018-dq-schema-local-overrides.md) | DQ schema local overrides: three-tier resolution, hash-based expiry | Accepted |
 | [0019](0019-odk-zero-row-parent-clears-raw-set.md) | A zero-row ODK parent clears the whole raw set, by default | Accepted — amends ADR-0010 point 4 |
-| [0020](0020-canonical-country-disease-codes.md) | Canonical, normalized country and disease codes | Accepted |
+| [0020](0020-canonical-country-disease-codes.md) | Canonical, normalized country and disease codes | Accepted — amends ADR-0012 point 5 |

--- a/inst/registry/data_model.yaml
+++ b/inst/registry/data_model.yaml
@@ -9,6 +9,34 @@
 # deliberately extensible: onboarding a new source/measure/format adds an entry here
 # (no core-code edit), and an unregistered value *warns* rather than errors, so the
 # system never blocks new data — it just nudges you to register it.
+#
+# `countries` and `diseases` are validated the same way, but ALSO normalized:
+# eri_data_path()/eri_odk_register() lowercase+trim whatever is passed before
+# checking it against these lists, so a path is always built from the canonical
+# form here regardless of input casing (ADR-0020 — prevents the `LF`/`lf`
+# legacy-casing drift found and fixed in #303).
+
+countries:
+  dr:       "Dominican Republic"
+  ht:       "Haiti"
+  eth:      "Ethiopia"
+  nga:      "Nigeria"
+  sdn:      "Sudan"
+  ssd:      "South Sudan"
+  uga:      "Uganda"
+  mad:      "Madagascar"
+  tcd:      "Chad"
+  atlantis: "(training sandbox) Synthetic country for teaching/testing; not a real ERI program."
+
+diseases:
+  malaria: "Malaria"
+  oncho:   "Onchocerciasis (river blindness)"
+  lf:      "Lymphatic filariasis"
+  sch:     "Schistosomiasis"
+  sth:     "Soil-transmitted helminths"
+  # Transitional (roadmap Phase 3): combined RB+LF programmatic code from the
+  # hsp-mal-era CMR pipeline, retired at the hsp-mal cutover -- not a new-write target.
+  rblf:    "(transitional) Combined RB+LF programmatic code; retired at the hsp-mal Phase-3 cutover."
 
 data_sources:
   surveillance: "Direct disease-output feed (e.g. a Ministry-of-Health surveillance system)."

--- a/man/eri_data_model.Rd
+++ b/man/eri_data_model.Rd
@@ -14,9 +14,11 @@ Invisibly, the registry as a named list.
 
 Prints (and returns invisibly) the registry of known values for the five-axis
 canonical path \verb{data/\{country\}/\{disease\}/\{data_source\}/\{data_type\}/\{layer\}/}
-(ADR-0012): the \code{data_source} channels, the \code{data_type} measures, the input
-\code{format}s, and the pipeline \code{layer}s. New sources/measures are added to the
-registry by onboarding; an unregistered value warns rather than errors.
+(ADR-0012): the \code{country} codes, \code{disease} codes, \code{data_source} channels,
+\code{data_type} measures, input \code{format}s, and pipeline \code{layer}s. New
+countries/sources/measures are added to the registry by onboarding; an
+unregistered value warns rather than errors. \code{country}/\code{disease} are also
+normalized to lowercase wherever a path is built (ADR-0020).
 }
 \examples{
 eri_data_model()

--- a/man/eri_data_path.Rd
+++ b/man/eri_data_path.Rd
@@ -7,9 +7,11 @@
 eri_data_path(country, disease, data_source, data_type, layer, filename = NULL)
 }
 \arguments{
-\item{country}{\code{str} Country code (e.g. \code{"dr"}, \code{"ht"}, \code{"uga"}).}
+\item{country}{\code{str} Country code (e.g. \code{"dr"}, \code{"ht"}, \code{"uga"}; extensible —
+see \code{\link[=eri_data_model]{eri_data_model()}}; unknown values warn, not error).}
 
-\item{disease}{\code{str} Disease name (e.g. \code{"malaria"}, \code{"lf"}, \code{"oncho"}).}
+\item{disease}{\code{str} Disease name (e.g. \code{"malaria"}, \code{"lf"}, \code{"oncho"}; extensible;
+unknown values warn).}
 
 \item{data_source}{\code{str} The channel: \code{"surveillance"}, \code{"programmatic"},
 \code{"research"} (extensible — see \code{\link[=eri_data_model]{eri_data_model()}}; unknown values warn).}
@@ -36,6 +38,11 @@ measure (what it captures). Use this instead of hard-coding path strings.
 The legacy four-axis form \code{eri_data_path(country, disease, data_source, layer[, filename])} is still accepted during the ADR-0012 migration and builds a
 measure-less \verb{\{country\}/\{disease\}/\{data_source\}/\{layer\}/} path — detected because
 its fourth argument is a \code{layer} keyword (a \code{data_type} measure never is).
+
+\code{country} and \code{disease} are normalized (lowercase + trim) before the path is
+built, so \code{"UGA"}/\code{"uga"}/\code{" Uga "} all produce the same canonical path
+(ADR-0020) — this is what prevents legacy-cased paths like the \code{LF}/\code{lf}
+drift found and fixed in issue #303 from recurring.
 }
 \examples{
 eri_data_path("dr", "malaria", "surveillance", "case", "staged")

--- a/man/eri_odk_register.Rd
+++ b/man/eri_odk_register.Rd
@@ -20,9 +20,10 @@ eri_odk_register(
 
 \item{form_id}{\code{str} ODK Central form ID (xmlFormId).}
 
-\item{country}{\code{str} Country code (e.g. \code{"uga"}). Must be a known ERI country.}
+\item{country}{\code{str} Country code (e.g. \code{"uga"}). Must be a known ERI country
+(see \code{\link[=eri_data_model]{eri_data_model()}}) -- unknown values error.}
 
-\item{disease}{\code{str} Disease name (e.g. \code{"oncho"}).}
+\item{disease}{\code{str} Disease name (e.g. \code{"oncho"}; extensible -- unknown values warn).}
 
 \item{server_url}{\code{str} ODK Central server URL (e.g. \code{"https://odk.example.org"}).}
 
@@ -39,6 +40,11 @@ The new registry entry (invisibly).
 \description{
 Appends a new entry to \code{odk/registry.yaml} in the \verb{data/} Azure blob.
 Errors if the \verb{(server_url, project_id, form_id)} triple is already active.
+}
+\details{
+Both \code{country} and \code{disease} are normalized (lowercase + trim) before being
+stored, so casing typos like \code{"UGA"} are silently corrected rather than
+erroring or drifting into a differently-cased path later (ADR-0020).
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -820,6 +820,19 @@ test_that("eri_split_cmr mirror_pipeline errors clearly for an unregistered pipe
   )
 })
 
+test_that("eri_split_cmr normalizes country casing before the mirror country_map lookup (ADR-0020)", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_uga_cmr(tmp)
+
+  # "UGA" normalizes to "uga", which IS registered for rb-expansion -- so this
+  # must reach the same "Could not parse" error as the lowercase "uga" case
+  # above, not "not registered for pipeline" (the "zzz" case above).
+  expect_error(
+    eri_split_cmr(tmp, "UGA", dry_run = TRUE, mirror_pipeline = "rb-expansion"),
+    "Could not parse"
+  )
+})
+
 test_that("eri_split_cmr dry_run alerts clean when nothing was skipped or warned", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   make_cmr_xlsx(tmp, sheet_name = "RB Treatment")
@@ -990,6 +1003,25 @@ test_that("eri_approve_cmr blocks and reports when a measure was never DQ-checke
   result <- eri_approve_cmr("sdn", "202605", plan = plan, data_con = structure(list(), class = "mock"))
   expect_equal(nrow(result), 2L)
   expect_true(all(grepl("never DQ-checked", result$issue)))
+})
+
+test_that("eri_approve_cmr normalizes country casing before calling eri_cmr_last_plan (ADR-0020)", {
+  captured_country <- NULL
+  local_mocked_bindings(
+    eri_cmr_last_plan = function(country, period, data_con = NULL) {
+      captured_country <<- country
+      cli::cli_abort("stop here for the test")
+    },
+    .package = "erifunctions"
+  )
+
+  tryCatch(
+    eri_approve_cmr("UGA", "202406", data_con = structure(list(), class = "mock")),
+    error = function(e) NULL
+  )
+  # plan = NULL (default) -> eri_approve_cmr() calls eri_cmr_last_plan(country, ...)
+  # itself; without normalizing first, it would pass "UGA" straight through.
+  expect_equal(captured_country, "uga")
 })
 
 test_that("eri_approve_cmr blocks on unresolved DQ flags and does not call eri_approve", {

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -181,6 +181,20 @@ test_that("eri_stage errors clearly for unregistered country", {
   )
 })
 
+test_that("eri_stage normalizes country casing before the country_map lookup (ADR-0020)", {
+  # "DR" normalizes to "dr", which IS registered for hsp-mal -- so this must
+  # NOT hit "not registered" (the "zz" case above); without normalizing
+  # before the country_map lookup, "DR" would incorrectly hit it too.
+  err <- tryCatch({
+    eri_stage("hsp-mal", "DR", "malaria",
+              projects_con = structure(list(), class = "mock"),
+              data_con     = structure(list(), class = "mock"))
+    NULL
+  }, error = function(e) conditionMessage(e))
+  expect_false(is.null(err))
+  expect_false(grepl("not registered", err, fixed = TRUE))
+})
+
 test_that("hsp-mal pipeline registry has required fields", {
   reg <- .eri_pipeline_registry[["hsp-mal"]]
   expect_false(is.null(reg))
@@ -205,6 +219,19 @@ test_that("eri_stage_cmr errors for unregistered country", {
                   data_con     = structure(list(), class = "mock")),
     "not registered"
   )
+})
+
+test_that("eri_stage_cmr normalizes country casing before the country_map lookup (ADR-0020)", {
+  # "UGA" normalizes to "uga", which IS registered for rb-expansion -- so this
+  # must NOT hit "not registered" (the "zz" case above).
+  err <- tryCatch({
+    eri_stage_cmr("UGA",
+                  projects_con = structure(list(), class = "mock"),
+                  data_con     = structure(list(), class = "mock"))
+    NULL
+  }, error = function(e) conditionMessage(e))
+  expect_false(is.null(err))
+  expect_false(grepl("not registered", err, fixed = TRUE))
 })
 
 test_that("eri_stage_cmr errors when source directory not found", {
@@ -325,6 +352,21 @@ test_that("eri_ingest errors for a country not registered to the mirror pipeline
                data_con        = structure(list(), class = "mock")),
     "not registered"
   )
+})
+
+test_that("eri_ingest normalizes country casing before the mirror country_map lookup (ADR-0020)", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  writexl::write_xlsx(tibble::tibble(x = 1), tmp)
+  # "DR" normalizes to "dr", which IS registered for hsp-mal -- so this must
+  # NOT hit "not registered" (the "zz" case above).
+  err <- tryCatch({
+    eri_ingest(tmp, "DR", "malaria",
+               mirror_pipeline = "hsp-mal",
+               data_con        = structure(list(), class = "mock"))
+    NULL
+  }, error = function(e) conditionMessage(e))
+  expect_false(is.null(err))
+  expect_false(grepl("not registered", err, fixed = TRUE))
 })
 
 test_that("eri_ingest no longer needs .eri_schema_country_map (retired)", {

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -544,6 +544,37 @@ test_that("eri_approve errors informatively when staged dir does not exist", {
   )
 })
 
+test_that("eri_approve normalizes country/disease so the log path matches the data path (ADR-0020)", {
+  mock_container <- structure(list(), class = "mock_container")
+  empty_tbl       <- tibble::tibble(name = character(0), size = integer(0))
+  captured_log_dir <- NULL
+
+  with_mocked_bindings(
+    storage_dir_exists = function(...) TRUE,
+    list_storage_files = function(...) empty_tbl,
+    .package = "AzureStor",
+    {
+      local_mocked_bindings(
+        .eri_write_log = function(op_log, azcontainer, log_dir) {
+          captured_log_dir <<- log_dir
+          invisible(NULL)
+        },
+        .package = "erifunctions"
+      )
+      expect_error(
+        eri_approve("UGA", "LF", "surveillance", "2024-W01",
+                    azcontainer = mock_container),
+        "No staged files"
+      )
+    }
+  )
+
+  # Without normalizing at eri_approve()'s own top, this would be
+  # "UGA/LF/surveillance/logs" -- a differently-cased sibling of the
+  # eri_data_path()-derived staged/processed dirs (uga/lf/...).
+  expect_equal(captured_log_dir, "uga/lf/surveillance/logs")
+})
+
 test_that(".eri_note_no_measure signposts the four-axis form once per session", {
   withr::local_options(erifunctions.noted_no_measure = NULL)
   expect_message(

--- a/tests/testthat/test-dal.R
+++ b/tests/testthat/test-dal.R
@@ -36,8 +36,8 @@ test_that("eri_data_path builds correct paths without filename", {
     "ht/lf/cmr/processed"
   )
   expect_equal(
-    eri_data_path("ug", "oncho", "odk", "raw"),
-    "ug/oncho/odk/raw"
+    eri_data_path("uga", "oncho", "odk", "raw"),
+    "uga/oncho/odk/raw"
   )
 })
 
@@ -70,6 +70,34 @@ test_that("eri_data_path warns (does not error) on an unregistered axis value", 
     eri_data_path("dr", "malaria", "surveillance", "newmeasure", "processed"),
     "data_type"
   )
+})
+
+test_that("eri_data_path normalizes country/disease casing to lowercase (ADR-0020)", {
+  expect_equal(
+    eri_data_path("UGA", "LF", "surveillance", "staged"),
+    "uga/lf/surveillance/staged"
+  )
+  expect_equal(
+    eri_data_path(" Uga ", " Oncho ", "surveillance", "staged"),
+    "uga/oncho/surveillance/staged"
+  )
+})
+
+test_that("eri_data_path warns (does not error) on an unregistered country/disease", {
+  expect_warning(
+    p <- eri_data_path("xx", "malaria", "surveillance", "staged"),
+    "country"
+  )
+  expect_equal(p, "xx/malaria/surveillance/staged")
+  expect_warning(
+    eri_data_path("dr", "newdisease", "surveillance", "staged"),
+    "disease"
+  )
+})
+
+test_that("eri_data_path does not warn on the training sandbox or transitional codes", {
+  expect_no_warning(eri_data_path("atlantis", "oncho", "surveillance", "staged"))
+  expect_no_warning(eri_data_path("uga", "rblf", "cmr", "staged"))
 })
 
 test_that("eri_data_path resolves the legacy named form (data_type = <source>)", {

--- a/tests/testthat/test-logs.R
+++ b/tests/testthat/test-logs.R
@@ -327,6 +327,34 @@ test_that("eri_dq_log writes a dq_flags envelope with the flags", {
   expect_equal(captured$flags[[1]]$column, "Age")
 })
 
+test_that("eri_dq_log normalizes country/disease casing in the log path (ADR-0020)", {
+  captured_dest <- NULL
+  local_mocked_bindings(
+    storage_dir_exists = function(...) TRUE,
+    storage_upload = function(container, src, dest, ...) {
+      captured_dest <<- dest; invisible(dest)
+    },
+    .package = "AzureStor"
+  )
+  local_mocked_bindings(
+    get_azure_storage_connection = function(...) "mock_con",
+    .package = "erifunctions"
+  )
+
+  res <- structure(
+    list(data = tibble::tibble(a = 1),
+         log  = tibble::tibble(row = integer()),
+         flags = tibble::tibble(row = integer(), column = character(),
+                                 value = character(), issue = character())),
+    class = "dq_result"
+  )
+
+  # .eri_dq_log_write() never calls eri_data_path() -- without its own
+  # normalization this would write to "UGA/LF/surveillance/logs/...".
+  eri_dq_log(res, "UGA", " LF ", "surveillance", period = "2024-01")
+  expect_true(startsWith(captured_dest, "uga/lf/surveillance/logs/"))
+})
+
 test_that("eri_dq_log records a clean status when there are no flags", {
   captured <- NULL
   local_mocked_bindings(

--- a/tests/testthat/test-odk_registry.R
+++ b/tests/testthat/test-odk_registry.R
@@ -252,6 +252,68 @@ test_that("form_display_name defaults to form_id when not supplied", {
   expect_equal(store$data$forms[[1]]$form_display_name, "MyForm")
 })
 
+# --- ADR-0020: country/disease normalization -----------------------------------
+
+test_that("eri_odk_register normalizes country/disease casing before storing", {
+  store <- new_yaml_store(list(forms = list()))
+  local_yaml_store(store)
+
+  local_mocked_bindings(
+    .eri_write_log     = function(...) invisible(NULL),
+    .odk_registry_read = function(data_con) {
+      if (is.null(store$data) || length(store$data$forms) == 0L) list(forms = list())
+      else store$data
+    },
+    .package = "erifunctions"
+  )
+
+  eri_odk_register(
+    project_id = 5L, form_id = "TAS3",
+    country = "UGA", disease = " LF ",
+    server_url = "https://odk3.example.org",
+    data_con = "mock"
+  )
+
+  expect_equal(store$data$forms[[1]]$country, "uga")
+  expect_equal(store$data$forms[[1]]$disease, "lf")
+})
+
+test_that("eri_odk_register warns (does not error) on an unregistered disease", {
+  store <- new_yaml_store(list(forms = list()))
+  local_yaml_store(store)
+
+  local_mocked_bindings(
+    .eri_write_log     = function(...) invisible(NULL),
+    .odk_registry_read = function(data_con) {
+      if (is.null(store$data) || length(store$data$forms) == 0L) list(forms = list())
+      else store$data
+    },
+    .package = "erifunctions"
+  )
+
+  expect_warning(
+    eri_odk_register(
+      project_id = 6L, form_id = "NewDiseaseForm",
+      country = "uga", disease = "newdisease",
+      server_url = "https://odk4.example.org",
+      data_con = "mock"
+    ),
+    "disease"
+  )
+  expect_equal(store$data$forms[[1]]$disease, "newdisease")
+})
+
+test_that("eri_odk_register still hard-errors on an unknown country regardless of case", {
+  expect_error(
+    eri_odk_register(
+      project_id = 1, form_id = "F", country = "XYZ",
+      disease = "oncho", server_url = "https://x.org",
+      data_con = mock_data_con()
+    ),
+    "not a known ERI country"
+  )
+})
+
 # --- .odk_data_con auto-connect ------------------------------------------------
 
 test_that(".odk_data_con delegates auto-connect to get_azure_storage_connection", {

--- a/tests/testthat/test-odk_registry.R
+++ b/tests/testthat/test-odk_registry.R
@@ -314,6 +314,21 @@ test_that("eri_odk_register still hard-errors on an unknown country regardless o
   )
 })
 
+test_that("eri_odk_register rejects the atlantis training sandbox (production-only)", {
+  # atlantis is a real, valid country for eri_data_path()'s general soft-warn
+  # validation (CMR/DQ sandbox), but ODK registration is production-only and
+  # already has its own sandbox convention (uga/demo) -- it was never valid
+  # here before the registries were unified, and should stay that way.
+  expect_error(
+    eri_odk_register(
+      project_id = 1, form_id = "F", country = "atlantis",
+      disease = "oncho", server_url = "https://x.org",
+      data_con = mock_data_con()
+    ),
+    "not a known ERI country"
+  )
+})
+
 # --- .odk_data_con auto-connect ------------------------------------------------
 
 test_that(".odk_data_con delegates auto-connect to get_azure_storage_connection", {


### PR DESCRIPTION
## Summary
- `country`/`disease` had zero validation or normalization anywhere in the data model -- exactly how `uga/LF`/`eth/RB` (legacy-cased paths) got created and silently diverged, found and fixed in #303/#304/#305. This is the durable prevention fix.
- Extends ADR-0012 point 5's existing "extensible by data, not code" philosophy (already applied to `data_source`/`data_type`) to `country`/`disease`, rather than special-casing it -- see [ADR-0020](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0020-canonical-country-disease-codes.md).
- `inst/registry/data_model.yaml` gains `countries:`/`diseases:` sections, including `atlantis` (training sandbox) and `rblf` (transitional combined code, already real, existing usages) so nothing starts warning spuriously.
- `eri_data_path()` (the shared chokepoint nearly every write routes through) normalizes `country`/`disease` (lowercase+trim) before building any path; unregistered values warn, never block, matching the existing `data_source`/`data_type` behavior.
- `eri_odk_register()` -- the actual entry point where a human first typed "LF" -- normalizes both before validating: `country` keeps its hard abort (small curated set, now case-insensitive so "UGA" is corrected instead of erroring on case alone); `disease` gets the same soft warn as everywhere else.
- Removed two independent hardcoded lists (`.KNOWN_COUNTRY_CODES` in `R/odk_registry.R`, `.KNOWN_DISEASES` in `R/wizard.R`) that could already drift from each other; both now read the one registry via `.eri_known_countries()`/`.eri_known_diseases()`.
- `eri_data_model()` now shows `country`/`disease` alongside the other three axes.

Fixes #306.

## Test plan
- [x] `devtools::test()` -- 0 fail (2907 pass, +12 new tests)
- [x] New tests: `eri_data_path()` casing normalization + unknown-country/disease warn + no spurious warn on `atlantis`/`rblf`; `eri_odk_register()` casing normalization on store, disease soft-warn, country hard-abort still works case-insensitively
- [x] `devtools::document()` -- man pages regenerated for `eri_data_path`, `eri_data_model`, `eri_odk_register`
- [x] Fixed a pre-existing test typo (`"ug"` instead of `"uga"`) surfaced by the new validation
- [ ] review-agent pass