### PR TITLE
fix(odk): .odk_creds aborts on unresolved auth instead of a bare 401

### DIFF
--- a/R/odk.R
+++ b/R/odk.R
@@ -5,13 +5,19 @@
 #' Resolve url/auth from an odk_connection or explicit args
 #' @keywords internal
 .odk_creds <- function(con, url, auth) {
-  if (!is.null(con)) {
+  creds <- if (!is.null(con)) {
     if (!inherits(con, "odk_connection"))
       cli::cli_abort("{.arg con} must be an {.cls odk_connection} object from {.fn init_odk_connection}.")
     list(url = con$url, auth = con$token)
   } else {
     list(url = url, auth = auth)
   }
+  if (is.null(creds$auth) || is.na(creds$auth) || !nzchar(creds$auth))
+    cli::cli_abort(c(
+      "No ODK credentials resolved -- refusing to call the server.",
+      "i" = "Pass {.arg con} from {.fn init_odk_connection}, or set the {.envvar ODK_URL}/{.envvar ODK_TOKEN} environment variables."
+    ))
+  creds
 }
 
 #' Check an httr response and return parsed content, or abort on HTTP error

--- a/tests/testthat/test-odk.R
+++ b/tests/testthat/test-odk.R
@@ -115,6 +115,21 @@ test_that(".odk_creds errors when con is not an odk_connection", {
   )
 })
 
+test_that(".odk_creds errors when resolved auth is empty", {
+  expect_error(
+    .odk_creds(NULL, "https://fallback.org/", ""),
+    "No ODK credentials resolved"
+  )
+})
+
+test_that(".odk_creds errors when con's token is empty", {
+  con <- structure(
+    list(url = "https://odk.example.org/", token = ""),
+    class = "odk_connection"
+  )
+  expect_error(.odk_creds(con, NULL, NULL), "No ODK credentials resolved")
+})
+
 #### Tests for empty-result guard ####
 
 test_that("list_odk_projects empty-result tibble has correct columns", {


### PR DESCRIPTION
## Summary
- A DA hit an opaque `HTTP 401` from `.odk_form_fields()` while running `eri_odk_upload()`. Root cause: she had a valid session from `init_odk_connection()`, but the upload call explicitly passed `con = NULL` plus `auth = Sys.getenv("ODK_TOKEN")` (a separate CI/automation-only credential she'd never set) -- silently discarding her real session and sending an empty `Authorization` header several calls before the failure surfaced.
- `.odk_creds()` now aborts immediately when the resolved `auth` is empty/NA, pointing at `init_odk_connection()`/`con` or the `ODK_URL`/`ODK_TOKEN` env vars, instead of letting a blank bearer token reach the network and come back as a generic 401.
- Every ODK entry point (`eri_odk_upload`, `eri_odk_sync`, `list_odk_projects`, `download_odk_form`, `eri_odk_bulk_users`, `eri_survey_status`, etc.) routes through this one helper, so the fix is general.

## Notes
- Landing on `dev` only -- no version bump / NEWS entry yet, per Nishant's call to let this accrue rather than cut a release now.
- Closes #318.

## Test plan
- [x] `devtools::test(filter = "odk")` -- 160 pass, 0 fail (1 pre-existing skip needing live creds), added 2 new cases covering empty-string auth via both the `url/auth` fallback path and an `odk_connection` with an empty token.