### PR TITLE
feat(cmr): close DQ schema coverage gap for eth/nga/mad/tcd, and uga's remaining gap (0.9.39)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.38
+Version: 0.9.39
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,12 +31,14 @@
   structurally**, not from a successfully-ingested sheet -- both sheets hit the same
   duplicate-field-code defect as "RB Ento Surveys" (ADR-0022) in Ethiopia's real submission.
   **Known gap, not yet resolved:** Ethiopia's "ToT Regional"/"ToT Zonal" sheets are still
-  routed to `rblf/training` by `inst/schemas/cmr/eth.yaml`, but excluded from this schema --
-  they have no `adm2`/district field at all (distinct donor/goal/tot_reg__male-fem shape),
-  so they can never satisfy this schema's required `district` column. Unlike CDD/CS, ToT
-  sheets ingest fine today, so ingesting one will produce a permanent, unresolvable "district
-  missing" flag under this schema until ToT gets its own `data_type` -- a design decision for
-  a maintainer, not made here.
+  routed to `rblf/training` by `inst/schemas/cmr/eth.yaml`, but excluded from this schema.
+  "ToT Regional" has no `adm2`/district field at all (distinct donor/goal/tot_reg__male-fem
+  shape) and can never satisfy this schema's required `district` column under any alias
+  mapping. "ToT Zonal" does have an `adm2` field, but a different shape otherwise (no
+  adm3/disease, distinct tot_zone__male/fem naming) -- not aliased pending a decision on
+  whether it fits this schema or needs its own `data_type`. Unlike CDD/CS, both ToT sheets
+  ingest fine today, so ingesting either will produce a permanent, unresolvable DQ flag under
+  this schema until this gap is resolved -- a design decision for a maintainer, not made here.
 
 # erifunctions 0.9.38
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,36 @@
+# erifunctions 0.9.39
+
+## Close the CMR DQ schema coverage gap for eth/nga/mad/tcd, and uga's remaining gap
+
+- **32 new DQ schemas**, built 2026-07-16 via read-only recon (structure/aggregate counts
+  only, no records persisted or shared) against each country's real most-recent CMR
+  submission. Before this, `load_dq_schema()` hard-aborted with "schema not found" for any
+  disease/measure without a bundled schema -- meaning DQ review (and therefore approval) was
+  completely broken past the initial split step for eth, nga, mad, and tcd, and partially
+  broken for uga:
+  - **uga** (5 of 7 measures were missing): `lf/mmdp`, `lf/tas`, `oncho/prevalence`,
+    `oncho/entomology`, `rblf/training`.
+  - **eth** (7 of 7, all): `oncho/treatment`, `lf/treatment`, `lf/mmdp`, `lf/tas`,
+    `oncho/prevalence`, `oncho/entomology`, `rblf/training`.
+  - **nga** (9 of 9, all): `oncho/treatment`, `lf/treatment`, `sch/treatment`,
+    `sth/treatment`, `lf/mmdp`, `lf/tas`, `oncho/prevalence`, `oncho/entomology`,
+    `rblf/training`.
+  - **mad** (4 of 4, all -- no oncho/sch/sth sheets in this country's template):
+    `lf/treatment`, `lf/mmdp`, `lf/tas`, `rblf/training`.
+  - **tcd** (7 of 7, all): `oncho/treatment`, `lf/treatment`, `lf/mmdp`, `lf/tas`,
+    `oncho/prevalence`, `oncho/entomology`, `rblf/training`.
+- **uga's and eth's `oncho/entomology` schemas are structural-only** (no real district
+  `allowed_values`): both countries' real "RB Ento Surveys" sheet has the known duplicate
+  field-code template defect (ADR-0022), which now blocks the whole workbook, so no real
+  ingested data was available to source a district list from this pass. Fill in once a
+  corrected template lets the sheet actually ingest.
+- Each `rblf/training` schema combines every training-sheet prefix that country's CMR
+  template routes to `rblf/training` into one canonical column set, aliasing all of them --
+  same precedent as `sdn_rblf_programmatic_training.yaml`/`ssd_rblf_programmatic_training.yaml`.
+  Ethiopia's "ToT Regional"/"ToT Zonal" sheets are deliberately excluded (distinct field
+  shape that doesn't fit the shared training template, same "scoped narrow" precedent used
+  for `tas`/`entomology`/`prevalence`).
+
 # erifunctions 0.9.38
 
 ## CMR pipeline fixes from the uga/ssd/nga pilot session

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,9 +27,16 @@
 - Each `rblf/training` schema combines every training-sheet prefix that country's CMR
   template routes to `rblf/training` into one canonical column set, aliasing all of them --
   same precedent as `sdn_rblf_programmatic_training.yaml`/`ssd_rblf_programmatic_training.yaml`.
-  Ethiopia's "ToT Regional"/"ToT Zonal" sheets are deliberately excluded (distinct field
-  shape that doesn't fit the shared training template, same "scoped narrow" precedent used
-  for `tas`/`entomology`/`prevalence`).
+  **`eth_rblf_programmatic_training.yaml` includes `#cddtrn_`/`#cstrn_` (CDD/CS Training)
+  structurally**, not from a successfully-ingested sheet -- both sheets hit the same
+  duplicate-field-code defect as "RB Ento Surveys" (ADR-0022) in Ethiopia's real submission.
+  **Known gap, not yet resolved:** Ethiopia's "ToT Regional"/"ToT Zonal" sheets are still
+  routed to `rblf/training` by `inst/schemas/cmr/eth.yaml`, but excluded from this schema --
+  they have no `adm2`/district field at all (distinct donor/goal/tot_reg__male-fem shape),
+  so they can never satisfy this schema's required `district` column. Unlike CDD/CS, ToT
+  sheets ingest fine today, so ingesting one will produce a permanent, unresolvable "district
+  missing" flag under this schema until ToT gets its own `data_type` -- a design decision for
+  a maintainer, not made here.
 
 # erifunctions 0.9.38
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.38 · **Status:** Active development
+**Version:** 0.9.39 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/inst/schemas/eth_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/eth_lf_programmatic_mmdp.yaml
@@ -18,24 +18,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfdmdi_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfdmdi_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -83,7 +81,7 @@ columns:
       - WTH
       - Yem
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -91,74 +89,58 @@ columns:
       - adm3
       - '#lfdmdi_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfdmdi_disease'
   surgery_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_surgeytarget'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_managed
       - '#lfdmdi_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   households_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_hh_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   surgeries_done:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_tot'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   surgeries_achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/eth_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/eth_lf_programmatic_mmdp.yaml
@@ -1,0 +1,164 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfdmdi_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Ethiopia.
+
+country: eth
+disease: lf
+data_source: programmatic
+data_type: mmdp
+version: '1.0'
+description: Ethiopia lf morbidity management and disability prevention (MMDP), 'LF
+  MMDP' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfdmdi_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfdmdi_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfdmdi_adm2'
+    allowed_values:
+      - Agnua
+      - Ari
+      - Awi
+      - Bale
+      - Basketo SpW
+      - Bench Sheko
+      - Buno Bedele
+      - Central Gondar
+      - Dawuro
+      - East Arsi
+      - East Bale
+      - East Hararge
+      - Gofa
+      - Gurage
+      - Hadiya
+      - Illubabor
+      - Itang SpW
+      - Jimma
+      - Kaffa
+      - Konta Special
+      - Liban
+      - Metekel
+      - Mezheng
+      - North Gojam
+      - North Shoa
+      - Sheka
+      - South Gondar
+      - South Omo
+      - South West Shoa
+      - South Wollo
+      - Tambaro SpW
+      - West Gojjam
+      - West Gondar
+      - West Guji
+      - West Hararge
+      - West Omo
+      - Wolayita
+      - WTH
+      - Yem
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfdmdi_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfdmdi_disease'
+  surgery_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_surgeytarget'
+    range:
+      - 0
+      - 50000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_male_tot'
+    range:
+      - 0
+      - 500000
+  female_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_fem_tot'
+    range:
+      - 0
+      - 500000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_managed
+      - '#lfdmdi_tot'
+    range:
+      - 0
+      - 500000
+  households_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_hh_tot'
+    range:
+      - 0
+      - 500000
+  surgeries_done:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_tot'
+    range:
+      - 0
+      - 50000
+  surgeries_achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/eth_lf_programmatic_tas.yaml
+++ b/inst/schemas/eth_lf_programmatic_tas.yaml
@@ -1,0 +1,78 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfsurv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Ethiopia.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: eth
+disease: lf
+data_source: programmatic
+data_type: tas
+version: '1.0'
+description: Ethiopia lf tas surveys, 'LF Surveys' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfsurv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfsurv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfsurv_adm2'
+    allowed_values:
+      - Agnua
+      - Ari
+      - Awi
+      - Bench Sheko
+      - Dawuro
+      - Gofa
+      - Illubabor
+      - Itang SpW
+      - Konta Special
+      - Metekel
+      - Mezheng
+      - South Gondar
+      - South Omo
+      - West Gondar
+      - West Omo
+      - Yem
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfsurv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfsurv_disease'
+

--- a/inst/schemas/eth_lf_programmatic_tas.yaml
+++ b/inst/schemas/eth_lf_programmatic_tas.yaml
@@ -21,24 +21,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfsurv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfsurv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -63,7 +61,7 @@ columns:
       - West Omo
       - Yem
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -71,7 +69,7 @@ columns:
       - adm3
       - '#lfsurv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfsurv_disease'

--- a/inst/schemas/eth_lf_programmatic_treatment.yaml
+++ b/inst/schemas/eth_lf_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lftrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lftrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -59,7 +57,7 @@ columns:
       - West Omo
       - Yem
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -67,85 +65,69 @@ columns:
       - adm3
       - '#lftrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lftrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#lftrt_pop'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#lftrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#lftrt_trttarget'
-    range:
-      - 1
-      - 500000
+    range: [1, 500000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#lftrt_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#lftrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/eth_lf_programmatic_treatment.yaml
+++ b/inst/schemas/eth_lf_programmatic_treatment.yaml
@@ -1,0 +1,160 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lftrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Ethiopia.
+
+country: eth
+disease: lf
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Ethiopia lf MDA coverage, 'LF Treatment' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lftrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lftrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lftrt_adm2'
+    allowed_values:
+      - Agnua
+      - Ari
+      - Awi
+      - Bench Sheko
+      - Dawuro
+      - Gofa
+      - Illubabor
+      - Itang SpW
+      - Konta Special
+      - Metekel
+      - Mezheng
+      - South Gondar
+      - South Omo
+      - West Gondar
+      - West Omo
+      - Yem
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lftrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lftrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#lftrt_pop'
+    range:
+      - 0
+      - 500000
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#lftrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#lftrt_trttarget'
+    range:
+      - 1
+      - 500000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_male_tot'
+    range:
+      - 0
+      - 500000
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_fem_tot'
+    range:
+      - 0
+      - 500000
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#lftrt_tot'
+    range:
+      - 0
+      - 500000
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#lftrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/eth_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/eth_oncho_programmatic_entomology.yaml
@@ -1,0 +1,62 @@
+country: eth
+disease: oncho
+data_source: programmatic
+data_type: entomology
+version: "1.0"
+description: "Ethiopia onchocerciasis entomological (blackfly) surveys, RB Ento Surveys sheet of the monthly CMR"
+language: en
+time_grain: annual
+
+# Built 2026-07-16 from the CMR routing schema's field codes only
+# (inst/schemas/cmr/eth.yaml, #rb_ento_surv_* prefix) -- NOT from a real
+# ingested sheet. Ethiopia's "RB Ento Surveys" sheet (202605 real submission)
+# has the same known duplicate field-code template defect as sdn/ssd/uga
+# ("#rb_ento_surv_notes_jan" typed twice), which now blocks the whole
+# workbook per ADR-0022 -- eri_ingest_cmr() cannot successfully read this
+# sheet at all until the shared Carter Center master template is fixed.
+#
+# Structurally identical to sdn_oncho_programmatic_entomology.yaml (same
+# template, same defect, same "otz" field) since that one WAS built from a
+# real ingested sheet before the whole-workbook block existed. district has
+# no allowed_values here -- no real Ethiopia entomology data has been
+# successfully read yet to source a district list from; add one once a
+# corrected file lets this sheet actually ingest.
+
+temporal:
+  year_col: year
+  period_col: year
+
+preprocessing:
+  - remove_smart_quotes
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, YEAR, "#rb_ento_surv_year"]
+    range: [1990, 2035]
+
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#rb_ento_surv_adm1"]
+
+  district:
+    required: true
+    type: character
+    aliases: [District, district_name, adm2, "#rb_ento_surv_adm2"]
+
+  sub_county:
+    required: false
+    type: character
+    aliases: [SubCounty, sub_county, adm3, "#rb_ento_surv_adm3"]
+
+  otz:
+    required: false
+    type: character
+    aliases: ["#rb_ento_surv_otz"]
+
+  disease_reported:
+    required: false
+    type: character
+    aliases: ["#rb_ento_surv_disease"]

--- a/inst/schemas/eth_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/eth_oncho_programmatic_prevalence.yaml
@@ -22,24 +22,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rb_epi_surv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rb_epi_surv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -87,7 +85,7 @@ columns:
       - WTH
       - Yem
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -95,12 +93,12 @@ columns:
       - adm3
       - '#rb_epi_surv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_disease'
   otz:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_otz'

--- a/inst/schemas/eth_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/eth_oncho_programmatic_prevalence.yaml
@@ -1,0 +1,107 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rb_epi_surv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Ethiopia.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: eth
+disease: oncho
+data_source: programmatic
+data_type: prevalence
+version: '1.0'
+description: Ethiopia oncho prevalence surveys, 'RB Epi Surveys' sheet of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rb_epi_surv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rb_epi_surv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rb_epi_surv_adm2'
+    allowed_values:
+      - Agnua
+      - Ari
+      - Awi
+      - Bale
+      - Basketo SpW
+      - Bench Sheko
+      - Buno Bedele
+      - Central Gondar
+      - Dawuro
+      - East Arsi
+      - East Bale
+      - East Hararge
+      - Gofa
+      - Gurage
+      - Hadiya
+      - Illubabor
+      - Itang SpW
+      - Jimma
+      - Kaffa
+      - Konta Special
+      - Liban
+      - Metekel
+      - Mezheng
+      - North Gojam
+      - North Shoa
+      - Sheka
+      - South Gondar
+      - South Omo
+      - South West Shoa
+      - South Wollo
+      - Tambaro SpW
+      - West Gojjam
+      - West Gondar
+      - West Guji
+      - West Hararge
+      - West Omo
+      - Wolayita
+      - WTH
+      - Yem
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rb_epi_surv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_disease'
+  otz:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_otz'
+

