### PR TITLE
chore(release): cut 0.9.40 -- fold ToT into eth's training schema, real entomology districts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.39
+Version: 0.9.40
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,11 @@ Two follow-ups to 0.9.39's new DQ schemas:
   instead of the other 8 types' plain `tot`). `district` is now `required: false` on this
   schema specifically: "ToT Regional" genuinely has no district-level field at all, and
   since each ingest only ever carries one sheet's columns, relaxing this doesn't weaken
-  district validation for the other 9 sheet types (their own alias is always present when
-  their data is ingested).
+  district validation for the other 9 sheet types today (an accepted, narrow trade-off if
+  a future template revision ever drops a sheet's own adm2 -- see the schema's header
+  comment). **Caveat for anyone rolling up `tot` across this measure:** ToT counts "people
+  trained as trainers," a different metric from the other 8 sheets' "front-line workers
+  trained" -- no discriminator column exists yet to separate them.
 - **`uga_oncho_programmatic_entomology.yaml`/`eth_oncho_programmatic_entomology.yaml` now
   have real district `allowed_values`** (54 and 39 districts respectively), read directly
   from the raw "RB Ento Surveys" sheet -- bypassing `eri_ingest_cmr()`'s duplicate-field-code

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# erifunctions 0.9.40
+
+## Fold ToT into eth's training schema; real district lists for the entomology schemas
+
+Two follow-ups to 0.9.39's new DQ schemas:
+
+- **`eth_rblf_programmatic_training.yaml` now includes Ethiopia's "ToT Regional"/"ToT Zonal"
+  (Training of Trainers) sheets**, instead of leaving them unsupported. `eri_split_cmr()`
+  already routes them to `rblf/training` like every other training sheet, so they belong in
+  the same schema, not a separate `data_type` -- they just needed alias coverage for their
+  distinct field-naming convention (`donor`/`goal`, and totals named `tot_reg_`/`tot_zone_`
+  instead of the other 8 types' plain `tot`). `district` is now `required: false` on this
+  schema specifically: "ToT Regional" genuinely has no district-level field at all, and
+  since each ingest only ever carries one sheet's columns, relaxing this doesn't weaken
+  district validation for the other 9 sheet types (their own alias is always present when
+  their data is ingested).
+- **`uga_oncho_programmatic_entomology.yaml`/`eth_oncho_programmatic_entomology.yaml` now
+  have real district `allowed_values`** (54 and 39 districts respectively), read directly
+  from the raw "RB Ento Surveys" sheet -- bypassing `eri_ingest_cmr()`'s duplicate-field-code
+  abort (ADR-0022) rather than waiting on it, since only the district column was needed, not
+  a full clean ingest. Previously left unconstrained pending "once a corrected template lets
+  the sheet ingest."
+
 # erifunctions 0.9.39
 
 ## Close the CMR DQ schema coverage gap for eth/nga/mad/tcd, and uga's remaining gap

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.39 · **Status:** Active development
+**Version:** 0.9.40 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/adr/0022-cmr-duplicate-field-code-blocks-workbook.md
+++ b/docs/adr/0022-cmr-duplicate-field-code-blocks-workbook.md
@@ -59,3 +59,11 @@ explicit rationale and a logged trail (which the pre-v0.9.8 behavior never had).
 - Reverses the tolerant behavior introduced in v0.9.8 (`eb2b5530`/`863eb5e9`,
   "Sudan/South Sudan pilot").
 - `R/cmr.R`'s `eri_ingest_cmr()` and `eri_split_cmr()`.
+- **Working around the abort for schema authoring:** a sheet blocked by this ADR can still
+  have specific columns (e.g. a district list) read directly via
+  `readxl::read_excel(path, sheet = sheet, skip = 4, col_names = TRUE)` — bypassing
+  `eri_ingest_cmr()` entirely, since only that ADR's duplicate-code *dedup* logic (not raw
+  Excel reading) is affected. Used in v0.9.40 to source real `allowed_values` for
+  `uga_oncho_programmatic_entomology.yaml`/`eth_oncho_programmatic_entomology.yaml` while
+  their "RB Ento Surveys" sheet was still blocked. Reach for this before leaving a schema
+  column unconstrained "pending a template fix."

