### PR TITLE
chore(release): cut 0.9.41 -- training_type discriminator for combined training schemas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.40
+Version: 0.9.41
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@ staged data: `ssd` (6 files) and `uga` (8 files) both have staged `rblf/training
 that will need a re-split; these counts will change as DAs work through their own backlogs,
 so treat them as a pointer to check `eri_logs()`, not a permanent count.
 
+- `eri_ingest_cmr()` also now aborts with a clear message when `sheet` is passed as an
+  out-of-range 1-based index, instead of R's raw "subscript out of bounds".
+
 # erifunctions 0.9.40
 
 ## Fold ToT into eth's training schema; real district lists for the entomology schemas

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# erifunctions 0.9.41
+
+## Add a training_type discriminator to every combined training schema
+
+`eri_ingest_cmr()` now stamps a `sheet` column (the real sheet name, resolved even when
+`sheet` was passed as an index or slug) onto every row it returns. All 7
+`{country}_rblf_programmatic_training.yaml` schemas (`sdn`, `ssd`, `uga`, `eth`, `nga`, `mad`,
+`tcd`) alias it into a new required `training_type` column, with `allowed_values` listing
+that country's real training sheet names.
+
+This closes the gap flagged in 0.9.40's review: rolling up `tot` across a combined training
+measure (e.g. via `eri_query()`) previously had no way to distinguish which of several
+training audiences (CDD vs. Field Ento vs. ToT, etc.) a row came from -- `training_type` is
+that discriminator. `eth`'s schema in particular now lets someone separate ToT's "people
+trained as trainers" from the other 9 sheets' "front-line workers trained."
+
 # erifunctions 0.9.40
 
 ## Fold ToT into eth's training schema; real district lists for the entomology schemas

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,14 @@ This closes the gap flagged in 0.9.40's review: rolling up `tot` across a combin
 measure (e.g. via `eri_query()`) previously had no way to distinguish which of several
 training audiences (CDD vs. Field Ento vs. ToT, etc.) a row came from -- `training_type` is
 that discriminator. `eth`'s schema in particular now lets someone separate ToT's "people
-trained as trainers" from the other 9 sheets' "front-line workers trained."
+trained as trainers" from the other 9 sheets' "front-line workers trained." See
+[ADR-0023](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0023-cmr-ingest-stamps-sheet-name.md).
+
+**Migration note:** any `rblf/training` parquet already staged (not yet approved) before this
+change was split without a `sheet` column, so it will now be missing `training_type`
+(`required: true`) on its next DQ check. Re-run `eri_split_cmr(..., supersede_staged = TRUE)`
+against the same source workbook to refresh it (same mechanism as any other staged-data
+fix, per ADR-0017) -- nothing migrates automatically.
 
 # erifunctions 0.9.40
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,10 @@ trained as trainers" from the other 9 sheets' "front-line workers trained." See
 change was split without a `sheet` column, so it will now be missing `training_type`
 (`required: true`) on its next DQ check. Re-run `eri_split_cmr(..., supersede_staged = TRUE)`
 against the same source workbook to refresh it (same mechanism as any other staged-data
-fix, per ADR-0017) -- nothing migrates automatically.
+fix, per ADR-0017) -- nothing migrates automatically. As of 2026-07-15, this affects real
+staged data: `ssd` (6 files) and `uga` (8 files) both have staged `rblf/training` parquet
+that will need a re-split; these counts will change as DAs work through their own backlogs,
+so treat them as a pointer to check `eri_logs()`, not a permanent count.
 
 # erifunctions 0.9.40
 

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -80,7 +80,10 @@ load_cmr_schema <- function(country) {
 #'   aliases are resolved. Default `NULL`.
 #'
 #' @returns A tibble with field-code column names and data from row 6 onward,
-#'   plus an `excel_row` column recording each row's real position in the
+#'   plus a `sheet` column (the real sheet name, resolved even when `sheet` was
+#'   passed as an index or slug -- lets a schema covering several sheets routed
+#'   to the same disease/data_type, e.g. combined trainings, tell them apart)
+#'   and an `excel_row` column recording each row's real position in the
 #'   workbook (survives all-NA spacer-row dropping, so it stays accurate even
 #'   after rows are removed). If `country` is supplied it is prepended as a
 #'   `country` column.
@@ -107,17 +110,22 @@ eri_ingest_cmr <- function(path, sheet, country = NULL) {
     }
   }
 
+  available <- readxl::excel_sheets(path)
+
   # Fail with a helpful, named error rather than readxl's opaque one when the
   # sheet (after alias resolution) isn't in the workbook.
-  if (is.character(actual_sheet)) {
-    available <- readxl::excel_sheets(path)
-    if (!actual_sheet %in% available) {
-      cli::cli_abort(c(
-        "Sheet {.val {actual_sheet}} not found in {.path {basename(path)}}.",
-        "i" = "Available sheets: {.val {available}}."
-      ))
-    }
+  if (is.character(actual_sheet) && !actual_sheet %in% available) {
+    cli::cli_abort(c(
+      "Sheet {.val {actual_sheet}} not found in {.path {basename(path)}}.",
+      "i" = "Available sheets: {.val {available}}."
+    ))
   }
+
+  # The real sheet name, whether `sheet` was passed as a name, a slug (resolved
+  # above), or a 1-based index -- stamped onto every row below so a combined
+  # schema (several sheets routed to the same disease/data_type, e.g.
+  # rblf/training) can tell which sheet a row actually came from.
+  sheet_name <- if (is.character(actual_sheet)) actual_sheet else available[[actual_sheet]]
 
   raw <- readxl::read_excel(path, sheet = actual_sheet, skip = 4,
                              col_names = TRUE, .name_repair = "minimal")
@@ -162,6 +170,7 @@ eri_ingest_cmr <- function(path, sheet, country = NULL) {
   df        <- tibble::as_tibble(df[!all_na, , drop = FALSE])
   excel_row <- excel_row[!all_na]
   df        <- tibble::add_column(df, excel_row = excel_row, .before = 1)
+  df        <- tibble::add_column(df, sheet = sheet_name, .before = 1)
 
   if (!is.null(country)) {
     df <- tibble::add_column(df, country = country, .before = 1)

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -112,12 +112,19 @@ eri_ingest_cmr <- function(path, sheet, country = NULL) {
 
   available <- readxl::excel_sheets(path)
 
-  # Fail with a helpful, named error rather than readxl's opaque one when the
-  # sheet (after alias resolution) isn't in the workbook.
+  # Fail with a helpful, named error rather than readxl's/R's opaque one when
+  # the sheet (after alias resolution) isn't in the workbook -- by name, or by
+  # an out-of-range 1-based index.
   if (is.character(actual_sheet) && !actual_sheet %in% available) {
     cli::cli_abort(c(
       "Sheet {.val {actual_sheet}} not found in {.path {basename(path)}}.",
       "i" = "Available sheets: {.val {available}}."
+    ))
+  }
+  if (!is.character(actual_sheet) && !actual_sheet %in% seq_along(available)) {
+    cli::cli_abort(c(
+      "Sheet index {.val {actual_sheet}} is out of range for {.path {basename(path)}}.",
+      "i" = "This workbook has {length(available)} sheet{?s}: {.val {available}}."
     ))
   }
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.40 · **Status:** Active development
+**Version:** 0.9.41 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/adr/0023-cmr-ingest-stamps-sheet-name.md
+++ b/docs/adr/0023-cmr-ingest-stamps-sheet-name.md
@@ -1,7 +1,7 @@
 # ADR-0023 — `eri_ingest_cmr()` stamps the real sheet name onto every row
 
 - **Status:** Accepted
-- **Date:** 2026-07-16
+- **Date:** 2026-07-15
 
 ## Context
 

--- a/docs/adr/0023-cmr-ingest-stamps-sheet-name.md
+++ b/docs/adr/0023-cmr-ingest-stamps-sheet-name.md
@@ -18,7 +18,7 @@ sheet a row came from. Rolling up `tot` (people trained) across the whole `rblf/
 — e.g. via `eri_query()` — silently conflated genuinely different training audiences. Ethiopia's
 case makes this concrete: "ToT" (Training of Trainers) counts trainer-cascade capacity, a different
 metric from the other 9 sheets' front-line worker headcounts, with no column to separate them