--- a/inst/schemas/eth_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/eth_oncho_programmatic_treatment.yaml
@@ -1,0 +1,183 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rbtrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Ethiopia.
+
+country: eth
+disease: oncho
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Ethiopia oncho MDA coverage, 'RB Treatment' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rbtrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rbtrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rbtrt_adm2'
+    allowed_values:
+      - Agnua
+      - Ari
+      - Awi
+      - Bale
+      - Basketo SpW
+      - Bench Sheko
+      - Buno Bedele
+      - Central Gondar
+      - Dawuro
+      - East Arsi
+      - East Bale
+      - East Hararge
+      - Gofa
+      - Gurage
+      - Hadiya
+      - Illubabor
+      - Itang SpW
+      - Jimma
+      - Kaffa
+      - Konta Special
+      - Liban
+      - Metekel
+      - Mezheng
+      - North Gojam
+      - North Shoa
+      - Sheka
+      - South Gondar
+      - South Omo
+      - South West Shoa
+      - South Wollo
+      - Tambaro SpW
+      - West Gojjam
+      - West Gondar
+      - West Guji
+      - West Hararge
+      - West Omo
+      - Wolayita
+      - WTH
+      - Yem
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rbtrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rbtrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#rbtrt_pop'
+    range:
+      - 0
+      - 775490
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#rbtrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#rbtrt_trttarget'
+    range:
+      - 1
+      - 1302823
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_male_tot'
+    range:
+      - 0
+      - 950016
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_fem_tot'
+    range:
+      - 0
+      - 950016
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#rbtrt_tot'
+    range:
+      - 0
+      - 950016
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#rbtrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/eth_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/eth_oncho_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rbtrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rbtrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -82,7 +80,7 @@ columns:
       - WTH
       - Yem
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -90,85 +88,69 @@ columns:
       - adm3
       - '#rbtrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rbtrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#rbtrt_pop'
-    range:
-      - 0
-      - 775490
+    range: [0, 775490]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#rbtrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#rbtrt_trttarget'
-    range:
-      - 1
-      - 1302823
+    range: [1, 1302823]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_male_tot'
-    range:
-      - 0
-      - 950016
+    range: [0, 950016]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_fem_tot'
-    range:
-      - 0
-      - 950016
+    range: [0, 950016]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#rbtrt_tot'
-    range:
-      - 0
-      - 950016
+    range: [0, 950016]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#rbtrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -22,11 +22,16 @@
 # mapping is exact even though it wasn't recon-verified against live data this pass.
 #
 # eth.yaml ALSO routes "ToT Regional"/"ToT Zonal" to rblf/training, deliberately NOT
-# aliased here: those two sheets have no adm2/district field at all (donor/goal/
-# tot_reg__male-fem instead), so they can never satisfy this schema's required `district`
-# column. Unlike CDD/CS (blocked entirely by the template defect), ToT sheets ingest fine
-# today -- ingesting one will produce a permanent, unresolvable "district missing" flag
-# under this schema until ToT gets its own data_type. Known gap, not silently dropped.
+# aliased here. "ToT Regional" has no adm2/district field at all (donor/goal/
+# tot_reg__male-fem instead), so it can never satisfy this schema's required `district`
+# column under any alias mapping. "ToT Zonal" DOES have an adm2 field (donor/goal/
+# tot_zone__male-fem alongside adm0/adm1/adm2) but a genuinely different field shape from
+# the other 8 sheets (no adm3/disease, distinct tot_zone__male/fem naming) -- not aliased
+# here either, pending a decision on whether it fits this schema or needs its own
+# data_type. Unlike CDD/CS (blocked entirely by the template defect), both ToT sheets
+# ingest fine today -- ingesting either will produce a permanent, unresolvable DQ flag
+# under this schema (missing `district` for Regional; missing required fields more
+# generally for Zonal) until this gap is resolved. Known gap, not silently dropped.
 
 country: eth
 disease: rblf

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -1,13 +1,32 @@
-# Built 2026-07-16 against the REAL CMR field codes (#dmditrnsx_* / #dmditrnpt_* / #entotrn_* / #hgtrn_* / #hwtrn_* / #labtrn_*), via read-only
-# recon (structure/aggregate counts only, no records persisted or shared) against the
-# real 202605 submission from Ethiopia.
+# Built 2026-07-16 against the REAL CMR field codes (#cddtrn_* / #cstrn_* / #dmditrnsx_* /
+# #dmditrnpt_* / #entotrn_* / #hgtrn_* / #hwtrn_* / #labtrn_*), via read-only recon
+# (structure/aggregate counts only, no records persisted or shared) against the real
+# 202605 submission from Ethiopia.
 #
-# ONE schema covers all training sheets present this period (MMDP (surgery) Training, MMDP (patient) Training, Field Ento Training, Hope Group Leader Training, HW Training, Lab Training) because
-# eri_split_cmr() routes all of them to the same disease/data_type combo (rblf/training,
-# per ADR-0012's combined training code) -- load_dq_schema() can only resolve one file
-# per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
-# prefix present, so aliasing every prefix under one canonical column set works:
-# run_dq_checks() resolves whichever alias matches the data actually present.
+# ONE schema covers all 8 training sheets inst/schemas/cmr/eth.yaml routes to rblf/training
+# (CDD Training, CS Training, MMDP (surgery) Training, MMDP (patient) Training, Field Ento
+# Training, Hope Group Leader Training, HW Training, Lab Training) because eri_split_cmr()
+# routes all of them to the same disease/data_type combo (rblf/training, per ADR-0012's
+# combined training code) -- load_dq_schema() can only resolve one file per (country,
+# disease, data_source, data_type). Each ingested sheet only ever has ONE prefix present,
+# so aliasing every prefix under one canonical column set works: run_dq_checks() resolves
+# whichever alias matches the data actually present.
+#
+# CDD Training and CS Training's #cddtrn_/#cstrn_ aliases are added STRUCTURALLY here, not
+# from a successfully-ingested sheet: Ethiopia's real 202605 submission has the same known
+# duplicate field-code template defect on both sheets ("#cddtrn_male_oct"/"#cstrn_male_oct"
+# each typed twice), which now blocks the whole workbook per ADR-0022 -- eri_ingest_cmr()
+# cannot read either sheet until the shared Carter Center master template is fixed. Their
+# field shape (year/adm0-3/disease/goal/tot_male/tot_fem/tot/achieved) is identical to the
+# other 6 training types per inst/schemas/cmr/eth.yaml's required_fields, so the alias
+# mapping is exact even though it wasn't recon-verified against live data this pass.
+#
+# eth.yaml ALSO routes "ToT Regional"/"ToT Zonal" to rblf/training, deliberately NOT
+# aliased here: those two sheets have no adm2/district field at all (donor/goal/
+# tot_reg__male-fem instead), so they can never satisfy this schema's required `district`
+# column. Unlike CDD/CS (blocked entirely by the template defect), ToT sheets ingest fine
+# today -- ingesting one will produce a permanent, unresolvable "district missing" flag
+# under this schema until ToT gets its own data_type. Known gap, not silently dropped.
 
 country: eth
 disease: rblf
@@ -25,11 +44,13 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
+      - '#cddtrn_year'
+      - '#cstrn_year'
       - '#dmditrnsx_year'
       - '#dmditrnpt_year'
       - '#entotrn_year'
@@ -37,11 +58,13 @@ columns:
       - '#hwtrn_year'
       - '#labtrn_year'
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
+      - '#cddtrn_adm1'
+      - '#cstrn_adm1'
       - '#dmditrnsx_adm1'
       - '#dmditrnpt_adm1'
       - '#entotrn_adm1'
@@ -49,12 +72,14 @@ columns:
       - '#hwtrn_adm1'
       - '#labtrn_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
       - district_name
       - adm2
+      - '#cddtrn_adm2'
+      - '#cstrn_adm2'
       - '#dmditrnsx_adm2'
       - '#dmditrnpt_adm2'
       - '#entotrn_adm2'
@@ -110,12 +135,14 @@ columns:
       - WTH
       - Yem
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
       - sub_county
       - adm3
+      - '#cddtrn_adm3'
+      - '#cstrn_adm3'
       - '#dmditrnsx_adm3'
       - '#dmditrnpt_adm3'
       - '#entotrn_adm3'
@@ -123,9 +150,11 @@ columns:
       - '#hwtrn_adm3'
       - '#labtrn_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
+      - '#cddtrn_disease'
+      - '#cstrn_disease'
       - '#dmditrnsx_disease'
       - '#dmditrnpt_disease'
       - '#entotrn_disease'
@@ -133,69 +162,69 @@ columns:
       - '#hwtrn_disease'
       - '#labtrn_disease'
   goal:
-    required: no
+    required: false
     type: numeric
     aliases:
+      - '#cddtrn_goal'
+      - '#cstrn_goal'
       - '#dmditrnsx_goal'
       - '#dmditrnpt_goal'
       - '#entotrn_goal'
       - '#hgtrn_goal'
       - '#hwtrn_goal'
       - '#labtrn_goal'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
+      - '#cddtrn_tot_male'
+      - '#cstrn_tot_male'
       - '#dmditrnsx_tot_male'
       - '#dmditrnpt_tot_male'
       - '#entotrn_tot_male'
       - '#hgtrn_tot_male'
       - '#hwtrn_tot_male'
       - '#labtrn_tot_male'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   female_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
+      - '#cddtrn_tot_fem'
+      - '#cstrn_tot_fem'
       - '#dmditrnsx_tot_fem'
       - '#dmditrnpt_tot_fem'
       - '#entotrn_tot_fem'
       - '#hgtrn_tot_fem'
       - '#hwtrn_tot_fem'
       - '#labtrn_tot_fem'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Trained
+      - '#cddtrn_tot'
+      - '#cstrn_tot'
       - '#dmditrnsx_tot'
       - '#dmditrnpt_tot'
       - '#entotrn_tot'
       - '#hgtrn_tot'
       - '#hwtrn_tot'
       - '#labtrn_tot'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
+      - '#cddtrn_achieved'
+      - '#cstrn_achieved'
       - '#dmditrnsx_achieved'
       - '#dmditrnpt_achieved'
       - '#entotrn_achieved'
       - '#hgtrn_achieved'
       - '#hwtrn_achieved'
       - '#labtrn_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -1,0 +1,201 @@
+# Built 2026-07-16 against the REAL CMR field codes (#dmditrnsx_* / #dmditrnpt_* / #entotrn_* / #hgtrn_* / #hwtrn_* / #labtrn_*), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Ethiopia.
+#
+# ONE schema covers all training sheets present this period (MMDP (surgery) Training, MMDP (patient) Training, Field Ento Training, Hope Group Leader Training, HW Training, Lab Training) because
+# eri_split_cmr() routes all of them to the same disease/data_type combo (rblf/training,
+# per ADR-0012's combined training code) -- load_dq_schema() can only resolve one file
+# per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
+# prefix present, so aliasing every prefix under one canonical column set works:
+# run_dq_checks() resolves whichever alias matches the data actually present.
+
+country: eth
+disease: rblf
+data_source: programmatic
+data_type: training
+version: '1.0'
+description: Ethiopia RB+LF programme trainings, combined training sheets of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#dmditrnsx_year'
+      - '#dmditrnpt_year'
+      - '#entotrn_year'
+      - '#hgtrn_year'
+      - '#hwtrn_year'
+      - '#labtrn_year'
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#dmditrnsx_adm1'
+      - '#dmditrnpt_adm1'
+      - '#entotrn_adm1'
+      - '#hgtrn_adm1'
+      - '#hwtrn_adm1'
+      - '#labtrn_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#dmditrnsx_adm2'
+      - '#dmditrnpt_adm2'
+      - '#entotrn_adm2'
+      - '#hgtrn_adm2'
+      - '#hwtrn_adm2'
+      - '#labtrn_adm2'
+    allowed_values:
+      - Agnua
+      - Amhara
+      - Ari
+      - Awi
+      - Bale
+      - Basketo SpW
+      - Bench Sheko
+      - Benishangul Gumz
+      - Buno Bedele
+      - Central
+      - Central Gondar
+      - Dawuro
+      - East Arsi
+      - East Bale
+      - East Hararge
+      - Gambella
+      - Gofa
+      - Gurage
+      - Hadiya
+      - Illubabor
+      - Itang SpW
+      - Jimma
+      - Kaffa
+      - Konta Special
+      - Liban
+      - Metekel
+      - Mezheng
+      - North Gojam
+      - North Shoa
+      - Oromia
+      - Sheka
+      - Somali
+      - South
+      - South Gondar
+      - South Omo
+      - South West Shoa
+      - South Wollo
+      - SWEPR
+      - Tambaro SpW
+      - West Gojjam
+      - West Gondar
+      - West Guji
+      - West Hararge
+      - West Omo
+      - Wolayita
+      - WTH
+      - Yem
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#dmditrnsx_adm3'
+      - '#dmditrnpt_adm3'
+      - '#entotrn_adm3'
+      - '#hgtrn_adm3'
+      - '#hwtrn_adm3'
+      - '#labtrn_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#dmditrnsx_disease'
+      - '#dmditrnpt_disease'
+      - '#entotrn_disease'
+      - '#hgtrn_disease'
+      - '#hwtrn_disease'
+      - '#labtrn_disease'
+  goal:
+    required: no
+    type: numeric
+    aliases:
+      - '#dmditrnsx_goal'
+      - '#dmditrnpt_goal'
+      - '#entotrn_goal'
+      - '#hgtrn_goal'
+      - '#hwtrn_goal'
+      - '#labtrn_goal'
+    range:
+      - 0
+      - 5000
+  male_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#dmditrnsx_tot_male'
+      - '#dmditrnpt_tot_male'
+      - '#entotrn_tot_male'
+      - '#hgtrn_tot_male'
+      - '#hwtrn_tot_male'
+      - '#labtrn_tot_male'
+    range:
+      - 0
+      - 1000
+  female_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#dmditrnsx_tot_fem'
+      - '#dmditrnpt_tot_fem'
+      - '#entotrn_tot_fem'
+      - '#hgtrn_tot_fem'
+      - '#hwtrn_tot_fem'
+      - '#labtrn_tot_fem'
+    range:
+      - 0
+      - 1000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Trained
+      - '#dmditrnsx_tot'
+      - '#dmditrnpt_tot'
+      - '#entotrn_tot'
+      - '#hgtrn_tot'
+      - '#hwtrn_tot'
+      - '#labtrn_tot'
+    range:
+      - 0
+      - 1000
+  achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#dmditrnsx_achieved'
+      - '#dmditrnpt_achieved'
+      - '#entotrn_achieved'
+      - '#hgtrn_achieved'
+      - '#hwtrn_achieved'
+      - '#labtrn_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/mad_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/mad_lf_programmatic_mmdp.yaml
@@ -18,24 +18,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfdmdi_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfdmdi_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -65,7 +63,7 @@ columns:
       - Sofia
       - Vatovavy- Fitovinany
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -73,74 +71,58 @@ columns:
       - adm3
       - '#lfdmdi_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfdmdi_disease'
   surgery_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_surgeytarget'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_managed
       - '#lfdmdi_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   households_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_hh_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   surgeries_done:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_tot'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   surgeries_achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/mad_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/mad_lf_programmatic_mmdp.yaml