--- a/inst/schemas/eth_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/eth_oncho_programmatic_entomology.yaml
@@ -7,20 +7,17 @@ description: "Ethiopia onchocerciasis entomological (blackfly) surveys, RB Ento 
 language: en
 time_grain: annual
 
-# Built 2026-07-16 from the CMR routing schema's field codes only
-# (inst/schemas/cmr/eth.yaml, #rb_ento_surv_* prefix) -- NOT from a real
-# ingested sheet. Ethiopia's "RB Ento Surveys" sheet (202605 real submission)
-# has the same known duplicate field-code template defect as sdn/ssd/uga
-# ("#rb_ento_surv_notes_jan" typed twice), which now blocks the whole
-# workbook per ADR-0022 -- eri_ingest_cmr() cannot successfully read this
-# sheet at all until the shared Carter Center master template is fixed.
+# Built 2026-07-16 against the REAL district values in Ethiopia's "RB Ento Surveys" sheet
+# (202605 real submission, #rb_ento_surv_* prefix), via read-only recon (structure/
+# aggregate counts only, no records persisted or shared).
 #
-# Structurally identical to sdn_oncho_programmatic_entomology.yaml (same
-# template, same defect, same "otz" field) since that one WAS built from a
-# real ingested sheet before the whole-workbook block existed. district has
-# no allowed_values here -- no real Ethiopia entomology data has been
-# successfully read yet to source a district list from; add one once a
-# corrected file lets this sheet actually ingest.
+# This sheet has the known duplicate field-code template defect ("#rb_ento_surv_notes_jan"
+# typed twice) shared with sdn/ssd/uga, which blocks eri_ingest_cmr() from building a clean
+# data frame for it (ADR-0022). That doesn't block reading a SPECIFIC column directly,
+# though -- the district list below was read straight from the raw sheet (readxl, no
+# dedup/cleanup needed for a single column), bypassing eri_ingest_cmr() entirely rather
+# than waiting on the template fix. 39 real districts (woreda-level, same roster as the
+# other Ethiopia programmatic sheets).
 
 temporal:
   year_col: year
@@ -45,6 +42,12 @@ columns:
     required: true
     type: character
     aliases: [District, district_name, adm2, "#rb_ento_surv_adm2"]
+    allowed_values: [Agnua, Ari, Awi, Bale, "Basketo SpW", "Bench Sheko", "Buno Bedele",
+      "Central Gondar", Dawuro, "East Arsi", "East Bale", "East Hararge", Gofa, Gurage,
+      Hadiya, Illubabor, "Itang SpW", Jimma, Kaffa, "Konta Special", Liban, Metekel,
+      Mezheng, "North Gojam", "North Shoa", Sheka, "South Gondar", "South Omo",
+      "South West Shoa", "South Wollo", "Tambaro SpW", "West Gojjam", "West Gondar",
+      "West Guji", "West Hararge", "West Omo", Wolayita, WTH, Yem]
 
   sub_county:
     required: false

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -1,235 +1,145 @@
 # Built 2026-07-16 against the REAL CMR field codes (#cddtrn_* / #cstrn_* / #dmditrnsx_* /
-# #dmditrnpt_* / #entotrn_* / #hgtrn_* / #hwtrn_* / #labtrn_*), via read-only recon
-# (structure/aggregate counts only, no records persisted or shared) against the real
-# 202605 submission from Ethiopia.
+# #dmditrnpt_* / #entotrn_* / #hgtrn_* / #hwtrn_* / #labtrn_* / #tot_reg_trn_* /
+# #tot_zone_trn_*), via read-only recon (structure/aggregate counts only, no records
+# persisted or shared) against the real 202605 submission from Ethiopia.
 #