-(flagged in the PR #311 review, 2026-07-16).
+(flagged in the PR #311 review, 2026-07-15).
 
 ## Decision
 

--- a/docs/adr/0023-cmr-ingest-stamps-sheet-name.md
+++ b/docs/adr/0023-cmr-ingest-stamps-sheet-name.md
@@ -1,0 +1,59 @@
+# ADR-0023 — `eri_ingest_cmr()` stamps the real sheet name onto every row
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+Several CMR schemas cover more than one sheet under a single `(country, disease, data_source,
+data_type)` identity — most visibly the `rblf/training` schemas (`sdn`, `ssd`, `uga`, `eth`, `nga`,
+`mad`, `tcd`), which each alias 6–10 distinct training sheets (CDD Training, Field Ento Training,
+ToT Regional, ...) into one canonical column set, per [ADR-0012](0012-source-measure-data-model.md)'s
+combined training code. `eri_split_cmr()` routes all of them to the same
+`{country}/rblf/programmatic/training/staged/` destination because `load_dq_schema()` can only
+resolve one schema file per that four-part identity.
+
+This has a real consequence: once staged (or processed), there was no way to tell which specific
+sheet a row came from. Rolling up `tot` (people trained) across the whole `rblf/training` measure
+— e.g. via `eri_query()` — silently conflated genuinely different training audiences. Ethiopia's
+case makes this concrete: "ToT" (Training of Trainers) counts trainer-cascade capacity, a different
+metric from the other 9 sheets' front-line worker headcounts, with no column to separate them
+(flagged in the PR #311 review, 2026-07-16).
+
+## Decision
+
+`eri_ingest_cmr()` — the shared, general-purpose CMR sheet reader every ingest path (`eri_split_cmr()`,
+direct calls) goes through — now stamps a `sheet` column onto every row it returns, holding the
+real sheet name. This resolves correctly whether `sheet` was passed as a name, a country-schema
+slug (via `sheet_aliases`), or a 1-based index. It is a change to the function's general return
+contract, not scoped to training sheets specifically — the same "problem is general, solve it
+generally" reasoning as `excel_row`/`country` (already stamped the same way).
+
+Each of the 7 `rblf_programmatic_training.yaml` schemas aliases this new `sheet` column into a new
+canonical `training_type` column (`required: true`, `allowed_values` = that country's exact real
+training-sheet names). Non-training schemas leave `sheet` unaliased — it lands in the staged data
+but sits inert, exactly like any other raw column no schema references (`run_dq_checks()` has no
+"reject unknown columns" behavior).
+
+## Consequences
+
+- **Easier:** anyone rolling up a combined-schema measure can now filter/group by `training_type`
+  to compare like with like, instead of every row of `rblf/training` looking interchangeable.
+- **Harder / accepted:** every already-staged (not yet approved) training parquet split *before*
+  this change lacks a `sheet` column entirely, so `training_type`'s `required: true` will now flag
+  it as missing on the next DQ check. This is the same situation ADR-0017's `supersede_staged`
+  already exists for — re-run `eri_split_cmr(..., supersede_staged = TRUE)` against the same source
+  workbook to refresh already-staged training data with the new column. Nothing auto-migrates.
+- **Not doing:** a general "which sheet did this row come from" column for every CMR data type's
+  schema (treatment, mmdp, tas, prevalence, entomology) — only the training schemas actually need
+  a discriminator today, since they're the only ones combining multiple sheets under one identity.
+  The `sheet` column is available to any future schema that needs the same pattern without a further
+  `eri_ingest_cmr()` change.
+
+## References
+
+- [ADR-0012](0012-source-measure-data-model.md) — the combined-training-code design this
+  discriminator serves.
+- [ADR-0017](0017-cmr-staged-file-supersession.md) — `supersede_staged`, the existing mechanism for
+  refreshing already-staged data after a schema/ingest change like this one.
+- `R/cmr.R`'s `eri_ingest_cmr()`; `inst/schemas/{sdn,ssd,uga,eth,nga,mad,tcd}_rblf_programmatic_training.yaml`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,3 +66,4 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0020](0020-canonical-country-disease-codes.md) | Canonical, normalized country and disease codes | Accepted — amends ADR-0012 point 5 |
 | [0021](0021-mirror-filename-period-leading.md) | Legacy mirror filename leads with period, not country | Accepted |
 | [0022](0022-cmr-duplicate-field-code-blocks-workbook.md) | A duplicate CMR field code blocks the whole workbook, not just its sheet | Accepted — reverses v0.9.8 |
+| [0023](0023-cmr-ingest-stamps-sheet-name.md) | `eri_ingest_cmr()` stamps the real sheet name onto every row | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,6 +82,7 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 | [0020](adr/0020-canonical-country-disease-codes.md) | Canonical, normalized (lowercase + trim) `country`/`disease`, validated against a registry; amends ADR-0012 point 5 | Prevent case-drift path duplication (#303/#306) |
 | [0021](adr/0021-mirror-filename-period-leading.md) | Legacy `projects`-blob mirror filename leads with period (`{period}_{country}_{timestamp}`), matching the real convention | CMR pilot-session filename mismatch |
 | [0022](adr/0022-cmr-duplicate-field-code-blocks-workbook.md) | A duplicate CMR field code blocks the whole workbook, not just its sheet; reverses the v0.9.8 per-sheet-tolerant behavior | CMR pilot-session template-defect handling |
+| [0023](adr/0023-cmr-ingest-stamps-sheet-name.md) | `eri_ingest_cmr()` stamps the real sheet name onto every row, so a combined schema (e.g. training) can discriminate its sources | `training_type` discriminator for rolled-up measures |
 
 ---
 

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -45,7 +45,7 @@
 #   including two zone-level entries -- "Agaro Town"/"Jimma Town" -- not seen in the other
 #   8 sheets' woreda-level rosters) but, like Regional, has no adm3/disease field.
 #
-# training_type (added 2026-07-16) discriminates which of the 10 sheets a row came from --
+# training_type (added 2026-07-15) discriminates which of the 10 sheets a row came from --
 # aliased to `sheet`, the real sheet name eri_ingest_cmr() now stamps onto every row. This is
 # what lets anyone rolling up `tot` across the whole measure (e.g. via eri_query()) separate
 # ToT's "people trained as trainers" (cascade capacity) from the other 8 sheets' "front-line

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -45,13 +45,13 @@
 #   including two zone-level entries -- "Agaro Town"/"Jimma Town" -- not seen in the other
 #   8 sheets' woreda-level rosters) but, like Regional, has no adm3/disease field.
 #
-# CAVEAT for anyone rolling up `tot` across the whole rblf/training measure (e.g. via
-# eri_query()): ToT counts "people trained as trainers" (cascade capacity), a different
-# thing from the other 8 sheets' "front-line workers trained" (direct service delivery) --
-# summing across both without distinguishing them conflates two different metrics. No
-# discriminator column exists to separate them (ADR-0012 already combines 8 different
-# training audiences with none); worth a `training_type`/`sheet` column in a future ADR if
-# this measure needs to support that kind of analysis.
+# training_type (added 2026-07-16) discriminates which of the 10 sheets a row came from --
+# aliased to `sheet`, the real sheet name eri_ingest_cmr() now stamps onto every row. This is
+# what lets anyone rolling up `tot` across the whole measure (e.g. via eri_query()) separate
+# ToT's "people trained as trainers" (cascade capacity) from the other 8 sheets' "front-line
+# workers trained" (direct service delivery) -- summing across both without filtering by
+# training_type still conflates two different metrics, but the column to do that filtering
+# now exists.
 
 country: eth
 disease: rblf
@@ -70,6 +70,14 @@ preprocessing:
   - remove_smart_quotes
 
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["CDD Training", "CS Training", "MMDP (surgery) Training",
+      "MMDP (patient) Training", "Field Ento Training", "Hope Group Leader Training",
+      "HW Training", "Lab Training", "ToT Regional", "ToT Zonal"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/mad_rblf_programmatic_training.yaml
+++ b/inst/schemas/mad_rblf_programmatic_training.yaml
@@ -8,6 +8,12 @@
 # per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
+#
+# training_type (added 2026-07-16) discriminates which of the 7 sheets a row
+# came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
+# stamps onto every row (added specifically so combined schemas like this one
+# can tell their sources apart; rolling up `tot` across the whole measure
+# without it would conflate 7 different training audiences under one number).
 
 country: mad
 disease: rblf
@@ -24,6 +30,14 @@ temporal:
 preprocessing:
   - remove_smart_quotes
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["Formation Distributeurs", "Formation SC", "PCMPI Formation Chirurgie",
+      "Formation PCMPI Patient", "Formation Travailleurs de Sante",
+      "Formation Leader Groupe HOPE", "Formation Professeurs"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/mad_rblf_programmatic_training.yaml
+++ b/inst/schemas/mad_rblf_programmatic_training.yaml
@@ -9,7 +9,7 @@
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
 #
-# training_type (added 2026-07-16) discriminates which of the 7 sheets a row
+# training_type (added 2026-07-15) discriminates which of the 7 sheets a row
 # came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
 # stamps onto every row (added specifically so combined schemas like this one
 # can tell their sources apart; rolling up `tot` across the whole measure

--- a/inst/schemas/nga_rblf_programmatic_training.yaml
+++ b/inst/schemas/nga_rblf_programmatic_training.yaml
@@ -9,7 +9,7 @@
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
 #
-# training_type (added 2026-07-16) discriminates which of the 9 sheets a row
+# training_type (added 2026-07-15) discriminates which of the 9 sheets a row
 # came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
 # stamps onto every row (added specifically so combined schemas like this one
 # can tell their sources apart; rolling up `tot` across the whole measure

--- a/inst/schemas/nga_rblf_programmatic_training.yaml
+++ b/inst/schemas/nga_rblf_programmatic_training.yaml
@@ -8,6 +8,12 @@
 # per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
+#
+# training_type (added 2026-07-16) discriminates which of the 9 sheets a row
+# came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
+# stamps onto every row (added specifically so combined schemas like this one
+# can tell their sources apart; rolling up `tot` across the whole measure
+# without it would conflate 9 different training audiences under one number).
 
 country: nga
 disease: rblf
@@ -24,6 +30,14 @@ temporal:
 preprocessing:
   - remove_smart_quotes
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["CDD Training", "CS Training", "MMDP (surgery) Training",
+      "MMDP (patient) Training", "Field Ento Training", "Health Workers Training",
+      "Hope Group Leader Training", "Lab Training", "Teacher Training"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/sdn_rblf_programmatic_training.yaml
+++ b/inst/schemas/sdn_rblf_programmatic_training.yaml
@@ -28,6 +28,12 @@ time_grain: annual
 # UNVERIFIED CEILING: goal/tot ranges below are set from the observed spread
 # across all 6 training types this period; not confirmed against a full year
 # of data.
+#
+# training_type (added 2026-07-16) discriminates which of the 6 sheets a row
+# came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
+# stamps onto every row (added specifically so combined schemas like this one
+# can tell their sources apart; rolling up `tot` across the whole measure
+# without it would conflate 6 different training audiences under one number).
 
 temporal:
   year_col: year
@@ -37,6 +43,13 @@ preprocessing:
   - remove_smart_quotes
 
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["CDD Training", "CS Training", "MMDP (surgery) Training",
+      "MMDP (patient) Training", "Field Ento Training", "Health Workers Training"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/sdn_rblf_programmatic_training.yaml
+++ b/inst/schemas/sdn_rblf_programmatic_training.yaml
@@ -29,7 +29,7 @@ time_grain: annual
 # across all 6 training types this period; not confirmed against a full year
 # of data.
 #
-# training_type (added 2026-07-16) discriminates which of the 6 sheets a row
+# training_type (added 2026-07-15) discriminates which of the 6 sheets a row
 # came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
 # stamps onto every row (added specifically so combined schemas like this one
 # can tell their sources apart; rolling up `tot` across the whole measure

--- a/inst/schemas/ssd_rblf_programmatic_training.yaml
+++ b/inst/schemas/ssd_rblf_programmatic_training.yaml
@@ -28,6 +28,12 @@ time_grain: annual
 # UNVERIFIED CEILING: goal/tot ranges below are set from the observed spread
 # across all 6 training types this period (goal up to ~2,832 for CDD Training);
 # not confirmed against a full year of data.
+#
+# training_type (added 2026-07-16) discriminates which of the 6 sheets a row
+# came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
+# stamps onto every row (added specifically so combined schemas like this one
+# can tell their sources apart; rolling up `tot` across the whole measure
+# without it would conflate 6 different training audiences under one number).
 
 temporal:
   year_col: year
@@ -37,6 +43,13 @@ preprocessing:
   - remove_smart_quotes
 
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["CDD Training", "CS Training", "MMDP (surgery) Training",
+      "MMDP (patient) Training", "Field Ento Training", "Health Workers Training"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/ssd_rblf_programmatic_training.yaml
+++ b/inst/schemas/ssd_rblf_programmatic_training.yaml
@@ -29,7 +29,7 @@ time_grain: annual
 # across all 6 training types this period (goal up to ~2,832 for CDD Training);
 # not confirmed against a full year of data.
 #
-# training_type (added 2026-07-16) discriminates which of the 6 sheets a row
+# training_type (added 2026-07-15) discriminates which of the 6 sheets a row
 # came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
 # stamps onto every row (added specifically so combined schemas like this one
 # can tell their sources apart; rolling up `tot` across the whole measure

--- a/inst/schemas/tcd_rblf_programmatic_training.yaml
+++ b/inst/schemas/tcd_rblf_programmatic_training.yaml
@@ -9,7 +9,7 @@
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
 #
-# training_type (added 2026-07-16) discriminates which of the 8 sheets a row
+# training_type (added 2026-07-15) discriminates which of the 8 sheets a row
 # came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
 # stamps onto every row (added specifically so combined schemas like this one
 # can tell their sources apart; rolling up `tot` across the whole measure

--- a/inst/schemas/tcd_rblf_programmatic_training.yaml
+++ b/inst/schemas/tcd_rblf_programmatic_training.yaml
@@ -8,6 +8,12 @@
 # per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
+#
+# training_type (added 2026-07-16) discriminates which of the 8 sheets a row
+# came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
+# stamps onto every row (added specifically so combined schemas like this one
+# can tell their sources apart; rolling up `tot` across the whole measure
+# without it would conflate 8 different training audiences under one number).
 
 country: tcd
 disease: rblf
@@ -24,6 +30,15 @@ temporal:
 preprocessing:
   - remove_smart_quotes
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["Formation Distributeurs Comm", "Formation Superviseurs Comm",
+      "PCMPI (Chirurgie) Formation", "PCMPI Formation (Patient)",
+      "Formation Ento de Terrain", "Formation Trav Sante", "Formation Leader Groupe Hope",
+      "Formation Professeurs"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/uga_rblf_programmatic_training.yaml
+++ b/inst/schemas/uga_rblf_programmatic_training.yaml
@@ -8,6 +8,12 @@
 # per (country, disease, data_source, data_type). Each ingested sheet only ever has ONE
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
+#
+# training_type (added 2026-07-16) discriminates which of the 8 sheets a row
+# came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
+# stamps onto every row (added specifically so combined schemas like this one
+# can tell their sources apart; rolling up `tot` across the whole measure
+# without it would conflate 8 different training audiences under one number).
 
 country: uga
 disease: rblf
@@ -24,6 +30,14 @@ temporal:
 preprocessing:
   - remove_smart_quotes
 columns:
+  training_type:
+    required: true
+    type: character
+    aliases: [sheet]
+    allowed_values: ["VHT Training", "Parish Supervisors Training", "Local Leaders Training",
+      "Subcounty Supervisor Training", "MMDP (surgery) Training", "MMDP (patient) Training",
+      "Field Ento Training", "Lab Training"]
+
   year:
     required: true
     type: numeric

--- a/inst/schemas/uga_rblf_programmatic_training.yaml
+++ b/inst/schemas/uga_rblf_programmatic_training.yaml
@@ -9,7 +9,7 @@
 # prefix present, so aliasing every prefix under one canonical column set works:
 # run_dq_checks() resolves whichever alias matches the data actually present.
 #
-# training_type (added 2026-07-16) discriminates which of the 8 sheets a row
+# training_type (added 2026-07-15) discriminates which of the 8 sheets a row
 # came from -- aliased to `sheet`, the real sheet name eri_ingest_cmr() now
 # stamps onto every row (added specifically so combined schemas like this one
 # can tell their sources apart; rolling up `tot` across the whole measure

--- a/man/eri_ingest_cmr.Rd
+++ b/man/eri_ingest_cmr.Rd
@@ -19,7 +19,10 @@ aliases are resolved. Default \code{NULL}.}
 }
 \value{
 A tibble with field-code column names and data from row 6 onward,
-plus an \code{excel_row} column recording each row's real position in the
+plus a \code{sheet} column (the real sheet name, resolved even when \code{sheet} was
+passed as an index or slug -- lets a schema covering several sheets routed
+to the same disease/data_type, e.g. combined trainings, tell them apart)
+and an \code{excel_row} column recording each row's real position in the
 workbook (survives all-NA spacer-row dropping, so it stays accurate even
 after rows are removed). If \code{country} is supplied it is prepended as a
 \code{country} column.

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -35,13 +35,21 @@ make_cmr_xlsx <- function(path,
 
 #### Tests for eri_ingest_cmr ####
 
-test_that("eri_ingest_cmr returns tibble with field code columns plus excel_row", {
+test_that("eri_ingest_cmr returns tibble with field code columns plus sheet/excel_row", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   make_cmr_xlsx(tmp)
   out <- eri_ingest_cmr(tmp, sheet = "RB Treatment")
   expect_s3_class(out, "tbl_df")
-  expect_true(all(startsWith(setdiff(names(out), "excel_row"), "#")))
-  expect_equal(ncol(out), 4L)  # 3 field codes + excel_row
+  expect_true(all(startsWith(setdiff(names(out), c("excel_row", "sheet")), "#")))
+  expect_equal(ncol(out), 5L)  # 3 field codes + sheet + excel_row
+  expect_equal(unique(out$sheet), "RB Treatment")
+})
+
+test_that("eri_ingest_cmr's sheet column resolves the real name even when sheet is passed as a 1-based index", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_cmr_xlsx(tmp, sheet_name = "RB Treatment")
+  out <- eri_ingest_cmr(tmp, sheet = 1L)
+  expect_equal(unique(out$sheet), "RB Treatment")
 })
 
 test_that("eri_ingest_cmr's excel_row points at the real workbook row (data starts at row 6)", {
@@ -141,7 +149,7 @@ test_that("eri_ingest_cmr ignores non-field-code columns (merged header cols)", 
   )
   out <- eri_ingest_cmr(tmp, sheet = "RB Treatment")
   expect_false(any(c("GroupHeader", "AnotherHeader") %in% names(out)))
-  expect_true(all(startsWith(setdiff(names(out), "excel_row"), "#")))
+  expect_true(all(startsWith(setdiff(names(out), c("excel_row", "sheet")), "#")))
 })
 
 test_that("eri_ingest_cmr aborts on a real-world duplicate field code in row 5", {

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -93,6 +93,12 @@ test_that("eri_ingest_cmr errors helpfully when the sheet is missing", {
                "Sheet .* not found")
 })
 
+test_that("eri_ingest_cmr errors helpfully (not R's raw 'subscript out of bounds') on an out-of-range sheet index", {
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  make_cmr_xlsx(tmp, sheet_name = "RB Treatment")
+  expect_error(eri_ingest_cmr(tmp, sheet = 5L), "out of range")
+})
+
 test_that("eri_ingest_cmr drops all-NA spacer rows", {
   tmp <- withr::local_tempfile(fileext = ".xlsx")
   make_cmr_xlsx(tmp,

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -508,6 +508,41 @@ test_that("uga_oncho schema flags a district not in the real allowed_values list
   expect_true(any(res$flags$column == "district"))
 })
 
+test_that("run_dq_checks resolves training_type from the sheet column eri_ingest_cmr() stamps", {
+  schema <- load_dq_schema("sdn", "rblf", "programmatic", "training", azcontainer = NULL)
+  df <- tibble::tibble(
+    sheet = "CDD Training", `#cddtrn_year` = "2026", `#cddtrn_adm2` = "Barbar",
+    `#cddtrn_tot` = "10"
+  )
+  res <- run_dq_checks(df, schema)
+  expect_equal(nrow(res$flags[res$flags$column == "training_type", ]), 0L)
+})
+
+test_that("run_dq_checks flags a training_type value not in the real sheet-name list", {
+  schema <- load_dq_schema("sdn", "rblf", "programmatic", "training", azcontainer = NULL)
+  df <- tibble::tibble(
+    sheet = "Not A Real Sheet", `#cddtrn_year` = "2026", `#cddtrn_adm2` = "Barbar",
+    `#cddtrn_tot` = "10"
+  )
+  res <- run_dq_checks(df, schema)
+  expect_true(any(res$flags$column == "training_type"))
+})
+
+test_that("every rblf_programmatic_training schema's training_type is required and lists its real sheet names", {
+  cases <- list(
+    list(country = "sdn", n = 6), list(country = "ssd", n = 6),
+    list(country = "uga", n = 8), list(country = "nga", n = 9),
+    list(country = "mad", n = 7), list(country = "tcd", n = 8),
+    list(country = "eth", n = 10)
+  )
+  for (cs in cases) {
+    schema <- load_dq_schema(cs$country, "rblf", "programmatic", "training", azcontainer = NULL)
+    expect_true(schema$columns$training_type$required, info = cs$country)
+    expect_true("sheet" %in% schema$columns$training_type$aliases, info = cs$country)
+    expect_equal(length(schema$columns$training_type$allowed_values), cs$n, info = cs$country)
+  }
+})
+
 test_that("eth_rblf_programmatic_training folds ToT Regional/Zonal into the shared training schema", {
   schema <- load_dq_schema("eth", "rblf", "programmatic", "training", azcontainer = NULL)
   # ToT-specific fields resolve

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -181,13 +181,18 @@ rb <- eri_ingest_cmr(report, sheet = "RB Treatment", country = "uga")
 #> ✔ CMR sheet "RB Treatment": 3 data rows, 6 field codes.
 
 rb
-#> # A tibble: 3 × 7
-#>   country `#rbtrt_year` `#rbtrt_month` `#rbtrt_adm1` `#rbtrt_adm2` `#rbtrt_target` `#rbtrt_treated`
-#>   <chr>   <chr>         <chr>          <chr>         <chr>         <chr>           <chr>
-#> 1 uga     2024          06             Central       Kampala       12000           11400
-#> 2 uga     2024          06             Western       Mbarara       8000            7600
-#> 3 uga     2024          06             Eastern       Soroti        6000            5800
+#> # A tibble: 3 × 9
+#>   country sheet        excel_row `#rbtrt_year` `#rbtrt_month` `#rbtrt_adm1` `#rbtrt_adm2` `#rbtrt_target` `#rbtrt_treated`
+#>   <chr>   <chr>            <int> <chr>         <chr>          <chr>         <chr>         <chr>           <chr>
+#> 1 uga     RB Treatment         6 2024          06             Central       Kampala       12000           11400
+#> 2 uga     RB Treatment         7 2024          06             Western       Mbarara       8000            7600
+#> 3 uga     RB Treatment         8 2024          06             Eastern       Soroti        6000            5800
 ```
+
+`sheet` (the real sheet name) and `excel_row` (each row's actual position in the workbook) are
+always there alongside `country` and the field-code columns -- `sheet` is what lets a schema
+covering several sheets routed to the same measure (e.g. the combined training schemas) tell
+which one a row came from.
 
 Each sheet is its own programme, parsed the same way:
 


### PR DESCRIPTION
## Summary
Brings `dev` (PR #313, already merged and reviewed there) onto `main` as a release cut per the project's dev->main convention.

- **#313** — `eri_ingest_cmr()` now stamps a `sheet` column (the real sheet name) onto every row; all 7 `{country}_rblf_programmatic_training.yaml` schemas alias it into a new required `training_type` column with `allowed_values` listing that country's real training sheet names. Closes the gap flagged in 0.9.40's review where rolling up `tot` across a combined training measure couldn't distinguish which training audience a row came from. See [ADR-0023](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0023-cmr-ingest-stamps-sheet-name.md).

**Migration note carried into this release:** real staged (not yet approved) `rblf/training` data for `ssd` (6 files) and `uga` (8 files) predates this change and will need `eri_split_cmr(..., supersede_staged = TRUE)` re-run against the source workbook to pick up the new `sheet`/`training_type` column.

PR #313 passed review-agent (two rounds) with no blockers. Version at 0.9.41 (DESCRIPTION/README already bumped on `dev`).

## Test plan
- [x] Full `testthat::test_dir()` clean on `dev` (only pre-existing CRAN/missing-package skips)
- [x] PR #313 individually reviewed twice, all findings addressed