@@ -1,0 +1,146 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfdmdi_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202604 submission from Madagascar.
+
+country: mad
+disease: lf
+data_source: programmatic
+data_type: mmdp
+version: '1.0'
+description: Madagascar lf morbidity management and disability prevention (MMDP),
+  'PCMPI FL' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfdmdi_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfdmdi_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfdmdi_adm2'
+    allowed_values:
+      - Alaotra Mango-ro
+      - Amoron'i Mania
+      - Analamanga
+      - Analanjirofo
+      - Androy
+      - Anosy
+      - Atsimo- Atsinanana
+      - Atsimo Andrefana
+      - Atsinanana
+      - Betsiboka-Betsiboka
+      - Boeny
+      - Bongolava
+      - Diana
+      - Haute Matsiatra
+      - Ihorombe
+      - Itasy
+      - Melaky
+      - Menabe
+      - Sava
+      - Sofia
+      - Vatovavy- Fitovinany
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfdmdi_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfdmdi_disease'
+  surgery_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_surgeytarget'
+    range:
+      - 0
+      - 50000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_male_tot'
+    range:
+      - 0
+      - 500000
+  female_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_fem_tot'
+    range:
+      - 0
+      - 500000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_managed
+      - '#lfdmdi_tot'
+    range:
+      - 0
+      - 500000
+  households_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_hh_tot'
+    range:
+      - 0
+      - 500000
+  surgeries_done:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_tot'
+    range:
+      - 0
+      - 50000
+  surgeries_achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/mad_lf_programmatic_tas.yaml
+++ b/inst/schemas/mad_lf_programmatic_tas.yaml
@@ -21,24 +21,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfsurv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfsurv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -67,7 +65,7 @@ columns:
       - Sofia
       - Vatovavy- Fitovinany
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -75,7 +73,7 @@ columns:
       - adm3
       - '#lfsurv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfsurv_disease'

--- a/inst/schemas/mad_lf_programmatic_tas.yaml
+++ b/inst/schemas/mad_lf_programmatic_tas.yaml
@@ -1,0 +1,82 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfsurv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202604 submission from Madagascar.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: mad
+disease: lf
+data_source: programmatic
+data_type: tas
+version: '1.0'
+description: Madagascar lf tas surveys, 'FL Enquetes' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfsurv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfsurv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfsurv_adm2'
+    allowed_values:
+      - Alaotra Mango-ro
+      - Amoron'i Mania
+      - Analamanga
+      - Analanjirofo
+      - Anosy
+      - Atsimo- Atsinanana
+      - Atsimo Andrefana
+      - Atsinanana
+      - Betsiboka-Betsiboka
+      - Boeny
+      - Bongolava
+      - Diana
+      - Haute Matsiatra
+      - Ihorombe
+      - Itasy
+      - Melaky
+      - Menabe
+      - Sava
+      - Sofia
+      - Vatovavy- Fitovinany
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfsurv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfsurv_disease'
+

--- a/inst/schemas/mad_lf_programmatic_treatment.yaml
+++ b/inst/schemas/mad_lf_programmatic_treatment.yaml
@@ -1,0 +1,164 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lftrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202604 submission from Madagascar.
+
+country: mad
+disease: lf
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Madagascar lf MDA coverage, 'Traitement FL' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lftrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lftrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lftrt_adm2'
+    allowed_values:
+      - Alaotra Mango-ro
+      - Amoron'i Mania
+      - Analamanga
+      - Analanjirofo
+      - Anosy
+      - Atsimo- Atsinanana
+      - Atsimo Andrefana
+      - Atsinanana
+      - Betsiboka-Betsiboka
+      - Boeny
+      - Bongolava
+      - Diana
+      - Haute Matsiatra
+      - Ihorombe
+      - Itasy
+      - Melaky
+      - Menabe
+      - Sava
+      - Sofia
+      - Vatovavy- Fitovinany
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lftrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lftrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#lftrt_pop'
+    range:
+      - 0
+      - 1257058
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#lftrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#lftrt_trttarget'
+    range:
+      - 1
+      - 500000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_male_tot'
+    range:
+      - 0
+      - 564183
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_fem_tot'
+    range:
+      - 0
+      - 564183
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#lftrt_tot'
+    range:
+      - 0
+      - 564183
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#lftrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/mad_lf_programmatic_treatment.yaml
+++ b/inst/schemas/mad_lf_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lftrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lftrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -63,7 +61,7 @@ columns:
       - Sofia
       - Vatovavy- Fitovinany
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -71,85 +69,69 @@ columns:
       - adm3
       - '#lftrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lftrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#lftrt_pop'