-# ONE schema covers all 8 training sheets inst/schemas/cmr/eth.yaml routes to rblf/training
-# (CDD Training, CS Training, MMDP (surgery) Training, MMDP (patient) Training, Field Ento
-# Training, Hope Group Leader Training, HW Training, Lab Training) because eri_split_cmr()
-# routes all of them to the same disease/data_type combo (rblf/training, per ADR-0012's
-# combined training code) -- load_dq_schema() can only resolve one file per (country,
-# disease, data_source, data_type). Each ingested sheet only ever has ONE prefix present,
-# so aliasing every prefix under one canonical column set works: run_dq_checks() resolves
-# whichever alias matches the data actually present.
+# ONE schema covers all 10 training sheets inst/schemas/cmr/eth.yaml routes to
+# rblf/training (CDD Training, CS Training, MMDP (surgery) Training, MMDP (patient)
+# Training, Field Ento Training, Hope Group Leader Training, HW Training, Lab Training,
+# ToT Regional, ToT Zonal) because eri_split_cmr() routes all of them to the same
+# disease/data_type combo (rblf/training, per ADR-0012's combined training code) --
+# load_dq_schema() can only resolve one file per (country, disease, data_source,
+# data_type). Each ingested sheet only ever has ONE prefix present, so aliasing every
+# prefix under one canonical column set works: run_dq_checks() resolves whichever alias
+# matches the data actually present.
 #
-# CDD Training and CS Training's #cddtrn_/#cstrn_ aliases are added STRUCTURALLY here, not
+# CDD Training and CS Training's #cddtrn_/#cstrn_ aliases are added STRUCTURALLY, not
 # from a successfully-ingested sheet: Ethiopia's real 202605 submission has the same known
 # duplicate field-code template defect on both sheets ("#cddtrn_male_oct"/"#cstrn_male_oct"
 # each typed twice), which now blocks the whole workbook per ADR-0022 -- eri_ingest_cmr()
 # cannot read either sheet until the shared Carter Center master template is fixed. Their
 # field shape (year/adm0-3/disease/goal/tot_male/tot_fem/tot/achieved) is identical to the
-# other 6 training types per inst/schemas/cmr/eth.yaml's required_fields, so the alias
-# mapping is exact even though it wasn't recon-verified against live data this pass.
+# other 6 already-verified training types per inst/schemas/cmr/eth.yaml's required_fields,
+# so the alias mapping is exact even though it wasn't recon-verified against live data.
 #
-# eth.yaml ALSO routes "ToT Regional"/"ToT Zonal" to rblf/training, deliberately NOT
-# aliased here. "ToT Regional" has no adm2/district field at all (donor/goal/
-# tot_reg__male-fem instead), so it can never satisfy this schema's required `district`
-# column under any alias mapping. "ToT Zonal" DOES have an adm2 field (donor/goal/
-# tot_zone__male-fem alongside adm0/adm1/adm2) but a genuinely different field shape from
-# the other 8 sheets (no adm3/disease, distinct tot_zone__male/fem naming) -- not aliased
-# here either, pending a decision on whether it fits this schema or needs its own
-# data_type. Unlike CDD/CS (blocked entirely by the template defect), both ToT sheets
-# ingest fine today -- ingesting either will produce a permanent, unresolvable DQ flag
-# under this schema (missing `district` for Regional; missing required fields more
-# generally for Zonal) until this gap is resolved. Known gap, not silently dropped.
+# ToT Regional/Zonal ("Training of Trainers") are genuinely training data too, folded into
+# this same schema rather than a separate data_type -- eri_split_cmr() already routes them
+# here, and they don't need their own storage location, just alias coverage for their
+# distinct field-naming convention:
+# - Both use "donor"/"goal" (a new optional column here) rather than a district-level
+#   target, and name their totals "tot_reg_"/"tot_zone_" instead of the other 8 types'
+#   plain "tot" (e.g. "#tot_reg_trn_tot_reg__male" is that prefix's "male_trained").
+# - "ToT Regional" genuinely has NO adm2/district field (only adm0/adm1) -- this is why
+#   `district` below is `required: false` rather than `true`: since each ingest only ever
+#   carries ONE sheet's columns, relaxing this doesn't weaken district validation for the
+#   other 9 sheet types (their own adm2 alias is always present when their data is
+#   ingested; `required` only fires on a column missing ENTIRELY from that ingest, not a
+#   per-row blank -- see .dq_check_required()).
+# - "ToT Zonal" DOES have adm2 (real values folded into district's allowed_values below,
+#   including two zone-level entries -- "Agaro Town"/"Jimma Town" -- not seen in the other
+#   8 sheets' woreda-level rosters) but, like Regional, has no adm3/disease field.
 
 country: eth
 disease: rblf
 data_source: programmatic
 data_type: training
-version: '1.0'
-description: Ethiopia RB+LF programme trainings, combined training sheets of the monthly
-  CMR
+version: "1.0"
+description: "Ethiopia RB+LF programme trainings, combined training sheets of the monthly CMR"
 language: en
 time_grain: annual
+
 temporal:
   year_col: year
   period_col: year
+
 preprocessing:
   - remove_smart_quotes
+
 columns:
   year:
     required: true
     type: numeric
-    aliases:
-      - Year
-      - YEAR
-      - '#cddtrn_year'
-      - '#cstrn_year'
-      - '#dmditrnsx_year'
-      - '#dmditrnpt_year'
-      - '#entotrn_year'
-      - '#hgtrn_year'
-      - '#hwtrn_year'
-      - '#labtrn_year'
+    aliases: [Year, YEAR, "#cddtrn_year", "#cstrn_year", "#dmditrnsx_year", "#dmditrnpt_year",
+      "#entotrn_year", "#hgtrn_year", "#hwtrn_year", "#labtrn_year", "#tot_reg_trn_year",
+      "#tot_zone_trn_year"]
+
   region:
     required: false
     type: character
-    aliases:
-      - Region
-      - adm1
-      - '#cddtrn_adm1'
-      - '#cstrn_adm1'
-      - '#dmditrnsx_adm1'
-      - '#dmditrnpt_adm1'
-      - '#entotrn_adm1'
-      - '#hgtrn_adm1'
-      - '#hwtrn_adm1'
-      - '#labtrn_adm1'
+    aliases: [Region, adm1, "#cddtrn_adm1", "#cstrn_adm1", "#dmditrnsx_adm1", "#dmditrnpt_adm1",
+      "#entotrn_adm1", "#hgtrn_adm1", "#hwtrn_adm1", "#labtrn_adm1", "#tot_reg_trn_adm1",
+      "#tot_zone_trn_adm1"]
+
   district:
-    required: true
+    # NOT required: "ToT Regional" has no adm2/district field at all -- see header note.
+    required: false
     type: character
-    aliases:
-      - District
-      - district_name
-      - adm2
-      - '#cddtrn_adm2'
-      - '#cstrn_adm2'
-      - '#dmditrnsx_adm2'
-      - '#dmditrnpt_adm2'
-      - '#entotrn_adm2'
-      - '#hgtrn_adm2'
-      - '#hwtrn_adm2'
-      - '#labtrn_adm2'
-    allowed_values:
-      - Agnua
-      - Amhara
-      - Ari
-      - Awi
-      - Bale
-      - Basketo SpW
-      - Bench Sheko
-      - Benishangul Gumz
-      - Buno Bedele
-      - Central
-      - Central Gondar
-      - Dawuro
-      - East Arsi
-      - East Bale
-      - East Hararge
-      - Gambella
-      - Gofa
-      - Gurage
-      - Hadiya
-      - Illubabor
-      - Itang SpW
-      - Jimma
-      - Kaffa
-      - Konta Special
-      - Liban
-      - Metekel
-      - Mezheng
-      - North Gojam
-      - North Shoa
-      - Oromia
-      - Sheka
-      - Somali
-      - South
-      - South Gondar
-      - South Omo
-      - South West Shoa
-      - South Wollo
-      - SWEPR
-      - Tambaro SpW
-      - West Gojjam
-      - West Gondar
-      - West Guji
-      - West Hararge
-      - West Omo
-      - Wolayita
-      - WTH
-      - Yem
+    aliases: [District, district_name, adm2, "#cddtrn_adm2", "#cstrn_adm2", "#dmditrnsx_adm2",
+      "#dmditrnpt_adm2", "#entotrn_adm2", "#hgtrn_adm2", "#hwtrn_adm2", "#labtrn_adm2",
+      "#tot_zone_trn_adm2"]
+    allowed_values: ["Agaro Town", Agnua, Amhara, Ari, Awi, Bale, "Basketo SpW",
+      "Bench Sheko", "Benishangul Gumz", "Buno Bedele", Central, "Central Gondar", Dawuro,
+      "East Arsi", "East Bale", "East Hararge", Gambella, Gofa, Gurage, Hadiya, Illubabor,
+      "Itang SpW", Jimma, "Jimma Town", Kaffa, "Konta Special", Liban, Metekel, Mezheng,
+      "North Gojam", "North Shoa", Oromia, Sheka, Somali, South, "South Gondar",
+      "South Omo", "South West Shoa", "South Wollo", SWEPR, "Tambaro SpW", "West Gojjam",
+      "West Gondar", "West Guji", "West Hararge", "West Omo", Wolayita, WTH, Yem]
+
   sub_county:
     required: false
     type: character