-    range:
-      - 0
-      - 1257058
+    range: [0, 1257058]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#lftrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#lftrt_trttarget'
-    range:
-      - 1
-      - 500000
+    range: [1, 500000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_male_tot'
-    range:
-      - 0
-      - 564183
+    range: [0, 564183]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_fem_tot'
-    range:
-      - 0
-      - 564183
+    range: [0, 564183]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#lftrt_tot'
-    range:
-      - 0
-      - 564183
+    range: [0, 564183]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#lftrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/mad_rblf_programmatic_training.yaml
+++ b/inst/schemas/mad_rblf_programmatic_training.yaml
@@ -1,0 +1,185 @@
+# Built 2026-07-16 against the REAL CMR field codes (#cddtrn_* / #cstrn_* / #dmditrnsx_* / #dmditrnpt_* / #hwtrn_* / #hgtrn_* / #tchrtrn_*), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202604 submission from Madagascar.
+#
+# ONE schema covers all training sheets present this period (Formation Distributeurs, Formation SC, PCMPI Formation Chirurgie, Formation PCMPI Patient, Formation Travailleurs de Sante, Formation Leader Groupe HOPE, Formation Professeurs) because
+# eri_split_cmr() routes all of them to the same disease/data_type combo (rblf/training,
+# per ADR-0012's combined training code) -- load_dq_schema() can only resolve one file
+# per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
+# prefix present, so aliasing every prefix under one canonical column set works:
+# run_dq_checks() resolves whichever alias matches the data actually present.
+
+country: mad
+disease: rblf
+data_source: programmatic
+data_type: training
+version: '1.0'
+description: Madagascar RB+LF programme trainings, combined training sheets of the
+  monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#cddtrn_year'
+      - '#cstrn_year'
+      - '#dmditrnsx_year'
+      - '#dmditrnpt_year'
+      - '#hwtrn_year'
+      - '#hgtrn_year'
+      - '#tchrtrn_year'
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#cddtrn_adm1'
+      - '#cstrn_adm1'
+      - '#dmditrnsx_adm1'
+      - '#dmditrnpt_adm1'
+      - '#hwtrn_adm1'
+      - '#hgtrn_adm1'
+      - '#tchrtrn_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#cddtrn_adm2'
+      - '#cstrn_adm2'
+      - '#dmditrnsx_adm2'
+      - '#dmditrnpt_adm2'
+      - '#hwtrn_adm2'
+      - '#hgtrn_adm2'
+      - '#tchrtrn_adm2'
+    allowed_values:
+      - Alaotra Mango-ro
+      - Amoron'i Mania
+      - Analamanga
+      - Analanjirofo
+      - Androy
+      - Anosy
+      - Atsimo- Atsinanana
+      - Atsimo Andrefana
+      - Atsinanana
+      - Betsiboka-Betsiboka
+      - Boeny
+      - Bongolava
+      - Diana
+      - Haute Matsiatra
+      - Ihorombe
+      - Itasy
+      - Melaky
+      - Menabe
+      - Sava
+      - Sofia
+      - Vatovavy- Fitovinany
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#cddtrn_adm3'
+      - '#cstrn_adm3'
+      - '#dmditrnsx_adm3'
+      - '#dmditrnpt_adm3'
+      - '#hwtrn_adm3'
+      - '#hgtrn_adm3'
+      - '#tchrtrn_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#cddtrn_disease'
+      - '#cstrn_disease'
+      - '#dmditrnsx_disease'
+      - '#dmditrnpt_disease'
+      - '#hwtrn_disease'
+      - '#hgtrn_disease'
+      - '#tchrtrn_disease'
+  goal:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_goal'
+      - '#cstrn_goal'
+      - '#dmditrnsx_goal'
+      - '#dmditrnpt_goal'
+      - '#hwtrn_goal'
+      - '#hgtrn_goal'
+      - '#tchrtrn_goal'
+    range:
+      - 0
+      - 5000
+  male_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_tot_male'
+      - '#cstrn_tot_male'
+      - '#dmditrnsx_tot_male'
+      - '#dmditrnpt_tot_male'
+      - '#hwtrn_tot_male'
+      - '#hgtrn_tot_male'
+      - '#tchrtrn_tot_male'
+    range:
+      - 0
+      - 1000
+  female_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_tot_fem'
+      - '#cstrn_tot_fem'
+      - '#dmditrnsx_tot_fem'
+      - '#dmditrnpt_tot_fem'
+      - '#hwtrn_tot_fem'
+      - '#hgtrn_tot_fem'
+      - '#tchrtrn_tot_fem'
+    range:
+      - 0
+      - 1000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Trained
+      - '#cddtrn_tot'
+      - '#cstrn_tot'
+      - '#dmditrnsx_tot'
+      - '#dmditrnpt_tot'
+      - '#hwtrn_tot'
+      - '#hgtrn_tot'
+      - '#tchrtrn_tot'
+    range:
+      - 0
+      - 1000
+  achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_achieved'
+      - '#cstrn_achieved'
+      - '#dmditrnsx_achieved'
+      - '#dmditrnpt_achieved'
+      - '#hwtrn_achieved'
+      - '#hgtrn_achieved'
+      - '#tchrtrn_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/mad_rblf_programmatic_training.yaml
+++ b/inst/schemas/mad_rblf_programmatic_training.yaml
@@ -25,7 +25,7 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
@@ -38,7 +38,7 @@ columns:
       - '#hgtrn_year'
       - '#tchrtrn_year'
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
@@ -51,7 +51,7 @@ columns:
       - '#hgtrn_adm1'
       - '#tchrtrn_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -87,7 +87,7 @@ columns:
       - Sofia
       - Vatovavy- Fitovinany
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -101,7 +101,7 @@ columns:
       - '#hgtrn_adm3'
       - '#tchrtrn_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#cddtrn_disease'
@@ -112,7 +112,7 @@ columns:
       - '#hgtrn_disease'
       - '#tchrtrn_disease'
   goal:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_goal'
@@ -122,11 +122,9 @@ columns:
       - '#hwtrn_goal'
       - '#hgtrn_goal'
       - '#tchrtrn_goal'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_tot_male'
@@ -136,11 +134,9 @@ columns:
       - '#hwtrn_tot_male'
       - '#hgtrn_tot_male'
       - '#tchrtrn_tot_male'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   female_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_tot_fem'
@@ -150,11 +146,9 @@ columns:
       - '#hwtrn_tot_fem'
       - '#hgtrn_tot_fem'
       - '#tchrtrn_tot_fem'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Trained
@@ -165,11 +159,9 @@ columns:
       - '#hwtrn_tot'
       - '#hgtrn_tot'
       - '#tchrtrn_tot'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_achieved'
@@ -179,7 +171,5 @@ columns:
       - '#hwtrn_achieved'
       - '#hgtrn_achieved'
       - '#tchrtrn_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/nga_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/nga_lf_programmatic_mmdp.yaml
@@ -1,0 +1,293 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfdmdi_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+
+country: nga
+disease: lf
+data_source: programmatic
+data_type: mmdp
+version: '1.0'
+description: Nigeria lf morbidity management and disability prevention (MMDP), 'LF
+  MMDP' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfdmdi_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfdmdi_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfdmdi_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Aboh-Mbaise
+      - Afikpo North
+      - Afikpo South
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akoko-Edo
+      - Akwanga
+      - Anambra East
+      - Anambra West
+      - Anaocha
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awe
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Barkin Ladi
+      - Bassa
+      - Bende
+      - Bokkos
+      - Bomadi
+      - Burutu
+      - Doma
+      - Dunukofia
+      - Ebonyi
+      - Egor
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Enugu North
+      - Enugu South
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ezza South
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze North
+      - Igbo-Eze South
+      - Igbo Etiti
+      - Igueben
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikpoba-Okha
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isoko South
+      - Isu
+      - Ivo
+      - Izzi
+      - Jos East
+      - Jos North
+      - Jos South
+      - Kanem
+      - Kanke
+      - Karu
+      - Keana
+      - Keffi
+      - Kokona
+      - Lafia
+      - Langtan North
+      - Langtan South
+      - Mangu
+      - Mbaitoli
+      - Mikang
+      - Nasarawa
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ndokwa West
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obi
+      - Obio-Ngwa
+      - Obowo
+      - Ogbaru
+      - Oguta
+      - Ohafia
+      - Ohaji/Egbema
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Okpe
+      - Onicha
+      - Onitsha North
+      - Onitsha South
+      - Onuimo
+      - Oredo
+      - Orhionmwon
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Oru East
+      - Oru West
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Osisioma Ngwa
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Owerri municipal
+      - Owerri North
+      - Owerri West
+      - Oyi
+      - Pankshin
+      - Patani
+      - Quan'Pam
+      - Riyom
+      - Sapele
+      - Shendam
+      - Toto
+      - Udenu
+      - Udi
+      - Udu
+      - Ughelli North
+      - Ughelli South
+      - Ugwunagbo
+      - Uhunmwonde
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uvwie
+      - Uzo-Uwani
+      - Wamba
+      - Warii North
+      - Warri South
+      - Warri South West
+      - Wase
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfdmdi_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfdmdi_disease'
+  surgery_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_surgeytarget'
+    range:
+      - 0
+      - 50000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_male_tot'
+    range:
+      - 0
+      - 500000
+  female_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_fem_tot'
+    range:
+      - 0
+      - 500000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_managed
+      - '#lfdmdi_tot'
+    range:
+      - 0
+      - 500000
+  households_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_hh_tot'
+    range:
+      - 0
+      - 500000
+  surgeries_done:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_tot'
+    range:
+      - 0
+      - 50000
+  surgeries_achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/nga_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/nga_lf_programmatic_mmdp.yaml
@@ -18,24 +18,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfdmdi_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfdmdi_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -212,7 +210,7 @@ columns:
       - Warri South West
       - Wase
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -220,74 +218,58 @@ columns:
       - adm3
       - '#lfdmdi_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfdmdi_disease'
   surgery_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_surgeytarget'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_managed
       - '#lfdmdi_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   households_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_hh_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   surgeries_done:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_tot'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   surgeries_achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/nga_lf_programmatic_tas.yaml
+++ b/inst/schemas/nga_lf_programmatic_tas.yaml
@@ -1,0 +1,203 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfsurv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: nga
+disease: lf
+data_source: programmatic
+data_type: tas
+version: '1.0'
+description: Nigeria lf tas surveys, 'LF Surveys' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfsurv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfsurv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfsurv_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Aboh-Mbaise
+      - Afikpo North
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akoko-Edo
+      - Akwanga
+      - Anambra East
+      - Anambra West
+      - Anaocha
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awe
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Barkin Ladi
+      - Bassa
+      - Bende
+      - Bokkos
+      - Bomadi
+      - Doma
+      - Dunukofia
+      - Ebonyi
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Enugu North
+      - Enugu South
+      - Esan North East
+      - Esan South East
+      - Ethiope East
+      - Etsako Central
+      - Etsako West
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isoko South
+      - Isu
+      - Izzi
+      - Jos East
+      - Jos North
+      - Jos South
+      - Kanem
+      - Kanke
+      - Karu
+      - Keana
+      - Keffi
+      - Kokona
+      - Lafia
+      - Langtan North
+      - Langtan South
+      - Mangu
+      - Mbaitoli
+      - Mikang
+      - Nasarawa
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obi
+      - Obio-Ngwa
+      - Obowo
+      - Ogbaru
+      - Oguta
+      - Ohafia
+      - Ohaji/Egbema
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Onitsha North
+      - Onitsha South
+      - Onuimo
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Oru East
+      - Oru West
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Osisioma Ngwa
+      - Ovia South West
+      - Owan East
+      - Owerri municipal
+      - Owerri North
+      - Owerri West
+      - Oyi
+      - Pankshin
+      - Patani
+      - Quan'Pam
+      - Riyom
+      - Shendam
+      - Toto
+      - Udenu
+      - Udi
+      - Udu
+      - Ugwunagbo
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Wamba
+      - Warii North
+      - Warri South
+      - Warri South West
+      - Wase
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfsurv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfsurv_disease'
+

--- a/inst/schemas/nga_lf_programmatic_tas.yaml
+++ b/inst/schemas/nga_lf_programmatic_tas.yaml
@@ -21,24 +21,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfsurv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfsurv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -188,7 +186,7 @@ columns:
       - Warri South West
       - Wase
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -196,7 +194,7 @@ columns:
       - adm3
       - '#lfsurv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfsurv_disease'

--- a/inst/schemas/nga_lf_programmatic_treatment.yaml
+++ b/inst/schemas/nga_lf_programmatic_treatment.yaml
@@ -1,0 +1,285 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lftrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+
+country: nga
+disease: lf
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Nigeria lf MDA coverage, 'LF Treatment' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lftrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lftrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lftrt_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Aboh-Mbaise
+      - Afikpo North
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akoko-Edo
+      - Akwanga
+      - Anambra East
+      - Anambra West
+      - Anaocha
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awe
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Barkin Ladi
+      - Bassa
+      - Bende
+      - Bokkos
+      - Bomadi
+      - Doma
+      - Dunukofia
+      - Ebonyi
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Enugu North
+      - Enugu South
+      - Esan North East
+      - Esan South East
+      - Ethiope East
+      - Etsako Central
+      - Etsako West
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isoko South
+      - Isu
+      - Izzi
+      - Jos East
+      - Jos North
+      - Jos South
+      - Kanem
+      - Kanke
+      - Karu
+      - Keana
+      - Keffi
+      - Kokona
+      - Lafia
+      - Langtan North
+      - Langtan South
+      - Mangu
+      - Mbaitoli
+      - Mikang
+      - Nasarawa
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obi
+      - Obio-Ngwa
+      - Obowo
+      - Ogbaru
+      - Oguta
+      - Ohafia
+      - Ohaji/Egbema
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Onitsha North
+      - Onitsha South
+      - Onuimo
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Oru East
+      - Oru West
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Osisioma Ngwa
+      - Ovia South West
+      - Owan East
+      - Owerri municipal
+      - Owerri North
+      - Owerri West
+      - Oyi
+      - Pankshin
+      - Patani
+      - Quan'Pam
+      - Riyom
+      - Shendam
+      - Toto
+      - Udenu
+      - Udi
+      - Udu
+      - Ugwunagbo
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Wamba
+      - Warii North
+      - Warri South
+      - Warri South West
+      - Wase
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lftrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lftrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#lftrt_pop'
+    range:
+      - 0
+      - 1411776
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#lftrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#lftrt_trttarget'
+    range:
+      - 1
+      - 500000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_male_tot'
+    range:
+      - 0
+      - 500000
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_fem_tot'
+    range:
+      - 0
+      - 500000
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#lftrt_tot'
+    range:
+      - 0
+      - 500000
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#lftrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/nga_lf_programmatic_treatment.yaml
+++ b/inst/schemas/nga_lf_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lftrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lftrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -184,7 +182,7 @@ columns:
       - Warri South West
       - Wase
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -192,85 +190,69 @@ columns:
       - adm3
       - '#lftrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lftrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#lftrt_pop'
-    range:
-      - 0
-      - 1411776
+    range: [0, 1411776]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#lftrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#lftrt_trttarget'
-    range:
-      - 1
-      - 500000
+    range: [1, 500000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#lftrt_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#lftrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/nga_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/nga_oncho_programmatic_entomology.yaml
@@ -22,24 +22,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rb_ento_surv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rb_ento_surv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -190,7 +188,7 @@ columns:
       - Yakur
       - Yala
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -198,12 +196,12 @@ columns:
       - adm3
       - '#rb_ento_surv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_ento_surv_disease'
   otz:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_ento_surv_otz'

--- a/inst/schemas/nga_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/nga_oncho_programmatic_entomology.yaml
@@ -1,0 +1,210 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rb_ento_surv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: nga
+disease: oncho
+data_source: programmatic
+data_type: entomology
+version: '1.0'
+description: Nigeria oncho entomology surveys, 'RB Ento Surveys' sheet of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rb_ento_surv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rb_ento_surv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rb_ento_surv_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Abo-Mbaise
+      - Afikpo North
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akamkpa
+      - Akoko-Edo
+      - Akpabuyo
+      - Akwanga
+      - Anaocha
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Bakasi
+      - Bassa
+      - Bekwara
+      - Bende
+      - Biase
+      - Boki
+      - Bokkos
+      - Calabar Municipal
+      - Dunukofia
+      - Ebonyi
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Etung
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ezza South
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze North
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Igueben
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikom
+      - Ikpoba-Okha
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isu
+      - Ivo
+      - Izzi
+      - Jos East
+      - Kanke
+      - Karu
+      - Kokona
+      - Lafia
+      - Mbaitoli
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ndokwa West
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obanliku
+      - Obio-Ngwa
+      - Obowo
+      - Obubra
+      - Obudu
+      - Odukpani
+      - Ogoja
+      - Ohafia
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Okpe
+      - Onicha
+      - Onuimo
+      - Orhionmwon
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Osisioma Ngwa
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Owerri Municipal
+      - Owerri North
+      - Oyi
+      - Pankshin
+      - Sapele
+      - Toto
+      - Udenu
+      - Udi
+      - Ughelli North
+      - Ugwunagbo
+      - Uhunmwonde
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uzo-Uwani
+      - Wamba
+      - Wase
+      - Yakur
+      - Yala
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rb_ento_surv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rb_ento_surv_disease'
+  otz:
+    required: no
+    type: character
+    aliases:
+      - '#rb_ento_surv_otz'
+

--- a/inst/schemas/nga_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/nga_oncho_programmatic_prevalence.yaml
@@ -1,0 +1,210 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rb_epi_surv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: nga
+disease: oncho
+data_source: programmatic
+data_type: prevalence
+version: '1.0'
+description: Nigeria oncho prevalence surveys, 'RB Epi Surveys' sheet of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rb_epi_surv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rb_epi_surv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rb_epi_surv_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Abo-Mbaise
+      - Afikpo North
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akamkpa
+      - Akoko-Edo
+      - Akpabuyo
+      - Akwanga
+      - Anaocha
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Bakasi
+      - Bassa
+      - Bekwara
+      - Bende
+      - Biase
+      - Boki
+      - Bokkos
+      - Calabar Municipal
+      - Dunukofia
+      - Ebonyi
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Etung
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ezza South
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze North
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Igueben
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikom
+      - Ikpoba-Okha
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isu
+      - Ivo
+      - Izzi
+      - Jos East
+      - Kanke
+      - Karu
+      - Kokona
+      - Lafia
+      - Mbaitoli
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ndokwa West
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obanliku
+      - Obio-Ngwa
+      - Obowo
+      - Obubra
+      - Obudu
+      - Odukpani
+      - Ogoja
+      - Ohafia
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Okpe
+      - Onicha
+      - Onuimo
+      - Orhionmwon
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Osisioma Ngwa
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Owerri Municipal
+      - Owerri North
+      - Oyi
+      - Pankshin
+      - Sapele
+      - Toto
+      - Udenu
+      - Udi
+      - Ughelli North
+      - Ugwunagbo
+      - Uhunmwonde
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uzo-Uwani
+      - Wamba
+      - Wase
+      - Yakur
+      - Yala
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rb_epi_surv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_disease'
+  otz:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_otz'
+

--- a/inst/schemas/nga_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/nga_oncho_programmatic_prevalence.yaml
@@ -22,24 +22,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rb_epi_surv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rb_epi_surv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -190,7 +188,7 @@ columns:
       - Yakur
       - Yala
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -198,12 +196,12 @@ columns:
       - adm3
       - '#rb_epi_surv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_disease'
   otz:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_otz'

--- a/inst/schemas/nga_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/nga_oncho_programmatic_treatment.yaml
@@ -1,0 +1,286 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rbtrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+
+country: nga
+disease: oncho
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Nigeria oncho MDA coverage, 'RB Treatment' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rbtrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rbtrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rbtrt_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Abo-Mbaise
+      - Afikpo North
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akamkpa
+      - Akoko-Edo
+      - Akpabuyo
+      - Akwanga
+      - Anaocha
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Bakasi
+      - Bassa
+      - Bekwara
+      - Bende
+      - Biase
+      - Boki
+      - Bokkos
+      - Calabar Municipal
+      - Dunukofia
+      - Ebonyi
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Etung
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ezza South
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze North
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Igueben
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikom
+      - Ikpoba-Okha
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isu
+      - Ivo
+      - Izzi
+      - Jos East
+      - Kanke
+      - Karu
+      - Kokona
+      - Lafia
+      - Mbaitoli
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ndokwa West
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obanliku
+      - Obio-Ngwa
+      - Obowo
+      - Obubra
+      - Obudu
+      - Odukpani
+      - Ogoja
+      - Ohafia
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Okpe
+      - Onicha
+      - Onuimo
+      - Orhionmwon
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Osisioma Ngwa
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Owerri Municipal
+      - Owerri North
+      - Oyi
+      - Pankshin
+      - Sapele
+      - Toto
+      - Udenu
+      - Udi
+      - Ughelli North
+      - Ugwunagbo
+      - Uhunmwonde
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uzo-Uwani
+      - Wamba
+      - Wase
+      - Yakur
+      - Yala
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rbtrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rbtrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#rbtrt_pop'
+    range:
+      - 0
+      - 1411776
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#rbtrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#rbtrt_trttarget'
+    range:
+      - 1
+      - 1779852
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_male_tot'
+    range:
+      - 0
+      - 516840
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_fem_tot'
+    range:
+      - 0
+      - 516840
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#rbtrt_tot'
+    range:
+      - 0
+      - 516840
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#rbtrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/nga_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/nga_oncho_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rbtrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rbtrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -185,7 +183,7 @@ columns:
       - Yakur
       - Yala
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -193,85 +191,69 @@ columns:
       - adm3
       - '#rbtrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rbtrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#rbtrt_pop'
-    range:
-      - 0
-      - 1411776
+    range: [0, 1411776]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#rbtrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#rbtrt_trttarget'
-    range:
-      - 1
-      - 1779852
+    range: [1, 1779852]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_male_tot'
-    range:
-      - 0
-      - 516840
+    range: [0, 516840]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_fem_tot'
-    range:
-      - 0
-      - 516840
+    range: [0, 516840]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#rbtrt_tot'
-    range:
-      - 0
-      - 516840
+    range: [0, 516840]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#rbtrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/nga_rblf_programmatic_training.yaml
+++ b/inst/schemas/nga_rblf_programmatic_training.yaml
@@ -25,7 +25,7 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
@@ -40,7 +40,7 @@ columns:
       - '#labtrn_year'
       - '#tchrtrn_year'
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
@@ -55,7 +55,7 @@ columns:
       - '#labtrn_adm1'
       - '#tchrtrn_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -258,7 +258,7 @@ columns:
       - Yakur
       - Yala
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -274,7 +274,7 @@ columns:
       - '#labtrn_adm3'
       - '#tchrtrn_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#cddtrn_disease'
@@ -287,7 +287,7 @@ columns:
       - '#labtrn_disease'
       - '#tchrtrn_disease'
   goal:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_goal'
@@ -299,11 +299,9 @@ columns:
       - '#hgtrn_goal'
       - '#labtrn_goal'
       - '#tchrtrn_goal'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_tot_male'
@@ -315,11 +313,9 @@ columns:
       - '#hgtrn_tot_male'
       - '#labtrn_tot_male'
       - '#tchrtrn_tot_male'
-    range:
-      - 0
-      - 1719
+    range: [0, 1719]
   female_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_tot_fem'
@@ -331,11 +327,9 @@ columns:
       - '#hgtrn_tot_fem'
       - '#labtrn_tot_fem'
       - '#tchrtrn_tot_fem'
-    range:
-      - 0
-      - 1719
+    range: [0, 1719]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Trained
@@ -348,11 +342,9 @@ columns:
       - '#hgtrn_tot'
       - '#labtrn_tot'
       - '#tchrtrn_tot'
-    range:
-      - 0
-      - 1719
+    range: [0, 1719]
   achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_achieved'
@@ -364,7 +356,5 @@ columns:
       - '#hgtrn_achieved'
       - '#labtrn_achieved'
       - '#tchrtrn_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/nga_rblf_programmatic_training.yaml
+++ b/inst/schemas/nga_rblf_programmatic_training.yaml
@@ -1,0 +1,370 @@
+# Built 2026-07-16 against the REAL CMR field codes (#cddtrn_* / #cstrn_* / #dmditrnsx_* / #dmditrnpt_* / #entotrn_* / #hwtrn_* / #hgtrn_* / #labtrn_* / #tchrtrn_*), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+#
+# ONE schema covers all training sheets present this period (CDD Training, CS Training, MMDP (surgery) Training, MMDP (patient) Training, Field Ento Training, Health Workers Training, Hope Group Leader Training, Lab Training, Teacher Training) because
+# eri_split_cmr() routes all of them to the same disease/data_type combo (rblf/training,
+# per ADR-0012's combined training code) -- load_dq_schema() can only resolve one file
+# per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
+# prefix present, so aliasing every prefix under one canonical column set works:
+# run_dq_checks() resolves whichever alias matches the data actually present.
+
+country: nga
+disease: rblf
+data_source: programmatic
+data_type: training
+version: '1.0'
+description: Nigeria RB+LF programme trainings, combined training sheets of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#cddtrn_year'
+      - '#cstrn_year'
+      - '#dmditrnsx_year'
+      - '#dmditrnpt_year'
+      - '#entotrn_year'
+      - '#hwtrn_year'
+      - '#hgtrn_year'
+      - '#labtrn_year'
+      - '#tchrtrn_year'
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#cddtrn_adm1'
+      - '#cstrn_adm1'
+      - '#dmditrnsx_adm1'
+      - '#dmditrnpt_adm1'
+      - '#entotrn_adm1'
+      - '#hwtrn_adm1'
+      - '#hgtrn_adm1'
+      - '#labtrn_adm1'
+      - '#tchrtrn_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#cddtrn_adm2'
+      - '#cstrn_adm2'
+      - '#dmditrnsx_adm2'
+      - '#dmditrnpt_adm2'
+      - '#entotrn_adm2'
+      - '#hwtrn_adm2'
+      - '#hgtrn_adm2'
+      - '#labtrn_adm2'
+      - '#tchrtrn_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Abo-Mbaise
+      - Aboh-Mbaise
+      - Afikpo North
+      - Afikpo South
+      - Aguata
+      - Ahiazu-Mbaise
+      - Akamkpa
+      - Akoko-Edo
+      - Akpabuyo
+      - Akwanga
+      - Anambra East
+      - Anambra West
+      - Anaocha
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awe
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Bakasi
+      - Barkin Ladi
+      - Bassa
+      - Bekwara
+      - Bende
+      - Biase
+      - Boki
+      - Bokkos
+      - Bomadi
+      - Burutu
+      - Calabar Municipal
+      - Doma
+      - Dunukofia
+      - Ebonyi
+      - Egor
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu East
+      - Enugu North
+      - Enugu South
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Etung
+      - Ezeagu
+      - Ezinihitte
+      - Ezza North
+      - Ezza South
+      - Ideato North
+      - Ideato South
+      - Idimili North
+      - Idimili South
+      - Igbo-Eze North
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Igbo Etiti
+      - Igueben
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikom
+      - Ikpoba-Okha
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isoko South
+      - Isu
+      - Ivo
+      - Izzi
+      - Jos East
+      - Jos North
+      - Jos South
+      - Kanem
+      - Kanke
+      - Karu
+      - Keana
+      - Keffi
+      - Kokona
+      - Lafia
+      - Langtan North
+      - Langtan South
+      - Mangu
+      - Mbaitoli
+      - Mikang
+      - Nasarawa
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ndokwa West
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nsuka
+      - Nwangele
+      - Obanliku
+      - Obi
+      - Obio-Ngwa
+      - Obowo
+      - Obubra
+      - Obudu
+      - Odukpani
+      - Ogbaru
+      - Ogoja
+      - Oguta
+      - Ohafia
+      - Ohaji/Egbema
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Okpe
+      - Onicha
+      - Onitsha North
+      - Onitsha South
+      - Onuimo
+      - Oredo
+      - Orhionmwon
+      - Orji-River
+      - Orlu
+      - Orsu
+      - Oru East
+      - Oru West
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Osisioma Ngwa
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Owerri municipal
+      - Owerri North
+      - Owerri West
+      - Oyi
+      - Pankshin
+      - Patani
+      - Quan'Pam
+      - Riyom
+      - Sapele
+      - Shendam
+      - Toto
+      - Udenu
+      - Udi
+      - Udu
+      - Ughelli North
+      - Ughelli South
+      - Ugwunagbo
+      - Uhunmwonde
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uvwie
+      - Uzo-Uwani
+      - Wamba
+      - Warii North
+      - Warri South
+      - Warri South West
+      - Wase
+      - Yakur
+      - Yala
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#cddtrn_adm3'
+      - '#cstrn_adm3'
+      - '#dmditrnsx_adm3'
+      - '#dmditrnpt_adm3'
+      - '#entotrn_adm3'
+      - '#hwtrn_adm3'
+      - '#hgtrn_adm3'
+      - '#labtrn_adm3'
+      - '#tchrtrn_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#cddtrn_disease'
+      - '#cstrn_disease'
+      - '#dmditrnsx_disease'
+      - '#dmditrnpt_disease'
+      - '#entotrn_disease'
+      - '#hwtrn_disease'
+      - '#hgtrn_disease'
+      - '#labtrn_disease'
+      - '#tchrtrn_disease'
+  goal:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_goal'
+      - '#cstrn_goal'
+      - '#dmditrnsx_goal'
+      - '#dmditrnpt_goal'
+      - '#entotrn_goal'
+      - '#hwtrn_goal'
+      - '#hgtrn_goal'
+      - '#labtrn_goal'
+      - '#tchrtrn_goal'
+    range:
+      - 0
+      - 5000
+  male_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_tot_male'
+      - '#cstrn_tot_male'
+      - '#dmditrnsx_tot_male'
+      - '#dmditrnpt_tot_male'
+      - '#entotrn_tot_male'
+      - '#hwtrn_tot_male'
+      - '#hgtrn_tot_male'
+      - '#labtrn_tot_male'
+      - '#tchrtrn_tot_male'
+    range:
+      - 0
+      - 1719
+  female_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_tot_fem'
+      - '#cstrn_tot_fem'
+      - '#dmditrnsx_tot_fem'
+      - '#dmditrnpt_tot_fem'
+      - '#entotrn_tot_fem'
+      - '#hwtrn_tot_fem'
+      - '#hgtrn_tot_fem'
+      - '#labtrn_tot_fem'
+      - '#tchrtrn_tot_fem'
+    range:
+      - 0
+      - 1719
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Trained
+      - '#cddtrn_tot'
+      - '#cstrn_tot'
+      - '#dmditrnsx_tot'
+      - '#dmditrnpt_tot'
+      - '#entotrn_tot'
+      - '#hwtrn_tot'
+      - '#hgtrn_tot'
+      - '#labtrn_tot'
+      - '#tchrtrn_tot'
+    range:
+      - 0
+      - 1719
+  achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_achieved'
+      - '#cstrn_achieved'
+      - '#dmditrnsx_achieved'
+      - '#dmditrnpt_achieved'
+      - '#entotrn_achieved'
+      - '#hwtrn_achieved'
+      - '#hgtrn_achieved'
+      - '#labtrn_achieved'
+      - '#tchrtrn_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/nga_sch_programmatic_treatment.yaml
+++ b/inst/schemas/nga_sch_programmatic_treatment.yaml
@@ -1,0 +1,260 @@
+# Built 2026-07-16 against the REAL CMR field codes (#schtrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+
+country: nga
+disease: sch
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Nigeria sch MDA coverage, 'SCH Treatment' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#schtrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#schtrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#schtrt_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Afikpo North
+      - Afikpo South
+      - Akoko-Edo
+      - Akwanga
+      - Anambra West
+      - Anaocha
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Awe
+      - Awgu
+      - Awka South
+      - Barkin Ladi
+      - Bassa
+      - Bende
+      - Bomadi
+      - Burutu
+      - Doma
+      - Dunukofia
+      - Ebonyi
+      - Egor
+      - Enugu East
+      - Enugu North
+      - Enugu South
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Ezza North
+      - Ezza South
+      - Idimili North
+      - Igbo-Eze North
+      - Igbo Ekiti
+      - Ika South
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isoko South
+      - Ivo
+      - Izzi
+      - Jos East
+      - Jos North
+      - Jos South
+      - Kanem
+      - Kanke
+      - Karu
+      - Keana
+      - Keffi
+      - Kokona
+      - Lafia
+      - Langtan North
+      - Langtan South
+      - Mangu
+      - Mikang
+      - Nasarawa
+      - Nasarawa-Eggon
+      - Ndokwa East
+      - Ndokwa West
+      - Njikoka
+      - Nkanu East
+      - Nkanu West
+      - Nnewi South
+      - Nsuka
+      - Obi
+      - Ogbaru
+      - Ohafia
+      - Ohaozara
+      - Ohaukwu
+      - Onicha
+      - Onitsha South
+      - Oredo
+      - Orhionmwon
+      - Orji-River
+      - Orumba North
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Osisioma Ngwa
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Oyi
+      - Pankshin
+      - Patani
+      - Quan'Pam
+      - Sapele
+      - Shendam
+      - Toto
+      - Udenu
+      - Udi
+      - Udu
+      - Ughelli North
+      - Ughelli South
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uvwie
+      - Uzo-Uwani
+      - Wamba
+      - Warri South
+      - Warri South West
+      - Wase
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#schtrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#schtrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#schtrt_pop'
+    range:
+      - 0
+      - 500000
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#schtrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#schtrt_trttarget'
+    range:
+      - 1
+      - 500000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#schtrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#schtrt_male_tot'
+    range:
+      - 0
+      - 500000
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#schtrt_fem_tot'
+    range:
+      - 0
+      - 500000
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#schtrt_tot'
+    range:
+      - 0
+      - 500000
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#schtrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/nga_sch_programmatic_treatment.yaml
+++ b/inst/schemas/nga_sch_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#schtrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#schtrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -159,7 +157,7 @@ columns:
       - Warri South West
       - Wase
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -167,85 +165,69 @@ columns:
       - adm3
       - '#schtrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#schtrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#schtrt_pop'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#schtrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#schtrt_trttarget'
-    range:
-      - 1
-      - 500000
+    range: [1, 500000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#schtrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#schtrt_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#schtrt_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#schtrt_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#schtrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/nga_sth_programmatic_treatment.yaml
+++ b/inst/schemas/nga_sth_programmatic_treatment.yaml
@@ -1,0 +1,265 @@
+# Built 2026-07-16 against the REAL CMR field codes (#sthtrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202605 submission from Nigeria.
+
+country: nga
+disease: sth
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Nigeria sth MDA coverage, 'STH Treatment' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#sthtrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#sthtrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#sthtrt_adm2'
+    allowed_values:
+      - Aba North
+      - Aba South
+      - Abakaliki
+      - Abo-Mbaise
+      - Afikpo North
+      - Afikpo South
+      - Aguata
+      - Akoko-Edo
+      - Aninri
+      - Aniocha North
+      - Aniocha South
+      - Arochukwu
+      - Awe
+      - Awgu
+      - Awka North
+      - Awka South
+      - Ayamelum
+      - Bende
+      - Bomadi
+      - Burutu
+      - Dunukofia
+      - Egor
+      - Ehime-Mbano
+      - Ekwusiko
+      - Enugu North
+      - Enugu South
+      - Esan Central
+      - Esan North East
+      - Esan South East
+      - Esan West
+      - Ethiope East
+      - Ethiope West
+      - Etsako Central
+      - Etsako East
+      - Etsako West
+      - Ezinihitte
+      - Ezza North
+      - Ezza South
+      - Ideato North
+      - Ideato South
+      - Igbo-Eze North
+      - Igbo-Eze South
+      - Igbo Ekiti
+      - Igueben
+      - Ihiala
+      - Ihite/Uboma
+      - Ika North East
+      - Ika South
+      - Ikeduru
+      - Ikpoba-Okha
+      - Ikwo
+      - Ikwuano
+      - Ishielu
+      - Isi-Uzo
+      - Isiala-Mbano
+      - Isiala-Ngwa North
+      - Isiala-Ngwa South
+      - Isiukwuato
+      - Isoko North
+      - Isoko South
+      - Isu
+      - Ivo
+      - Kokona
+      - Mbaitoli
+      - Nasarawa
+      - Ndokwa East
+      - Ndokwa West
+      - Ngor-Okp
+      - Njaba
+      - Njikoka
+      - Nkwere
+      - Nnewi North
+      - Nnewi South
+      - Nwangele
+      - Obi
+      - Obio-Ngwa
+      - Obowo
+      - Oguta
+      - Ohafia
+      - Ohaji/Egbema
+      - Ohaozara
+      - Ohaukwu
+      - Okigwe
+      - Okpe
+      - Onicha
+      - Onuimo
+      - Oredo
+      - Orhionmwon
+      - Orlu
+      - Orsu
+      - Oru East
+      - Oru West
+      - Orumba South
+      - Oshimili North
+      - Oshimili South
+      - Ovia North East
+      - Ovia South West
+      - Owan East
+      - Owan West
+      - Owerri North
+      - Owerri West
+      - Oyi
+      - Patani
+      - Sapele
+      - Udenu
+      - Udi
+      - Udu
+      - Ughelli North
+      - Ughelli South
+      - Ugwunagbo
+      - Uhunmwonde
+      - Ukwa East
+      - Ukwa West
+      - Ukwuani
+      - Umu-Nneochi
+      - Umuahia North
+      - Umuahia South
+      - Uvwie
+      - Warii North
+      - Warri South
+      - Warri South West
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#sthtrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#sthtrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#sthtrt_pop'
+    range:
+      - 0
+      - 1389062
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#sthtrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#sthtrt_trttarget'
+    range:
+      - 1
+      - 589166
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#sthtrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#sthtrt_male_tot'
+    range:
+      - 0
+      - 500000
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#sthtrt_fem_tot'
+    range:
+      - 0
+      - 500000
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#sthtrt_tot'
+    range:
+      - 0
+      - 500000
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#sthtrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/nga_sth_programmatic_treatment.yaml
+++ b/inst/schemas/nga_sth_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#sthtrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#sthtrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -164,7 +162,7 @@ columns:
       - Warri South
       - Warri South West
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -172,85 +170,69 @@ columns:
       - adm3
       - '#sthtrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#sthtrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#sthtrt_pop'
-    range:
-      - 0
-      - 1389062
+    range: [0, 1389062]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#sthtrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#sthtrt_trttarget'
-    range:
-      - 1
-      - 589166
+    range: [1, 589166]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#sthtrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#sthtrt_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#sthtrt_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#sthtrt_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#sthtrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/tcd_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/tcd_lf_programmatic_mmdp.yaml
@@ -1,0 +1,168 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfdmdi_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+
+country: tcd
+disease: lf
+data_source: programmatic
+data_type: mmdp
+version: '1.0'
+description: Chad lf morbidity management and disability prevention (MMDP), 'LF MMDP'
+  sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfdmdi_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfdmdi_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfdmdi_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebalem
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Beinamar
+      - Benoye
+      - Bere
+      - Bessao
+      - Biobe Singako
+      - Bodo
+      - Bologo
+      - Dafra
+      - Danamadji
+      - Deressia
+      - Doba
+      - Donia
+      - Donomanga
+      - Gore
+      - Guelendeng
+      - Guidari
+      - Kara
+      - Katoa
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Krim-Krim
+      - Kyabe
+      - Lai
+      - Laokassy
+      - Larmanaye
+      - Maro
+      - Moulkou
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Ndam
+      - Sarh
+      - Yamodo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfdmdi_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfdmdi_disease'
+  surgery_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_surgeytarget'
+    range:
+      - 0
+      - 50000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_male_tot'
+    range:
+      - 0
+      - 500000
+  female_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_fem_tot'
+    range:
+      - 0
+      - 500000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_managed
+      - '#lfdmdi_tot'
+    range:
+      - 0
+      - 500000
+  households_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_hh_tot'
+    range:
+      - 0
+      - 500000
+  surgeries_done:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_tot'
+    range:
+      - 0
+      - 50000
+  surgeries_achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/tcd_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/tcd_lf_programmatic_mmdp.yaml
@@ -18,24 +18,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfdmdi_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfdmdi_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -87,7 +85,7 @@ columns:
       - Sarh
       - Yamodo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -95,74 +93,58 @@ columns:
       - adm3
       - '#lfdmdi_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfdmdi_disease'
   surgery_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_surgeytarget'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_managed
       - '#lfdmdi_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   households_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_hh_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   surgeries_done:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_tot'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   surgeries_achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/tcd_lf_programmatic_tas.yaml
+++ b/inst/schemas/tcd_lf_programmatic_tas.yaml
@@ -1,0 +1,105 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfsurv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: tcd
+disease: lf
+data_source: programmatic
+data_type: tas
+version: '1.0'
+description: Chad lf tas surveys, 'LF Enquetes' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfsurv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfsurv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfsurv_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebalem
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Beinamar
+      - Benoye
+      - Bere
+      - Bessao
+      - Biobe Singako
+      - Bodo
+      - Bologo
+      - Dafra
+      - Danamadji
+      - Deressia
+      - Doba
+      - Donia
+      - Donomanga
+      - Gore
+      - Guelendeng
+      - Guidari
+      - Kara
+      - Katoa
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Krim-Krim
+      - Kyabe
+      - Lai
+      - Laokassy
+      - Larmanaye
+      - Maro
+      - Moulkou
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Ndam
+      - Sarh
+      - Yamodo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfsurv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfsurv_disease'
+

--- a/inst/schemas/tcd_lf_programmatic_tas.yaml
+++ b/inst/schemas/tcd_lf_programmatic_tas.yaml
@@ -21,24 +21,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfsurv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfsurv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -90,7 +88,7 @@ columns:
       - Sarh
       - Yamodo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -98,7 +96,7 @@ columns:
       - adm3
       - '#lfsurv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfsurv_disease'

--- a/inst/schemas/tcd_lf_programmatic_treatment.yaml
+++ b/inst/schemas/tcd_lf_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lftrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lftrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -88,7 +86,7 @@ columns:
       - Sarh
       - Yamodo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -96,85 +94,69 @@ columns:
       - adm3
       - '#lftrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lftrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#lftrt_pop'
-    range:
-      - 0
-      - 579158
+    range: [0, 579158]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#lftrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#lftrt_trttarget'
-    range:
-      - 1
-      - 500000
+    range: [1, 500000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lftrt_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#lftrt_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#lftrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/tcd_lf_programmatic_treatment.yaml
+++ b/inst/schemas/tcd_lf_programmatic_treatment.yaml
@@ -1,0 +1,189 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lftrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+
+country: tcd
+disease: lf
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Chad lf MDA coverage, 'Traitement FL' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lftrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lftrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lftrt_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebalem
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Beinamar
+      - Benoye
+      - Bere
+      - Bessao
+      - Billiam Oursi
+      - Biobe Singako
+      - Bodo
+      - Bologo
+      - Dafra
+      - Danamadji
+      - Deressia
+      - Doba
+      - Donia
+      - Donomanga
+      - Gore
+      - Guelendeng
+      - Guidari
+      - Kara
+      - Katoa
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Krim-Krim
+      - Kyabe
+      - Lai
+      - Laokassy
+      - Larmanaye
+      - Maro
+      - Moulkou
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Mouroum Goulaye
+      - Ndam
+      - Sarh
+      - Yamodo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lftrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lftrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#lftrt_pop'
+    range:
+      - 0
+      - 579158
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#lftrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#lftrt_trttarget'
+    range:
+      - 1
+      - 500000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_male_tot'
+    range:
+      - 0
+      - 500000
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#lftrt_fem_tot'
+    range:
+      - 0
+      - 500000
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#lftrt_tot'
+    range:
+      - 0
+      - 500000
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#lftrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/tcd_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/tcd_oncho_programmatic_entomology.yaml
@@ -1,0 +1,124 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rb_ento_surv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: tcd
+disease: oncho
+data_source: programmatic
+data_type: entomology
+version: '1.0'
+description: Chad oncho entomology surveys, 'Oncho Enquetes Ento' sheet of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rb_ento_surv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rb_ento_surv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rb_ento_surv_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Bedjondo
+      - Beinamar
+      - Bekourou
+      - Bere
+      - Bessao
+      - Billiam Oursi
+      - Binder
+      - Biobe Singako
+      - Bologo
+      - Bouna
+      - Dafra
+      - Danamadji
+      - Dembo
+      - Djodo Gassa
+      - Doba
+      - Donia
+      - Fianga
+      - Gagal
+      - Gore
+      - Gounou Gaya
+      - Guegou
+      - Guelao
+      - Guene
+      - Kara
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Koupor
+      - Krim-Krim
+      - Kyabe
+      - Lagon
+      - Lame
+      - Laokassy
+      - Larmanaye
+      - Lere
+      - Maro
+      - Moissala
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Mouroum Goulaye
+      - Pala
+      - Peni
+      - Pont Carol
+      - Sarh
+      - Torrock
+      - Yamodo
+      - Youe
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rb_ento_surv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rb_ento_surv_disease'
+  otz:
+    required: no
+    type: character
+    aliases:
+      - '#rb_ento_surv_otz'
+

--- a/inst/schemas/tcd_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/tcd_oncho_programmatic_entomology.yaml
@@ -22,24 +22,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rb_ento_surv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rb_ento_surv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -104,7 +102,7 @@ columns:
       - Yamodo
       - Youe
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -112,12 +110,12 @@ columns:
       - adm3
       - '#rb_ento_surv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_ento_surv_disease'
   otz:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_ento_surv_otz'

--- a/inst/schemas/tcd_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/tcd_oncho_programmatic_prevalence.yaml
@@ -1,0 +1,124 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rb_epi_surv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: tcd
+disease: oncho
+data_source: programmatic
+data_type: prevalence
+version: '1.0'
+description: Chad oncho prevalence surveys, 'Oncho Enquetes Epi' sheet of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rb_epi_surv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rb_epi_surv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rb_epi_surv_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Bedjondo
+      - Beinamar
+      - Bekourou
+      - Bere
+      - Bessao
+      - Billiam Oursi
+      - Binder
+      - Biobe Singako
+      - Bologo
+      - Bouna
+      - Dafra
+      - Danamadji
+      - Dembo
+      - Djodo Gassa
+      - Doba
+      - Donia
+      - Fianga
+      - Gagal
+      - Gore
+      - Gounou Gaya
+      - Guegou
+      - Guelao
+      - Guene
+      - Kara
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Koupor
+      - Krim-Krim
+      - Kyabe
+      - Lagon
+      - Lame
+      - Laokassy
+      - Larmanaye
+      - Lere
+      - Maro
+      - Moissala
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Mouroum Goulaye
+      - Pala
+      - Peni
+      - Pont Carol
+      - Sarh
+      - Torrock
+      - Yamodo
+      - Youe
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rb_epi_surv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_disease'
+  otz:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_otz'
+

--- a/inst/schemas/tcd_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/tcd_oncho_programmatic_prevalence.yaml
@@ -22,24 +22,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rb_epi_surv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rb_epi_surv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -104,7 +102,7 @@ columns:
       - Yamodo
       - Youe
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -112,12 +110,12 @@ columns:
       - adm3
       - '#rb_epi_surv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_disease'
   otz:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_otz'

--- a/inst/schemas/tcd_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/tcd_oncho_programmatic_treatment.yaml
@@ -17,24 +17,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rbtrt_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rbtrt_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -98,7 +96,7 @@ columns:
       - Yamodo
       - Youe
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -106,85 +104,69 @@ columns:
       - adm3
       - '#rbtrt_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rbtrt_disease'
   population:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Population
       - '#rbtrt_pop'
-    range:
-      - 0
-      - 579158
+    range: [0, 579158]
   treatment_round:
-    required: no
+    required: false
     type: numeric
     aliases:
       - Round
       - MDA_round
       - treatment_round
       - '#rbtrt_trtrd'
-    range:
-      - 0
-      - 10
+    range: [0, 10]
   target_pop:
-    required: no
+    required: false
     type: numeric
     aliases:
       - TargetPop
       - target_population
       - eligible_pop
       - '#rbtrt_trttarget'
-    range:
-      - 1
-      - 500000
+    range: [1, 500000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_treated:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#rbtrt_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   treated:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_treated
       - '#rbtrt_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   coverage_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - CoveragePct
       - coverage
       - '#rbtrt_coverage'
-    range:
-      - 0
-      - 150
+    range: [0, 150]
 consistency:
   implausible_overcoverage:
     lhs: treated

--- a/inst/schemas/tcd_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/tcd_oncho_programmatic_treatment.yaml
@@ -1,0 +1,199 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rbtrt_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+
+country: tcd
+disease: oncho
+data_source: programmatic
+data_type: treatment
+version: '1.0'
+description: Chad oncho MDA coverage, 'Oncho Traitement' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: treatment_round
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rbtrt_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rbtrt_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rbtrt_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Bedjondo
+      - Beinamar
+      - Bekourou
+      - Bere
+      - Bessao
+      - Binder
+      - Biobe Singako
+      - Bologo
+      - Bouna
+      - Dafra
+      - Danamadji
+      - Dembo
+      - Djodo Gassa
+      - Doba
+      - Donia
+      - Fianga
+      - Gagal
+      - Gore
+      - Gounou Gaya
+      - Guegou
+      - Guelao
+      - Guene
+      - Kara
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Koupor
+      - Krim-Krim
+      - Kyabe
+      - Lagon
+      - Lame
+      - Laokassy
+      - Larmanaye
+      - Lere
+      - Maro
+      - Moissala
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Mouroum Goulaye
+      - Pala
+      - Peni
+      - Pont Carol
+      - Sarh
+      - Torrock
+      - Yamodo
+      - Youe
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rbtrt_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rbtrt_disease'
+  population:
+    required: no
+    type: numeric
+    aliases:
+      - Population
+      - '#rbtrt_pop'
+    range:
+      - 0
+      - 579158
+  treatment_round:
+    required: no
+    type: numeric
+    aliases:
+      - Round
+      - MDA_round
+      - treatment_round
+      - '#rbtrt_trtrd'
+    range:
+      - 0
+      - 10
+  target_pop:
+    required: no
+    type: numeric
+    aliases:
+      - TargetPop
+      - target_population
+      - eligible_pop
+      - '#rbtrt_trttarget'
+    range:
+      - 1
+      - 500000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_male_tot'
+    range:
+      - 0
+      - 500000
+  female_treated:
+    required: no
+    type: numeric
+    aliases:
+      - '#rbtrt_fem_tot'
+    range:
+      - 0
+      - 500000
+  treated:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_treated
+      - '#rbtrt_tot'
+    range:
+      - 0
+      - 500000
+  coverage_pct:
+    required: no
+    type: numeric
+    aliases:
+      - CoveragePct
+      - coverage
+      - '#rbtrt_coverage'
+    range:
+      - 0
+      - 150
+consistency:
+  implausible_overcoverage:
+    lhs: treated
+    op: <=
+    rhs: target_pop
+    message: treated exceeds target_pop (over 100% raw coverage)
+  treated_nonneg:
+    lhs: treated
+    op: '>='
+    rhs_value: 0.0
+    message: Negative treated count
+

--- a/inst/schemas/tcd_rblf_programmatic_training.yaml
+++ b/inst/schemas/tcd_rblf_programmatic_training.yaml
@@ -1,0 +1,241 @@
+# Built 2026-07-16 against the REAL CMR field codes (#cddtrn_* / #cstrn_* / #dmditrnsx_* / #dmditrnpt_* / #entotrn_* / #hwtrn_* / #hgtrn_* / #tchrtrn_*), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Chad.
+#
+# ONE schema covers all training sheets present this period (Formation Distributeurs Comm, Formation Superviseurs Comm, PCMPI (Chirurgie) Formation, PCMPI Formation (Patient), Formation Ento de Terrain, Formation Trav Sante, Formation Leader Groupe Hope, Formation Professeurs) because
+# eri_split_cmr() routes all of them to the same disease/data_type combo (rblf/training,
+# per ADR-0012's combined training code) -- load_dq_schema() can only resolve one file
+# per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
+# prefix present, so aliasing every prefix under one canonical column set works:
+# run_dq_checks() resolves whichever alias matches the data actually present.
+
+country: tcd
+disease: rblf
+data_source: programmatic
+data_type: training
+version: '1.0'
+description: Chad RB+LF programme trainings, combined training sheets of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#cddtrn_year'
+      - '#cstrn_year'
+      - '#dmditrnsx_year'
+      - '#dmditrnpt_year'
+      - '#entotrn_year'
+      - '#hwtrn_year'
+      - '#hgtrn_year'
+      - '#tchrtrn_year'
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#cddtrn_adm1'
+      - '#cstrn_adm1'
+      - '#dmditrnsx_adm1'
+      - '#dmditrnpt_adm1'
+      - '#entotrn_adm1'
+      - '#hwtrn_adm1'
+      - '#hgtrn_adm1'
+      - '#tchrtrn_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#cddtrn_adm2'
+      - '#cstrn_adm2'
+      - '#dmditrnsx_adm2'
+      - '#dmditrnpt_adm2'
+      - '#entotrn_adm2'
+      - '#hwtrn_adm2'
+      - '#hgtrn_adm2'
+      - '#tchrtrn_adm2'
+    allowed_values:
+      - Baibokoum
+      - Bakctchoro
+      - Balimba
+      - Bebalem
+      - Bebedjia
+      - Beboto
+      - Bedaya
+      - Bedjondo
+      - Beinamar
+      - Bekourou
+      - Benoye
+      - Bere
+      - Bessao
+      - Billiam Oursi
+      - Binder
+      - Biobe Singako
+      - Bodo
+      - Bologo
+      - Bouna
+      - Dafra
+      - Danamadji
+      - Dembo
+      - Deressia
+      - Djodo Gassa
+      - Doba
+      - Donia
+      - Donomanga
+      - Fianga
+      - Gagal
+      - Gore
+      - Gounou Gaya
+      - Guegou
+      - Guelao
+      - Guelendeng
+      - Guene
+      - Guidari
+      - Kara
+      - Katoa
+      - Kelo
+      - Kolon
+      - Korbol
+      - Koumogo
+      - Koumra
+      - Koupor
+      - Krim-Krim
+      - Kyabe
+      - Lagon
+      - Lai
+      - Lame
+      - Laokassy
+      - Larmanaye
+      - Lere
+      - Maro
+      - Moissala
+      - Moulkou
+      - Moundou Centre
+      - Moundou Est
+      - Moundou Ouest
+      - Mouroum Goulaye
+      - Ndam
+      - Pala
+      - Peni
+      - Pont Carol
+      - Sarh
+      - Torrock
+      - Yamodo
+      - Youe
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#cddtrn_adm3'
+      - '#cstrn_adm3'
+      - '#dmditrnsx_adm3'
+      - '#dmditrnpt_adm3'
+      - '#entotrn_adm3'
+      - '#hwtrn_adm3'
+      - '#hgtrn_adm3'
+      - '#tchrtrn_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#cddtrn_disease'
+      - '#cstrn_disease'
+      - '#dmditrnsx_disease'
+      - '#dmditrnpt_disease'
+      - '#entotrn_disease'
+      - '#hwtrn_disease'
+      - '#hgtrn_disease'
+      - '#tchrtrn_disease'
+  goal:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_goal'
+      - '#cstrn_goal'
+      - '#dmditrnsx_goal'
+      - '#dmditrnpt_goal'
+      - '#entotrn_goal'
+      - '#hwtrn_goal'
+      - '#hgtrn_goal'
+      - '#tchrtrn_goal'
+    range:
+      - 0
+      - 5000
+  male_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_tot_male'
+      - '#cstrn_tot_male'
+      - '#dmditrnsx_tot_male'
+      - '#dmditrnpt_tot_male'
+      - '#entotrn_tot_male'
+      - '#hwtrn_tot_male'
+      - '#hgtrn_tot_male'
+      - '#tchrtrn_tot_male'
+    range:
+      - 0
+      - 1000
+  female_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_tot_fem'
+      - '#cstrn_tot_fem'
+      - '#dmditrnsx_tot_fem'
+      - '#dmditrnpt_tot_fem'
+      - '#entotrn_tot_fem'
+      - '#hwtrn_tot_fem'
+      - '#hgtrn_tot_fem'
+      - '#tchrtrn_tot_fem'
+    range:
+      - 0
+      - 1000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Trained
+      - '#cddtrn_tot'
+      - '#cstrn_tot'
+      - '#dmditrnsx_tot'
+      - '#dmditrnpt_tot'
+      - '#entotrn_tot'
+      - '#hwtrn_tot'
+      - '#hgtrn_tot'
+      - '#tchrtrn_tot'
+    range:
+      - 0
+      - 1000
+  achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#cddtrn_achieved'
+      - '#cstrn_achieved'
+      - '#dmditrnsx_achieved'
+      - '#dmditrnpt_achieved'
+      - '#entotrn_achieved'
+      - '#hwtrn_achieved'
+      - '#hgtrn_achieved'
+      - '#tchrtrn_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/tcd_rblf_programmatic_training.yaml
+++ b/inst/schemas/tcd_rblf_programmatic_training.yaml
@@ -25,7 +25,7 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
@@ -39,7 +39,7 @@ columns:
       - '#hgtrn_year'
       - '#tchrtrn_year'
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
@@ -53,7 +53,7 @@ columns:
       - '#hgtrn_adm1'
       - '#tchrtrn_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -136,7 +136,7 @@ columns:
       - Yamodo
       - Youe
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -151,7 +151,7 @@ columns:
       - '#hgtrn_adm3'
       - '#tchrtrn_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#cddtrn_disease'
@@ -163,7 +163,7 @@ columns:
       - '#hgtrn_disease'
       - '#tchrtrn_disease'
   goal:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_goal'
@@ -174,11 +174,9 @@ columns:
       - '#hwtrn_goal'
       - '#hgtrn_goal'
       - '#tchrtrn_goal'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_tot_male'
@@ -189,11 +187,9 @@ columns:
       - '#hwtrn_tot_male'
       - '#hgtrn_tot_male'
       - '#tchrtrn_tot_male'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   female_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_tot_fem'
@@ -204,11 +200,9 @@ columns:
       - '#hwtrn_tot_fem'
       - '#hgtrn_tot_fem'
       - '#tchrtrn_tot_fem'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Trained
@@ -220,11 +214,9 @@ columns:
       - '#hwtrn_tot'
       - '#hgtrn_tot'
       - '#tchrtrn_tot'
-    range:
-      - 0
-      - 1000
+    range: [0, 1000]
   achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#cddtrn_achieved'
@@ -235,7 +227,5 @@ columns:
       - '#hwtrn_achieved'
       - '#hgtrn_achieved'
       - '#tchrtrn_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/uga_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/uga_lf_programmatic_mmdp.yaml
@@ -1,0 +1,176 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfdmdi_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Uganda.
+
+country: uga
+disease: lf
+data_source: programmatic
+data_type: mmdp
+version: '1.0'
+description: Uganda lf morbidity management and disability prevention (MMDP), 'LF
+  MMDP' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfdmdi_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfdmdi_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfdmdi_adm2'
+    allowed_values:
+      - Adjumani
+      - Amuru
+      - Arua
+      - Bududa
+      - Buhweju
+      - Buliisa
+      - Bushenyi
+      - Gulu
+      - Gulu City
+      - Hoima
+      - Ibanda
+      - Jinja
+      - Kabarole
+      - Kagadi
+      - Kamuli
+      - Kanungu
+      - Kasese
+      - Kayunga
+      - Kikuube
+      - Kisoro
+      - Kitagwenda
+      - Kitgum
+      - KOBOKO
+      - Kyenjojo
+      - Lamwo
+      - Lira
+      - MadI-Okollo
+      - Manafwa
+      - Maracha/Teregago
+      - Masindi
+      - Mayuge
+      - Mbale
+      - Mbale City
+      - Mitooma
+      - MOYO
+      - Mukono
+      - Namisindwa
+      - Nebbi
+      - Nwoya
+      - Obongi
+      - Omoro
+      - Oyam
+      - Pader
+      - Pakwach
+      - Refugees
+      - Rubanda
+      - Rubirizi
+      - Sironko
+      - Terego
+      - YUMBE
+      - Zombo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfdmdi_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfdmdi_disease'
+  surgery_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_surgeytarget'
+    range:
+      - 0
+      - 50000
+  village_target:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_villagetarget'
+    range:
+      - 0
+      - 5000
+  male_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_male_tot'
+    range:
+      - 0
+      - 500000
+  female_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_fem_tot'
+    range:
+      - 0
+      - 500000
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Treated
+      - people_managed
+      - '#lfdmdi_tot'
+    range:
+      - 0
+      - 500000
+  households_managed:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_hh_tot'
+    range:
+      - 0
+      - 500000
+  surgeries_done:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_tot'
+    range:
+      - 0
+      - 50000
+  surgeries_achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#lfdmdi_sx_achieved'
+    range:
+      - 0
+      - 2
+

--- a/inst/schemas/uga_lf_programmatic_mmdp.yaml
+++ b/inst/schemas/uga_lf_programmatic_mmdp.yaml
@@ -18,24 +18,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfdmdi_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfdmdi_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -95,7 +93,7 @@ columns:
       - YUMBE
       - Zombo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -103,74 +101,58 @@ columns:
       - adm3
       - '#lfdmdi_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfdmdi_disease'
   surgery_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_surgeytarget'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   village_target:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_villagetarget'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_male_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   female_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_fem_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Treated
       - people_managed
       - '#lfdmdi_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   households_managed:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_hh_tot'
-    range:
-      - 0
-      - 500000
+    range: [0, 500000]
   surgeries_done:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_tot'
-    range:
-      - 0
-      - 50000
+    range: [0, 50000]
   surgeries_achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#lfdmdi_sx_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/uga_lf_programmatic_tas.yaml
+++ b/inst/schemas/uga_lf_programmatic_tas.yaml
@@ -21,24 +21,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#lfsurv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#lfsurv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -75,7 +73,7 @@ columns:
       - YUMBE
       - Zombo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -83,7 +81,7 @@ columns:
       - adm3
       - '#lfsurv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#lfsurv_disease'

--- a/inst/schemas/uga_lf_programmatic_tas.yaml
+++ b/inst/schemas/uga_lf_programmatic_tas.yaml
@@ -1,0 +1,90 @@
+# Built 2026-07-16 against the REAL CMR field codes (#lfsurv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Uganda.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: uga
+disease: lf
+data_source: programmatic
+data_type: tas
+version: '1.0'
+description: Uganda lf tas surveys, 'LF Surveys' sheet of the monthly CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#lfsurv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#lfsurv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#lfsurv_adm2'
+    allowed_values:
+      - Adjumani
+      - Amuru
+      - Arua
+      - Arua City
+      - Bugiri
+      - Gulu
+      - Gulu City
+      - Kamuli
+      - Kitgum
+      - KOBOKO
+      - Lamwo
+      - Lira
+      - MadI-Okollo
+      - Maracha
+      - Maracha/Teregago
+      - Mayuge
+      - MOYO
+      - Namayingo
+      - Nebbi
+      - Nwoya
+      - Obongi
+      - Omoro
+      - Oyam
+      - Pader
+      - Pakwach
+      - Terego
+      - YUMBE
+      - Zombo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#lfsurv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#lfsurv_disease'
+

--- a/inst/schemas/uga_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/uga_oncho_programmatic_entomology.yaml
@@ -1,0 +1,62 @@
+country: uga
+disease: oncho
+data_source: programmatic
+data_type: entomology
+version: "1.0"
+description: "Uganda onchocerciasis entomological (blackfly) surveys, RB Ento Surveys sheet of the monthly CMR"
+language: en
+time_grain: annual
+
+# Built 2026-07-16 from the CMR routing schema's field codes only
+# (inst/schemas/cmr/uga.yaml, #rb_ento_surv_* prefix) -- NOT from a real
+# ingested sheet. Uganda's "RB Ento Surveys" sheet (202606 real submission)
+# has the same known duplicate field-code template defect as sdn/ssd/eth
+# ("#rb_ento_surv_notes_jan" typed twice), which now blocks the whole
+# workbook per ADR-0022 -- eri_ingest_cmr() cannot successfully read this
+# sheet at all until the shared Carter Center master template is fixed.
+#
+# Structurally identical to sdn_oncho_programmatic_entomology.yaml (same
+# template, same defect, same "otz" field) since that one WAS built from a
+# real ingested sheet before the whole-workbook block existed. district has
+# no allowed_values here -- no real Uganda entomology data has been
+# successfully read yet to source a district list from; add one once a
+# corrected file lets this sheet actually ingest.
+
+temporal:
+  year_col: year
+  period_col: year
+
+preprocessing:
+  - remove_smart_quotes
+
+columns:
+  year:
+    required: true
+    type: numeric
+    aliases: [Year, YEAR, "#rb_ento_surv_year"]
+    range: [1990, 2035]
+
+  region:
+    required: false
+    type: character
+    aliases: [Region, adm1, "#rb_ento_surv_adm1"]
+
+  district:
+    required: true
+    type: character
+    aliases: [District, district_name, adm2, "#rb_ento_surv_adm2"]
+
+  sub_county:
+    required: false
+    type: character
+    aliases: [SubCounty, sub_county, adm3, "#rb_ento_surv_adm3"]
+
+  otz:
+    required: false
+    type: character
+    aliases: ["#rb_ento_surv_otz"]
+
+  disease_reported:
+    required: false
+    type: character
+    aliases: ["#rb_ento_surv_disease"]

--- a/inst/schemas/uga_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/uga_oncho_programmatic_prevalence.yaml
@@ -1,0 +1,121 @@
+# Built 2026-07-16 against the REAL CMR field codes (#rb_epi_surv_* prefix), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Uganda.
+#
+# Scoped to the identifier spine only (year/region/district/sub_county), matching
+# sdn/ssd's precedent for this sheet shape: monthly-wide survey-result blocks with
+# no single annual roll-up column to validate a range against.
+
+country: uga
+disease: oncho
+data_source: programmatic
+data_type: prevalence
+version: '1.0'
+description: Uganda oncho prevalence surveys, 'RB Epi Surveys' sheet of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#rb_epi_surv_year'
+    range:
+      - 1990
+      - 2035
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#rb_epi_surv_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#rb_epi_surv_adm2'
+    allowed_values:
+      - Adjumani
+      - Adjumani Refugee Settlements
+      - Amuru
+      - Arua
+      - Bududa
+      - Buhweju
+      - Buliisa
+      - Bushenyi
+      - Gulu
+      - Gulu City
+      - Hoima
+      - Ibanda
+      - Jinja
+      - Kabarole
+      - Kagadi
+      - Kamuli
+      - Kanungu
+      - Kasese
+      - Kayunga
+      - Kikuube
+      - Kisoro
+      - Kitagwenda
+      - Kitgum
+      - KOBOKO
+      - Kyenjojo
+      - Lamwo
+      - Lira
+      - MadI-Okollo
+      - Manafwa
+      - Maracha/Teregago
+      - Masindi
+      - Mayuge
+      - Mbale
+      - Mbale City
+      - Mitooma
+      - MOYO
+      - Mukono
+      - Namisindwa
+      - Nebbi
+      - Nwoya
+      - Obongi
+      - Omoro
+      - Oyam
+      - Pader
+      - Pakwach
+      - Palabek Refugee Settlements
+      - Palorinya Refugee Settlements
+      - Rubanda
+      - Rubirizi
+      - Sironko
+      - Terego
+      - YUMBE
+      - Zombo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#rb_epi_surv_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_disease'
+  otz:
+    required: no
+    type: character
+    aliases:
+      - '#rb_epi_surv_otz'
+

--- a/inst/schemas/uga_oncho_programmatic_prevalence.yaml
+++ b/inst/schemas/uga_oncho_programmatic_prevalence.yaml
@@ -22,24 +22,22 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
       - YEAR
       - '#rb_epi_surv_year'
-    range:
-      - 1990
-      - 2035
+    range: [1990, 2035]
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
       - adm1
       - '#rb_epi_surv_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -101,7 +99,7 @@ columns:
       - YUMBE
       - Zombo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -109,12 +107,12 @@ columns:
       - adm3
       - '#rb_epi_surv_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_disease'
   otz:
-    required: no
+    required: false
     type: character
     aliases:
       - '#rb_epi_surv_otz'

--- a/inst/schemas/uga_rblf_programmatic_training.yaml
+++ b/inst/schemas/uga_rblf_programmatic_training.yaml
@@ -25,7 +25,7 @@ preprocessing:
   - remove_smart_quotes
 columns:
   year:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Year
@@ -39,7 +39,7 @@ columns:
       - '#entotrn_year'
       - '#labtrn_year'
   region:
-    required: no
+    required: false
     type: character
     aliases:
       - Region
@@ -53,7 +53,7 @@ columns:
       - '#entotrn_adm1'
       - '#labtrn_adm1'
   district:
-    required: yes
+    required: true
     type: character
     aliases:
       - District
@@ -121,7 +121,7 @@ columns:
       - YUMBE
       - Zombo
   sub_county:
-    required: no
+    required: false
     type: character
     aliases:
       - SubCounty
@@ -136,7 +136,7 @@ columns:
       - '#entotrn_adm3'
       - '#labtrn_adm3'
   disease_reported:
-    required: no
+    required: false
     type: character
     aliases:
       - '#vhttrn_disease'
@@ -148,7 +148,7 @@ columns:
       - '#entotrn_disease'
       - '#labtrn_disease'
   goal:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#vhttrn_goal'
@@ -159,11 +159,9 @@ columns:
       - '#dmditrnpt_goal'
       - '#entotrn_goal'
       - '#labtrn_goal'
-    range:
-      - 0
-      - 5000
+    range: [0, 5000]
   male_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#vhttrn_tot_male'
@@ -174,11 +172,9 @@ columns:
       - '#dmditrnpt_tot_male'
       - '#entotrn_tot_male'
       - '#labtrn_tot_male'
-    range:
-      - 0
-      - 4926
+    range: [0, 4926]
   female_trained:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#vhttrn_tot_fem'
@@ -189,11 +185,9 @@ columns:
       - '#dmditrnpt_tot_fem'
       - '#entotrn_tot_fem'
       - '#labtrn_tot_fem'
-    range:
-      - 0
-      - 4926
+    range: [0, 4926]
   tot:
-    required: yes
+    required: true
     type: numeric
     aliases:
       - Trained
@@ -205,11 +199,9 @@ columns:
       - '#dmditrnpt_tot'
       - '#entotrn_tot'
       - '#labtrn_tot'
-    range:
-      - 0
-      - 4926
+    range: [0, 4926]
   achieved_pct:
-    required: no
+    required: false
     type: numeric
     aliases:
       - '#vhttrn_achieved'
@@ -220,7 +212,5 @@ columns:
       - '#dmditrnpt_achieved'
       - '#entotrn_achieved'
       - '#labtrn_achieved'
-    range:
-      - 0
-      - 2
+    range: [0, 2]
 

--- a/inst/schemas/uga_rblf_programmatic_training.yaml
+++ b/inst/schemas/uga_rblf_programmatic_training.yaml
@@ -1,0 +1,226 @@
+# Built 2026-07-16 against the REAL CMR field codes (#vhttrn_* / #pstrn_* / #lltrn_* / #sstrn_* / #dmditrnsx_* / #dmditrnpt_* / #entotrn_* / #labtrn_*), via read-only
+# recon (structure/aggregate counts only, no records persisted or shared) against the
+# real 202606 submission from Uganda.
+#
+# ONE schema covers all training sheets present this period (VHT Training, Parish Supervisors Training, Local Leaders Training, Subcounty Supervisor Training, MMDP (surgery) Training, MMDP (patient) Training, Field Ento Training, Lab Training) because
+# eri_split_cmr() routes all of them to the same disease/data_type combo (rblf/training,
+# per ADR-0012's combined training code) -- load_dq_schema() can only resolve one file
+# per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
+# prefix present, so aliasing every prefix under one canonical column set works:
+# run_dq_checks() resolves whichever alias matches the data actually present.
+
+country: uga
+disease: rblf
+data_source: programmatic
+data_type: training
+version: '1.0'
+description: Uganda RB+LF programme trainings, combined training sheets of the monthly
+  CMR
+language: en
+time_grain: annual
+temporal:
+  year_col: year
+  period_col: year
+preprocessing:
+  - remove_smart_quotes
+columns:
+  year:
+    required: yes
+    type: numeric
+    aliases:
+      - Year
+      - YEAR
+      - '#vhttrn_year'
+      - '#pstrn_year'
+      - '#lltrn_year'
+      - '#sstrn_year'
+      - '#dmditrnsx_year'
+      - '#dmditrnpt_year'
+      - '#entotrn_year'
+      - '#labtrn_year'
+  region:
+    required: no
+    type: character
+    aliases:
+      - Region
+      - adm1
+      - '#vhttrn_adm1'
+      - '#pstrn_adm1'
+      - '#lltrn_adm1'
+      - '#sstrn_adm1'
+      - '#dmditrnsx_adm1'
+      - '#dmditrnpt_adm1'
+      - '#entotrn_adm1'
+      - '#labtrn_adm1'
+  district:
+    required: yes
+    type: character
+    aliases:
+      - District
+      - district_name
+      - adm2
+      - '#vhttrn_adm2'
+      - '#pstrn_adm2'
+      - '#lltrn_adm2'
+      - '#sstrn_adm2'
+      - '#dmditrnsx_adm2'
+      - '#dmditrnpt_adm2'
+      - '#entotrn_adm2'
+      - '#labtrn_adm2'
+    allowed_values:
+      - Adjumani
+      - Amuru
+      - Arua
+      - Bududa
+      - Buhweju
+      - Buliisa
+      - Bushenyi
+      - Gulu
+      - Gulu City
+      - Hoima
+      - Ibanda
+      - Jinja
+      - Kabarole
+      - Kagadi
+      - Kamuli
+      - Kanungu
+      - Kasese
+      - Kayunga
+      - Kikuube
+      - Kiryandongo
+      - Kisoro
+      - Kitagwenda
+      - Kitgum
+      - KOBOKO
+      - Kyenjojo
+      - Lamwo
+      - Lira
+      - MadI-Okollo
+      - Manafwa
+      - Maracha/Teregago
+      - Masindi
+      - Mayuge
+      - Mbale
+      - Mbale City
+      - Mitooma
+      - MOYO
+      - Mukono
+      - Namisindwa
+      - Nebbi
+      - Nwoya
+      - Obongi
+      - Omoro
+      - Oyam
+      - Pader
+      - Pakwach
+      - Refugees
+      - Rubanda
+      - Rubirizi
+      - Sironko
+      - Terego
+      - YUMBE
+      - Zombo
+  sub_county:
+    required: no
+    type: character
+    aliases:
+      - SubCounty
+      - sub_county
+      - adm3
+      - '#vhttrn_adm3'
+      - '#pstrn_adm3'
+      - '#lltrn_adm3'
+      - '#sstrn_adm3'
+      - '#dmditrnsx_adm3'
+      - '#dmditrnpt_adm3'
+      - '#entotrn_adm3'
+      - '#labtrn_adm3'
+  disease_reported:
+    required: no
+    type: character
+    aliases:
+      - '#vhttrn_disease'
+      - '#pstrn_disease'
+      - '#lltrn_disease'
+      - '#sstrn_disease'
+      - '#dmditrnsx_disease'
+      - '#dmditrnpt_disease'
+      - '#entotrn_disease'
+      - '#labtrn_disease'
+  goal:
+    required: no
+    type: numeric
+    aliases:
+      - '#vhttrn_goal'
+      - '#pstrn_goal'
+      - '#lltrn_goal'
+      - '#sstrn_goal'
+      - '#dmditrnsx_goal'
+      - '#dmditrnpt_goal'
+      - '#entotrn_goal'
+      - '#labtrn_goal'
+    range:
+      - 0
+      - 5000
+  male_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#vhttrn_tot_male'
+      - '#pstrn_tot_male'
+      - '#lltrn_tot_male'
+      - '#sstrn_tot_male'
+      - '#dmditrnsx_tot_male'
+      - '#dmditrnpt_tot_male'
+      - '#entotrn_tot_male'
+      - '#labtrn_tot_male'
+    range:
+      - 0
+      - 4926
+  female_trained:
+    required: no
+    type: numeric
+    aliases:
+      - '#vhttrn_tot_fem'
+      - '#pstrn_tot_fem'
+      - '#lltrn_tot_fem'
+      - '#sstrn_tot_fem'
+      - '#dmditrnsx_tot_fem'
+      - '#dmditrnpt_tot_fem'
+      - '#entotrn_tot_fem'
+      - '#labtrn_tot_fem'
+    range:
+      - 0
+      - 4926
+  tot:
+    required: yes
+    type: numeric
+    aliases:
+      - Trained
+      - '#vhttrn_tot'
+      - '#pstrn_tot'
+      - '#lltrn_tot'
+      - '#sstrn_tot'
+      - '#dmditrnsx_tot'
+      - '#dmditrnpt_tot'
+      - '#entotrn_tot'
+      - '#labtrn_tot'
+    range:
+      - 0
+      - 4926
+  achieved_pct:
+    required: no
+    type: numeric
+    aliases:
+      - '#vhttrn_achieved'
+      - '#pstrn_achieved'
+      - '#lltrn_achieved'
+      - '#sstrn_achieved'
+      - '#dmditrnsx_achieved'
+      - '#dmditrnpt_achieved'
+      - '#entotrn_achieved'
+      - '#labtrn_achieved'
+    range:
+      - 0
+      - 2
+

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -508,6 +508,37 @@ test_that("uga_oncho schema flags a district not in the real allowed_values list
   expect_true(any(res$flags$column == "district"))
 })
 
+test_that("eth_oncho_programmatic_treatment schema loads with the real district list", {
+  schema <- load_dq_schema("eth", "oncho", "programmatic", "treatment", azcontainer = NULL)
+  expect_true("#rbtrt_adm2" %in% schema$columns$district$aliases)
+  expect_true("Ari" %in% schema$columns$district$allowed_values)
+})
+
+test_that("nga_sth_programmatic_treatment schema loads (STH is Nigeria-only) with real aliases", {
+  schema <- load_dq_schema("nga", "sth", "programmatic", "treatment", azcontainer = NULL)
+  expect_true("#sthtrt_adm2" %in% schema$columns$district$aliases)
+  expect_true("Aba North" %in% schema$columns$district$allowed_values)
+})
+
+test_that("mad_lf_programmatic_treatment schema loads with the real (French-template) district list", {
+  schema <- load_dq_schema("mad", "lf", "programmatic", "treatment", azcontainer = NULL)
+  expect_true("#lftrt_adm2" %in% schema$columns$district$aliases)
+  expect_true("Analamanga" %in% schema$columns$district$allowed_values)
+})
+
+test_that("tcd_rblf_programmatic_training schema combines all training-sheet prefixes into one alias set", {
+  schema <- load_dq_schema("tcd", "rblf", "programmatic", "training", azcontainer = NULL)
+  expect_true("#cddtrn_tot" %in% schema$columns$tot$aliases)
+  expect_true("#entotrn_tot" %in% schema$columns$tot$aliases)
+})
+
+test_that("uga_lf_programmatic_mmdp and uga_lf_programmatic_tas schemas exist and resolve real codes (pilot-session gap fill)", {
+  mmdp <- load_dq_schema("uga", "lf", "programmatic", "mmdp", azcontainer = NULL)
+  expect_true("#lfdmdi_adm2" %in% mmdp$columns$district$aliases)
+  tas <- load_dq_schema("uga", "lf", "programmatic", "tas", azcontainer = NULL)
+  expect_true("#lfsurv_adm2" %in% tas$columns$district$aliases)
+})
+
 test_that("uga_sch_programmatic_treatment schema loads and resolves #schtrt_ codes", {
   schema <- load_dq_schema("uga", "sch", "programmatic", "treatment", azcontainer = NULL)
   expect_true("#schtrt_adm2" %in% schema$columns$district$aliases)

--- a/tests/testthat/test-onboarding.R
+++ b/tests/testthat/test-onboarding.R
@@ -359,7 +359,46 @@ new_schemas <- list(
   c("global", "schisto", "programmatic", "treatment"),
   c("global", "schisto", "research",     "prevalence"),
   c("global", "sth",     "programmatic", "treatment"),
-  c("global", "sth",     "research",     "prevalence")
+  c("global", "sth",     "research",     "prevalence"),
+
+  # uga's remaining CMR gap + eth/nga/mad/tcd (NEWS 0.9.39): every disease/measure
+  # each country's own inst/schemas/cmr/{code}.yaml actually routes to programmatic/.
+  c("uga", "lf",    "programmatic", "mmdp"),
+  c("uga", "lf",    "programmatic", "tas"),
+  c("uga", "oncho", "programmatic", "prevalence"),
+  c("uga", "oncho", "programmatic", "entomology"),
+  c("uga", "rblf",  "programmatic", "training"),
+
+  c("eth", "oncho", "programmatic", "treatment"),
+  c("eth", "lf",    "programmatic", "treatment"),
+  c("eth", "lf",    "programmatic", "mmdp"),
+  c("eth", "lf",    "programmatic", "tas"),
+  c("eth", "oncho", "programmatic", "prevalence"),
+  c("eth", "oncho", "programmatic", "entomology"),
+  c("eth", "rblf",  "programmatic", "training"),
+
+  c("nga", "oncho", "programmatic", "treatment"),
+  c("nga", "lf",    "programmatic", "treatment"),
+  c("nga", "sch",   "programmatic", "treatment"),
+  c("nga", "sth",   "programmatic", "treatment"),
+  c("nga", "lf",    "programmatic", "mmdp"),
+  c("nga", "lf",    "programmatic", "tas"),
+  c("nga", "oncho", "programmatic", "prevalence"),
+  c("nga", "oncho", "programmatic", "entomology"),
+  c("nga", "rblf",  "programmatic", "training"),
+
+  c("mad", "lf",    "programmatic", "treatment"),
+  c("mad", "lf",    "programmatic", "mmdp"),
+  c("mad", "lf",    "programmatic", "tas"),
+  c("mad", "rblf",  "programmatic", "training"),
+
+  c("tcd", "oncho", "programmatic", "treatment"),
+  c("tcd", "lf",    "programmatic", "treatment"),
+  c("tcd", "lf",    "programmatic", "mmdp"),
+  c("tcd", "lf",    "programmatic", "tas"),
+  c("tcd", "oncho", "programmatic", "prevalence"),
+  c("tcd", "oncho", "programmatic", "entomology"),
+  c("tcd", "rblf",  "programmatic", "training")
 )
 
 for (s in new_schemas) {


### PR DESCRIPTION
## Summary
Audit found that `load_dq_schema()` hard-aborts ("schema not found") for any disease/measure without a bundled DQ schema — meaning CMR ingestion was completely broken past the split step for eth/nga/mad/tcd, and partially broken for uga (2 of 7 measures covered).

- **32 new DQ schemas**, built via read-only recon (structure/aggregate counts only, no records persisted or shared) against each country's real most-recent CMR submission in the `projects` blob raw-drop location.
  - uga: 5 missing measures filled (`lf/mmdp`, `lf/tas`, `oncho/prevalence`, `oncho/entomology`, `rblf/training`)
  - eth: 7/7, nga: 9/9, mad: 4/4, tcd: 7/7 — all filled
- uga's and eth's `oncho/entomology` schemas are structural-only (no district `allowed_values`) — both countries' real "RB Ento Surveys" sheet currently can't be ingested at all due to the known duplicate-field-code defect that now blocks the whole workbook (ADR-0022 from the prior PR). Fill in once a corrected template lets the sheet ingest.
- Combined `rblf/training` schemas alias every training-sheet prefix each country's CMR routes there, same precedent as `sdn`/`ssd`'s existing training schemas. Ethiopia's ToT sheets are deliberately excluded (distinct field shape, doesn't fit the shared template).

Version bumped to 0.9.39 (this PR + the already-merged pilot-session-fixes PR ship together in one release).

## Test plan
- [x] `eri_schema_validate()` clean on all 32 new files
- [x] End-to-end smoke test: `run_dq_checks()` against real ingested data for 5 of the new schemas (eth oncho/treatment, nga sth/treatment, mad rblf/training, tcd lf/tas, uga lf/mmdp) — all alias resolution and range/allowed_values checks work correctly, including eth surfacing 30 real `target_pop = 0` flags
- [x] Full `testthat::test_dir()` run clean (only pre-existing CRAN/missing-package skips, no failures)
- [x] New regression tests: schema loads + real alias resolution for eth/nga/mad/tcd, multi-prefix training alias combination, uga's filled gaps