-    aliases:
-      - SubCounty
-      - sub_county
-      - adm3
-      - '#cddtrn_adm3'
-      - '#cstrn_adm3'
-      - '#dmditrnsx_adm3'
-      - '#dmditrnpt_adm3'
-      - '#entotrn_adm3'
-      - '#hgtrn_adm3'
-      - '#hwtrn_adm3'
-      - '#labtrn_adm3'
+    aliases: [SubCounty, sub_county, adm3, "#cddtrn_adm3", "#cstrn_adm3", "#dmditrnsx_adm3",
+      "#dmditrnpt_adm3", "#entotrn_adm3", "#hgtrn_adm3", "#hwtrn_adm3", "#labtrn_adm3"]
+
   disease_reported:
     required: false
     type: character
-    aliases:
-      - '#cddtrn_disease'
-      - '#cstrn_disease'
-      - '#dmditrnsx_disease'
-      - '#dmditrnpt_disease'
-      - '#entotrn_disease'
-      - '#hgtrn_disease'
-      - '#hwtrn_disease'
-      - '#labtrn_disease'
+    aliases: ["#cddtrn_disease", "#cstrn_disease", "#dmditrnsx_disease", "#dmditrnpt_disease",
+      "#entotrn_disease", "#hgtrn_disease", "#hwtrn_disease", "#labtrn_disease"]
+
+  donor:
+    # ToT-specific -- no equivalent in the other 8 training types.
+    required: false
+    type: character
+    aliases: ["#tot_reg_trn_donor", "#tot_zone_trn_donor"]
+
   goal:
     required: false
     type: numeric
-    aliases:
-      - '#cddtrn_goal'
-      - '#cstrn_goal'
-      - '#dmditrnsx_goal'
-      - '#dmditrnpt_goal'
-      - '#entotrn_goal'
-      - '#hgtrn_goal'
-      - '#hwtrn_goal'
-      - '#labtrn_goal'
+    aliases: ["#cddtrn_goal", "#cstrn_goal", "#dmditrnsx_goal", "#dmditrnpt_goal",
+      "#entotrn_goal", "#hgtrn_goal", "#hwtrn_goal", "#labtrn_goal", "#tot_reg_trn_goal",
+      "#tot_zone_trn_goal"]
     range: [0, 5000]
+
   male_trained:
     required: false
     type: numeric
-    aliases:
-      - '#cddtrn_tot_male'
-      - '#cstrn_tot_male'
-      - '#dmditrnsx_tot_male'
-      - '#dmditrnpt_tot_male'
-      - '#entotrn_tot_male'
-      - '#hgtrn_tot_male'
-      - '#hwtrn_tot_male'
-      - '#labtrn_tot_male'
+    aliases: ["#cddtrn_tot_male", "#cstrn_tot_male", "#dmditrnsx_tot_male",
+      "#dmditrnpt_tot_male", "#entotrn_tot_male", "#hgtrn_tot_male", "#hwtrn_tot_male",
+      "#labtrn_tot_male", "#tot_reg_trn_tot_reg__male", "#tot_zone_trn_tot_zone__male"]
     range: [0, 1000]
+
   female_trained:
     required: false
     type: numeric
-    aliases:
-      - '#cddtrn_tot_fem'
-      - '#cstrn_tot_fem'
-      - '#dmditrnsx_tot_fem'
-      - '#dmditrnpt_tot_fem'
-      - '#entotrn_tot_fem'
-      - '#hgtrn_tot_fem'
-      - '#hwtrn_tot_fem'
-      - '#labtrn_tot_fem'
+    aliases: ["#cddtrn_tot_fem", "#cstrn_tot_fem", "#dmditrnsx_tot_fem", "#dmditrnpt_tot_fem",
+      "#entotrn_tot_fem", "#hgtrn_tot_fem", "#hwtrn_tot_fem", "#labtrn_tot_fem",
+      "#tot_reg_trn_tot_reg__fem", "#tot_zone_trn_tot_zone__fem"]
     range: [0, 1000]
+
   tot:
     required: true
     type: numeric
-    aliases:
-      - Trained
-      - '#cddtrn_tot'
-      - '#cstrn_tot'
-      - '#dmditrnsx_tot'
-      - '#dmditrnpt_tot'
-      - '#entotrn_tot'
-      - '#hgtrn_tot'
-      - '#hwtrn_tot'
-      - '#labtrn_tot'
+    aliases: [Trained, "#cddtrn_tot", "#cstrn_tot", "#dmditrnsx_tot", "#dmditrnpt_tot",
+      "#entotrn_tot", "#hgtrn_tot", "#hwtrn_tot", "#labtrn_tot", "#tot_reg_trn_tot_reg_",
+      "#tot_zone_trn_tot_zone_"]
     range: [0, 1000]
+
   achieved_pct:
     required: false
     type: numeric
-    aliases:
-      - '#cddtrn_achieved'
-      - '#cstrn_achieved'
-      - '#dmditrnsx_achieved'
-      - '#dmditrnpt_achieved'
-      - '#entotrn_achieved'
-      - '#hgtrn_achieved'
-      - '#hwtrn_achieved'
-      - '#labtrn_achieved'
+    aliases: ["#cddtrn_achieved", "#cstrn_achieved", "#dmditrnsx_achieved",
+      "#dmditrnpt_achieved", "#entotrn_achieved", "#hgtrn_achieved", "#hwtrn_achieved",
+      "#labtrn_achieved", "#tot_reg_trn_achieved", "#tot_zone_trn_achieved"]
+    # Proportion scale, not percentage.
     range: [0, 2]
-

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -28,16 +28,30 @@
 # distinct field-naming convention:
 # - Both use "donor"/"goal" (a new optional column here) rather than a district-level
 #   target, and name their totals "tot_reg_"/"tot_zone_" instead of the other 8 types'
-#   plain "tot" (e.g. "#tot_reg_trn_tot_reg__male" is that prefix's "male_trained").
+#   plain "tot" (e.g. "#tot_reg_trn_tot_reg__male" is that prefix's "male_trained"; the
+#   ungendered "#tot_reg_trn_tot_reg_"/"#tot_zone_trn_tot_zone_" aliased into `tot` were
+#   both directly observed as real columns in the 202605 raw sheet, not inferred from the
+#   other 8 types' naming convention).
 # - "ToT Regional" genuinely has NO adm2/district field (only adm0/adm1) -- this is why
 #   `district` below is `required: false` rather than `true`: since each ingest only ever
 #   carries ONE sheet's columns, relaxing this doesn't weaken district validation for the
-#   other 9 sheet types (their own adm2 alias is always present when their data is
-#   ingested; `required` only fires on a column missing ENTIRELY from that ingest, not a
-#   per-row blank -- see .dq_check_required()).
+#   other 9 sheet types AS LONG AS each keeps reporting adm2 (their own alias is always
+#   present when their data is ingested today; `required` only fires on a column missing
+#   ENTIRELY from that ingest, not a per-row blank -- see .dq_check_required()). If a
+#   future template revision drops adm2 from one of the other 9 sheets, that specific
+#   regression would go uncaught by this check -- an accepted, narrow trade-off, not a
+#   general weakening.
 # - "ToT Zonal" DOES have adm2 (real values folded into district's allowed_values below,
 #   including two zone-level entries -- "Agaro Town"/"Jimma Town" -- not seen in the other
 #   8 sheets' woreda-level rosters) but, like Regional, has no adm3/disease field.
+#
+# CAVEAT for anyone rolling up `tot` across the whole rblf/training measure (e.g. via
+# eri_query()): ToT counts "people trained as trainers" (cascade capacity), a different
+# thing from the other 8 sheets' "front-line workers trained" (direct service delivery) --
+# summing across both without distinguishing them conflates two different metrics. No
+# discriminator column exists to separate them (ADR-0012 already combines 8 different
+# training audiences with none); worth a `training_type`/`sheet` column in a future ADR if
+# this measure needs to support that kind of analysis.
 
 country: eth
 disease: rblf

--- a/inst/schemas/uga_oncho_programmatic_entomology.yaml
+++ b/inst/schemas/uga_oncho_programmatic_entomology.yaml
@@ -7,20 +7,18 @@ description: "Uganda onchocerciasis entomological (blackfly) surveys, RB Ento Su
 language: en
 time_grain: annual
 
-# Built 2026-07-16 from the CMR routing schema's field codes only
-# (inst/schemas/cmr/uga.yaml, #rb_ento_surv_* prefix) -- NOT from a real
-# ingested sheet. Uganda's "RB Ento Surveys" sheet (202606 real submission)
-# has the same known duplicate field-code template defect as sdn/ssd/eth
-# ("#rb_ento_surv_notes_jan" typed twice), which now blocks the whole
-# workbook per ADR-0022 -- eri_ingest_cmr() cannot successfully read this
-# sheet at all until the shared Carter Center master template is fixed.
+# Built 2026-07-16 against the REAL district values in Uganda's "RB Ento Surveys" sheet
+# (202606 real submission, #rb_ento_surv_* prefix), via read-only recon (structure/
+# aggregate counts only, no records persisted or shared).
 #
-# Structurally identical to sdn_oncho_programmatic_entomology.yaml (same
-# template, same defect, same "otz" field) since that one WAS built from a
-# real ingested sheet before the whole-workbook block existed. district has
-# no allowed_values here -- no real Uganda entomology data has been
-# successfully read yet to source a district list from; add one once a
-# corrected file lets this sheet actually ingest.
+# This sheet has the known duplicate field-code template defect ("#rb_ento_surv_notes_jan"
+# typed twice) shared with sdn/ssd/eth, which blocks eri_ingest_cmr() from building a clean
+# data frame for it (ADR-0022). That doesn't block reading a SPECIFIC column directly,
+# though -- the district list below was read straight from the raw sheet (readxl, no
+# dedup/cleanup needed for a single column), bypassing eri_ingest_cmr() entirely rather
+# than waiting on the template fix. 54 real districts, including two refugee-settlement
+# entries ("Adjumani Refugee Settlements", "Palabek Refugee Settlements",
+# "Palorinya Refugee Settlements") not seen in the treatment-sheet district rosters.
 
 temporal:
   year_col: year
@@ -45,6 +43,13 @@ columns:
     required: true
     type: character
     aliases: [District, district_name, adm2, "#rb_ento_surv_adm2"]
+    allowed_values: [Adjumani, "Adjumani Refugee Settlements", Amuru, Arua, Bududa,
+      Buhweju, Buliisa, Bushenyi, Gulu, "Gulu City", Hoima, Ibanda, Jinja, Kabarole,
+      Kagadi, Kamuli, Kanungu, Kasese, Kayunga, Kikuube, Kiryandongo, Kisoro, Kitagwenda,
+      Kitgum, KOBOKO, Kyenjojo, Lamwo, Lira, "MadI-Okollo", Manafwa, "Maracha/Teregago",
+      Masindi, Mayuge, Mbale, "Mbale City", Mitooma, MOYO, Mukono, Namisindwa, Nebbi,
+      Nwoya, Obongi, Omoro, Oyam, Pader, Pakwach, "Palabek Refugee Settlements",
+      "Palorinya Refugee Settlements", Rubanda, Rubirizi, Sironko, Terego, YUMBE, Zombo]
 
   sub_county:
     required: false

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -508,6 +508,42 @@ test_that("uga_oncho schema flags a district not in the real allowed_values list
   expect_true(any(res$flags$column == "district"))
 })
 
+test_that("eth_rblf_programmatic_training folds ToT Regional/Zonal into the shared training schema", {
+  schema <- load_dq_schema("eth", "rblf", "programmatic", "training", azcontainer = NULL)
+  # ToT-specific fields resolve
+  expect_true("#tot_reg_trn_donor" %in% schema$columns$donor$aliases)
+  expect_true("#tot_zone_trn_donor" %in% schema$columns$donor$aliases)
+  expect_true("#tot_reg_trn_tot_reg_" %in% schema$columns$tot$aliases)
+  expect_true("#tot_zone_trn_tot_zone_" %in% schema$columns$tot$aliases)
+  # district is NOT required -- "ToT Regional" genuinely has no adm2 field
+  expect_false(schema$columns$district$required)
+  # "ToT Zonal" real district values are present (including zone-level entries
+  # not seen in the other 8 sheets' woreda-level rosters)
+  expect_true("Agaro Town" %in% schema$columns$district$allowed_values)
+})
+
+test_that("eth_rblf_programmatic_training: a ToT Regional row (no district at all) is not flagged as missing a required column", {
+  schema <- load_dq_schema("eth", "rblf", "programmatic", "training", azcontainer = NULL)
+  df <- tibble::tibble(
+    `#tot_reg_trn_year` = "2026", `#tot_reg_trn_adm1` = "Amhara",
+    `#tot_reg_trn_donor` = "Sightsavers", `#tot_reg_trn_tot_reg_` = "20"
+  )
+  res <- run_dq_checks(df, schema)
+  expect_false(any(res$flags$issue == "Required column is missing from data" & res$flags$column == "district"))
+})
+
+test_that("uga_oncho_programmatic_entomology and eth_oncho_programmatic_entomology have real district allowed_values", {
+  # Both sheets currently fail eri_ingest_cmr() (duplicate field code, ADR-0022), but the
+  # district list was read directly from the raw sheet, bypassing that abort.
+  uga <- load_dq_schema("uga", "oncho", "programmatic", "entomology", azcontainer = NULL)
+  expect_true("Adjumani" %in% uga$columns$district$allowed_values)
+  expect_true(length(uga$columns$district$allowed_values) > 1L)
+
+  eth <- load_dq_schema("eth", "oncho", "programmatic", "entomology", azcontainer = NULL)
+  expect_true("Awi" %in% eth$columns$district$allowed_values)
+  expect_true(length(eth$columns$district$allowed_values) > 1L)
+})
+
 test_that("eth_oncho_programmatic_treatment schema loads with the real district list", {
   schema <- load_dq_schema("eth", "oncho", "programmatic", "treatment", azcontainer = NULL)
   expect_true("#rbtrt_adm2" %in% schema$columns$district$aliases)


### PR DESCRIPTION
## Summary
Brings `dev` (PR #311, already merged and reviewed there) onto `main` as a release cut per the project's dev->main convention.

- **#311** — fast follow-up to 0.9.39: Ethiopia's "ToT Regional"/"ToT Zonal" (Training of Trainers) sheets folded into the existing combined `rblf/training` schema instead of left unsupported; real district `allowed_values` (54 uga / 39 eth) for the two `oncho/entomology` schemas, sourced by reading the raw sheet directly (bypassing `eri_ingest_cmr()`'s duplicate-field-code abort) rather than waiting on a template fix.

PR #311 passed review-agent with no blockers. Version at 0.9.40 (DESCRIPTION/README already bumped on `dev`).

## Test plan
- [x] Full `testthat::test_dir()` clean on `dev` (only pre-existing CRAN/missing-package skips)
- [x] PR #311 individually reviewed, findings addressed