### PR TITLE
chore(release): cut 0.9.42 -- conditional DQ ranges (ETH target_pop, CDD/CS training) + ODK creds fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.41
+Version: 0.9.42
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,41 @@
+# erifunctions 0.9.42
+
+## Conditional DQ ranges keyed on another column's value (`range_overrides`)
+
+Fixes two Ethiopia DQ over-flagging issues Emalee reported while uploading the June 2026 CMR
+(202606), cc Hannah:
+
+- **RB/LF Treatment's `target_pop` no longer flags a legitimate 0.** Both schemas now capture
+  the real `#rbtrt_programstatus` / `#lftrt_programstatus` field as a new `program_status`
+  column, and `target_pop`'s range is conditioned on it: RB expects `[1, 1302823]` while
+  transmission is still active (`Transmission ongoing`, `Transmission suppressed`,
+  `Transmission suspected interrupted`, `PTS Failed`) and exactly `0` once it's
+  `Transmission interrupted`/`Transmission eliminated`; LF expects `[1, 500000]` before TAS
+  (`MDA Not Started`, `MDA Started`, `Passed EMS`) and `0` once `Passed TAS1`/`TAS2`/`TAS3`.
+  (LF keeps its existing, data-grounded 500000 ceiling rather than the 1302823 in Emalee's
+  email, which real LF data doesn't support -- see the schema comment.) Both keep their
+  pre-existing bound as a fallback `range` for any row where `program_status` is missing or
+  unrecognized, so that case still gets today's coverage rather than going unchecked.
+- **CDD/CS Training's `goal`/`tot` caps widened to `[0, 10000]`**, up from `[0, 5000]` /
+  `[0, 1000]` -- real 202606 CDD training reached a goal of 8902 and a total of 7360, both
+  already past the old caps. The other 8 training types sharing `eth_rblf_programmatic_training.yaml`
+  (HW, Lab, MMDP, Field Ento, Hope Group, ToT) keep their original, tighter caps -- real values
+  for those stay under ~200, so a blanket widen would have meaningfully loosened DQ protection
+  for them.
+
+Both are built on the same new schema mechanism: `range_overrides`, an ordered list of
+`{when: {column, op, value}, range: [lo, hi]}` blocks on any numeric column. The first override
+whose condition is confirmed true claims a row's range; rows no override claims fall back to
+the column's base `range` (if any), else go unchecked -- never flagged on an unconfirmed guess.
+This generalizes the existing `range_when` gate (which only turns a single range on/off) to
+cases where *which* range applies varies by category, and adds `op: in`/`not_in` (list
+membership) alongside the existing `<=`/`>=`/`==`/`<`/`>`/`!=`. A `when` block missing `value`
+now warns and disables cleanly (falls back to the base range / ignores the gate), rather than
+silently leaving the row completely unchecked -- caught in review before this shipped.
+
+- Tracked as issue [#320](https://github.com/thecartercenter/erifunctions/issues/320), feedback
+  tickets #9/#10.
+
 # erifunctions 0.9.41
 
 ## Add a training_type discriminator to every combined training schema

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # erifunctions 0.9.42
 
+## `.odk_creds()` aborts on unresolved auth instead of a bare 401
+
+A DA hit an opaque `HTTP 401` from `.odk_form_fields()` while running `eri_odk_upload()`. Root
+cause: she had a valid session from `init_odk_connection()`, but the upload call explicitly
+passed `con = NULL` plus `auth = Sys.getenv("ODK_TOKEN")` (a separate CI/automation-only
+credential she'd never set) -- silently discarding her real session and sending an empty
+`Authorization` header several calls before the failure surfaced.
+
+`.odk_creds()` now aborts immediately when the resolved `auth` is empty/NA, pointing at
+`init_odk_connection()`/`con` or the `ODK_URL`/`ODK_TOKEN` env vars, instead of letting a blank
+bearer token reach the network and come back as a generic 401. Every ODK entry point
+(`eri_odk_upload`, `eri_odk_sync`, `list_odk_projects`, `download_odk_form`,
+`eri_odk_bulk_users`, `eri_survey_status`, etc.) routes through this one helper, so the fix is
+general. Closes [#318](https://github.com/thecartercenter/erifunctions/issues/318).
+
 ## Conditional DQ ranges keyed on another column's value (`range_overrides`)
 
 Fixes two Ethiopia DQ over-flagging issues Emalee reported while uploading the June 2026 CMR

--- a/R/dq.R
+++ b/R/dq.R
@@ -194,17 +194,118 @@
   state
 }
 
+.ERI_DQ_RANGE_OPS <- c("<=", ">=", "==", "<", ">", "!=", "in", "not_in")
+
+# Evaluate a `{column, op, value}` condition against `data`, row-wise. Returns
+# a logical vector (TRUE only where the condition is confirmed true) the same
+# length as `nrow(data)`, or NULL if the condition itself is malformed --
+# an unrecognized `op`, or a missing `value` (the caller decides the fallback;
+# range_when and range_overrides fall back differently). A missing `value` is
+# checked here, centrally, rather than by each caller: left unchecked, e.g.
+# `cond_vals == NULL` returns `logical(0)`, and the NA-masking line below
+# silently *extends* it with NA instead of producing an all-FALSE vector --
+# that NA then poisons every downstream accumulator (`matched`, `in_scope`),
+# disabling the range check entirely with no warning ever firing. A gate
+# column absent from this sheet, or NA on a given row, means the condition
+# can't be confirmed, so those rows read FALSE rather than TRUE -- never
+# flagged on a guess.
+.dq_eval_condition <- function(data, when, col_label, field_label) {
+  op         <- when$op %||% "=="
+  valid_ops  <- .ERI_DQ_RANGE_OPS
+  if (!op %in% valid_ops || is.null(when$value)) {
+    # A schema author's typo here must not silently narrow (or widen) what
+    # gets flagged -- warn loudly; the caller falls back to the safer
+    # direction for its own construct rather than guessing here.
+    reason <- if (!op %in% valid_ops) {
+      cli::format_inline("an unrecognized op {.val {op}}")
+    } else {
+      "no `value`"
+    }
+    cli::cli_warn(c(
+      "Column {.val {col_label}}'s {.field {field_label}} has {reason}.",
+      "i" = "Valid ops: {.val {valid_ops}}."
+    ))
+    return(NULL)
+  }
+  cond_vals <- if (when$column %in% names(data)) data[[when$column]] else NA
+  cond_ok <- switch(op,
+    "<="     = cond_vals <= when$value,
+    ">="     = cond_vals >= when$value,
+    "=="     = cond_vals == when$value,
+    "<"      = cond_vals <  when$value,
+    ">"      = cond_vals >  when$value,
+    "!="     = cond_vals != when$value,
+    "in"     = cond_vals %in% when$value,
+    "not_in" = !(cond_vals %in% when$value)
+  )
+  cond_ok[is.na(cond_vals)] <- FALSE
+  cond_ok
+}
+
 .dq_check_ranges <- function(state, schema) {
   data        <- state$data
   cols_schema <- schema$columns %||% list()
 
   for (col in names(cols_schema)) {
     if (!col %in% names(data)) next
-    range_def <- cols_schema[[col]]$range
-    if (is.null(range_def) || length(range_def) != 2) next
+    col_def   <- cols_schema[[col]]
+    # Exact matching (not `$`/default `[[`) matters here: a column with
+    # `range_overrides` but no `range` would otherwise have `range` PARTIAL-
+    # MATCH onto `range_overrides` (both start with "range"), silently
+    # treating the overrides list as the base range.
+    range_def <- col_def[["range", exact = TRUE]]
+    if (!is.null(range_def) && length(range_def) != 2) range_def <- NULL
+    overrides <- col_def[["range_overrides", exact = TRUE]]
 
-    vals     <- data[[col]]
-    in_scope <- !is.na(vals)
+    vals   <- data[[col]]
+    not_na <- !is.na(vals)
+
+    # `range_overrides`: which range applies depends on another column's
+    # value (e.g. ETH target_pop's floor of 1 only holds while program_status
+    # says transmission is still active; CDD/CS training's higher goal/tot
+    # ceiling only holds for those two training_types, not the other 8 that
+    # share this schema). Each override is tried in order; the first whose
+    # `when` condition is confirmed true claims the row. Rows no override
+    # claims fall back to the column's base `range` (if any); with neither a
+    # matching override nor a base range, they go unchecked.
+    if (!is.null(overrides)) {
+      matched <- rep(FALSE, length(vals))
+      for (ov in overrides) {
+        when     <- ov$when
+        ov_range <- ov$range
+        if (is.null(when) || is.null(when$column) || is.null(ov_range) || length(ov_range) != 2) {
+          cli::cli_warn("Column {.val {col}} has a malformed {.field range_overrides} entry -- skipping it.")
+          next
+        }
+        cond_ok <- .dq_eval_condition(data, when, col, "range_overrides")
+        if (is.null(cond_ok)) next
+        scope   <- not_na & !matched & cond_ok
+        matched <- matched | scope
+        out_of_range <- which(scope & (vals < ov_range[1] | vals > ov_range[2]))
+        if (length(out_of_range) > 0) {
+          state <- .dq_log_flag(
+            state, rows = out_of_range, column = col,
+            value = as.character(vals[out_of_range]),
+            issue = glue::glue("Value outside expected range [{ov_range[1]}, {ov_range[2]}]")
+          )
+        }
+      }
+      if (!is.null(range_def)) {
+        scope <- not_na & !matched
+        out_of_range <- which(scope & (vals < range_def[1] | vals > range_def[2]))
+        if (length(out_of_range) > 0) {
+          state <- .dq_log_flag(
+            state, rows = out_of_range, column = col,
+            value = as.character(vals[out_of_range]),
+            issue = glue::glue("Value outside expected range [{range_def[1]}, {range_def[2]}]")
+          )
+        }
+      }
+      next
+    }
+
+    if (is.null(range_def)) next
+    in_scope <- not_na
 
     # Optional gate: only apply this range floor/ceiling to rows where another
     # column satisfies a condition (e.g. UGA target_pop's floor of 1 should
@@ -212,29 +313,14 @@
     # untargeted round legitimately reports 0). A gate column absent from this
     # sheet, or NA on a given row, means the condition can't be confirmed, so
     # those rows are treated as out of scope rather than flagged.
-    when <- cols_schema[[col]]$range_when
+    when <- col_def[["range_when", exact = TRUE]]
     if (!is.null(when) && !is.null(when$column)) {
-      op <- when$op %||% "=="
-      if (!op %in% c("<=", ">=", "==", "<", ">", "!=")) {
-        # A schema author's typo here must not silently narrow (or widen) what
-        # gets flagged -- warn loudly and fall back to the unconditional range
-        # check (never fires -> could hide a real problem; ignoring the gate
-        # is the safer failure direction, and impossible to miss in the log).
-        cli::cli_warn(c(
-          "Column {.val {col}}'s {.field range_when} has an unrecognized op {.val {op}} -- ignoring the gate, checking the range unconditionally.",
-          "i" = "Valid ops: <=, >=, ==, <, >, !=."
-        ))
+      cond_ok <- .dq_eval_condition(data, when, col, "range_when")
+      if (is.null(cond_ok)) {
+        # Unrecognized op: ignoring the gate (check unconditionally) is the
+        # safer failure direction for a plain gate -- never firing could hide
+        # a real problem, and it's impossible to miss in the warning log.
       } else {
-        cond_vals <- if (when$column %in% names(data)) data[[when$column]] else NA
-        cond_ok <- switch(op,
-          "<=" = cond_vals <= when$value,
-          ">=" = cond_vals >= when$value,
-          "==" = cond_vals == when$value,
-          "<"  = cond_vals <  when$value,
-          ">"  = cond_vals >  when$value,
-          "!=" = cond_vals != when$value
-        )
-        cond_ok[is.na(cond_ok)] <- FALSE
         in_scope <- in_scope & cond_ok
       }
     }

--- a/R/odk.R
+++ b/R/odk.R
@@ -5,13 +5,19 @@
 #' Resolve url/auth from an odk_connection or explicit args
 #' @keywords internal
 .odk_creds <- function(con, url, auth) {
-  if (!is.null(con)) {
+  creds <- if (!is.null(con)) {
     if (!inherits(con, "odk_connection"))
       cli::cli_abort("{.arg con} must be an {.cls odk_connection} object from {.fn init_odk_connection}.")
     list(url = con$url, auth = con$token)
   } else {
     list(url = url, auth = auth)
   }
+  if (is.null(creds$auth) || is.na(creds$auth) || !nzchar(creds$auth))
+    cli::cli_abort(c(
+      "No ODK credentials resolved -- refusing to call the server.",
+      "i" = "Pass {.arg con} from {.fn init_odk_connection}, or set the {.envvar ODK_URL}/{.envvar ODK_TOKEN} environment variables."
+    ))
+  creds
 }
 
 #' Check an httr response and return parsed content, or abort on HTTP error

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.41 · **Status:** Active development
+**Version:** 0.9.42 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/inst/schemas/eth_lf_programmatic_treatment.yaml
+++ b/inst/schemas/eth_lf_programmatic_treatment.yaml
@@ -69,6 +69,19 @@ columns:
     type: character
     aliases:
       - '#lftrt_disease'
+  program_status:
+    required: false
+    type: character
+    aliases:
+      - program_status
+      - '#lftrt_programstatus'
+    allowed_values:
+      - MDA Not Started
+      - MDA Started
+      - Passed EMS
+      - Passed TAS1
+      - Passed TAS2
+      - Passed TAS3
   population:
     required: false
     type: numeric
@@ -93,7 +106,27 @@ columns:
       - target_population
       - eligible_pop
       - '#lftrt_trttarget'
+    # See eth_oncho_programmatic_treatment.yaml's target_pop for the same
+    # program_status-conditioned logic (reported by Emalee, 2026-07-29), and
+    # for why the base `range` below is kept as a fallback for an unrecognized
+    # program_status.
+    # NOTE: Emalee's email asked for [1, 1302823] here too (RB's bound), but
+    # real ETH 202606 LF target_pop tops out around 125k -- keeping this
+    # schema's existing, data-grounded 500000 ceiling (matches `population`'s
+    # own range) rather than carrying over what looks like a copy/paste from
+    # the RB section.
     range: [1, 500000]
+    range_overrides:
+      - when:
+          column: program_status
+          op: in
+          value: [MDA Not Started, MDA Started, Passed EMS]
+        range: [1, 500000]
+      - when:
+          column: program_status
+          op: in
+          value: [Passed TAS1, Passed TAS2, Passed TAS3]
+        range: [0, 0]
   village_target:
     required: false
     type: numeric

--- a/inst/schemas/eth_oncho_programmatic_treatment.yaml
+++ b/inst/schemas/eth_oncho_programmatic_treatment.yaml
@@ -92,6 +92,19 @@ columns:
     type: character
     aliases:
       - '#rbtrt_disease'
+  program_status:
+    required: false
+    type: character
+    aliases:
+      - program_status
+      - '#rbtrt_programstatus'
+    allowed_values:
+      - Transmission ongoing
+      - Transmission suppressed
+      - Transmission suspected interrupted
+      - PTS Failed
+      - Transmission interrupted
+      - Transmission eliminated
   population:
     required: false
     type: numeric
@@ -116,7 +129,27 @@ columns:
       - target_population
       - eligible_pop
       - '#rbtrt_trttarget'
+    # Whether a target_pop of 0 is a flag or expected depends on program_status:
+    # once transmission is interrupted/eliminated, a genuinely zero target is
+    # correct, not a data error (reported by Emalee, 2026-07-29, real ETH
+    # 202606 data -- e.g. "Transmission interrupted" rows with target_pop = 0).
+    # The base `range` below is the pre-existing bound, kept as a fallback for
+    # a program_status this schema can't recognize (missing/blank/unexpected
+    # value) -- so those rows still get today's coverage rather than going
+    # completely unchecked.
     range: [1, 1302823]
+    range_overrides:
+      - when:
+          column: program_status
+          op: in
+          value: [Transmission ongoing, Transmission suppressed,
+                  Transmission suspected interrupted, PTS Failed]
+        range: [1, 1302823]
+      - when:
+          column: program_status
+          op: in
+          value: [Transmission interrupted, Transmission eliminated]
+        range: [0, 0]
   village_target:
     required: false
     type: numeric

--- a/inst/schemas/eth_rblf_programmatic_training.yaml
+++ b/inst/schemas/eth_rblf_programmatic_training.yaml
@@ -131,6 +131,17 @@ columns:
     aliases: ["#cddtrn_goal", "#cstrn_goal", "#dmditrnsx_goal", "#dmditrnpt_goal",
       "#entotrn_goal", "#hgtrn_goal", "#hwtrn_goal", "#labtrn_goal", "#tot_reg_trn_goal",
       "#tot_zone_trn_goal"]
+    # CDD/CS goals run to the thousands (community-wide reach) where the other
+    # 8 training types stay under ~200 (specialist cohorts) -- real 202606 CDD
+    # goal reached 8902, which the flat 5000 cap flagged (reported by Emalee,
+    # 2026-07-29). Widen only for CDD/CS; the base 5000 cap still protects the
+    # other 8 types.
+    range_overrides:
+      - when:
+          column: training_type
+          op: in
+          value: ["CDD Training", "CS Training"]
+        range: [0, 10000]
     range: [0, 5000]
 
   male_trained:
@@ -155,6 +166,15 @@ columns:
     aliases: [Trained, "#cddtrn_tot", "#cstrn_tot", "#dmditrnsx_tot", "#dmditrnpt_tot",
       "#entotrn_tot", "#hgtrn_tot", "#hwtrn_tot", "#labtrn_tot", "#tot_reg_trn_tot_reg_",
       "#tot_zone_trn_tot_zone_"]
+    # Same CDD/CS-only widening as `goal` above -- real 202606 CDD tot reached
+    # 7360 against the flat 1000 cap (reported by Emalee, 2026-07-29). The
+    # other 8 types stay well under 200, so their base 1000 cap is unchanged.
+    range_overrides:
+      - when:
+          column: training_type
+          op: in
+          value: ["CDD Training", "CS Training"]
+        range: [0, 10000]
     range: [0, 1000]
 
   achieved_pct:

--- a/tests/testthat/test-dq.R
+++ b/tests/testthat/test-dq.R
@@ -499,6 +499,130 @@ test_that("range_when warns and falls back to an unconditional range check on an
   expect_equal(nrow(res$flags[res$flags$column == "target_pop", ]), 1L)
 })
 
+test_that("range_when accepts a `not_in` op, and an NA gate value doesn't match it", {
+  schema <- list(columns = list(
+    target_pop = list(type = "numeric", range = list(1, 100),
+                      range_when = list(column = "status", op = "not_in",
+                                        value = list("interrupted", "eliminated")))
+  ))
+  df <- tibble::tibble(target_pop = c(0, 0, 0),
+                       status     = c("ongoing", "interrupted", NA_character_))
+  res <- run_dq_checks(df, schema)
+  # row 1: status not in the excluded set -> gate true -> flagged.
+  # row 2: status IS in the excluded set -> gate false -> not flagged.
+  # row 3: status missing -> can't confirm -> not flagged (not_in's inverted-NA
+  # trap: `!(NA %in% x)` would otherwise read TRUE, wrongly matching the gate).
+  expect_equal(res$flags$row[res$flags$column == "target_pop"], 1L)
+})
+
+test_that("range_when/range_overrides warn and disable (not silently no-op) on a condition missing `value`", {
+  schema_gate <- list(columns = list(
+    target_pop = list(type = "numeric", range = list(1, 100),
+                      range_when = list(column = "status", op = "=="))
+  ))
+  df <- tibble::tibble(target_pop = 0, status = "ongoing")
+  expect_warning(res <- run_dq_checks(df, schema_gate), "no `value`")
+  # gate ignored (no `value` to compare against) -- range checked unconditionally
+  expect_equal(nrow(res$flags[res$flags$column == "target_pop", ]), 1L)
+
+  schema_override <- list(columns = list(
+    tot = list(type = "numeric", range = list(0, 1000),
+              range_overrides = list(
+                list(when = list(column = "training_type", op = "=="), range = list(0, 10000))
+              ))
+  ))
+  df2 <- tibble::tibble(tot = 5000, training_type = "CDD Training")
+  expect_warning(res2 <- run_dq_checks(df2, schema_override), "no `value`")
+  # override skipped (no `value` to compare against) -- falls back to the base [0,1000] range,
+  # NOT silently unchecked (the bug this test guards against: a missing `value` used to
+  # produce an NA that poisoned `matched`, leaving the row completely unvalidated).
+  expect_equal(nrow(res2$flags[res2$flags$column == "tot", ]), 1L)
+})
+
+test_that("range_when accepts an `in` op for list-membership gates", {
+  schema <- list(columns = list(
+    target_pop = list(type = "numeric", range = list(1, 100),
+                      range_when = list(column = "status", op = "in",
+                                        value = list("ongoing", "suppressed")))
+  ))
+  df <- tibble::tibble(target_pop = c(0, 0, 0),
+                       status     = c("ongoing", "suppressed", "interrupted"))
+  res <- run_dq_checks(df, schema)
+  expect_equal(sort(res$flags$row[res$flags$column == "target_pop"]), c(1L, 2L))
+})
+
+test_that("range_overrides applies a different range per training_type, first match wins", {
+  schema <- list(columns = list(
+    tot = list(type = "numeric", range = list(0, 1000),
+              range_overrides = list(
+                list(when = list(column = "training_type", op = "in",
+                                 value = list("CDD Training", "CS Training")),
+                    range = list(0, 10000))
+              ))
+  ))
+  df <- tibble::tibble(
+    tot           = c(7360, 1780, 1780),
+    training_type = c("CDD Training", "CS Training", "HW Training")
+  )
+  res <- run_dq_checks(df, schema)
+  # CDD (7360) and CS (1780) fall under the widened [0,10000] override -- not flagged.
+  # HW (1780) has no matching override, falls back to the base [0,1000] -- flagged.
+  expect_equal(res$flags$row[res$flags$column == "tot"], 3L)
+})
+
+test_that("range_overrides with no matching override and no base range leaves the row unchecked", {
+  schema <- list(columns = list(
+    tot = list(type = "numeric",
+              range_overrides = list(
+                list(when = list(column = "training_type", op = "in", value = list("CDD Training")),
+                    range = list(0, 10000))
+              ))
+  ))
+  df <- tibble::tibble(tot = 999999, training_type = "Lab Training")
+  res <- run_dq_checks(df, schema)
+  expect_equal(nrow(res$flags[res$flags$column == "tot", ]), 0L)
+})
+
+test_that("range_overrides supports two-sided conditional bounds (e.g. target_pop by program_status)", {
+  schema <- list(columns = list(
+    target_pop = list(type = "numeric",
+      range_overrides = list(
+        list(when = list(column = "program_status", op = "in",
+                         value = list("Transmission ongoing", "PTS Failed")),
+            range = list(1, 1302823)),
+        list(when = list(column = "program_status", op = "in",
+                         value = list("Transmission interrupted", "Transmission eliminated")),
+            range = list(0, 0))
+      ))
+  ))
+  df <- tibble::tibble(
+    target_pop     = c(0, 5000, 0, 10),
+    program_status = c("Transmission ongoing", "Transmission ongoing",
+                       "Transmission interrupted", "Transmission interrupted")
+  )
+  res <- run_dq_checks(df, schema)
+  # row 1: ongoing but 0 -> flagged. row 2: ongoing, nonzero -> fine.
+  # row 3: interrupted, legitimately 0 -> fine (this is the false positive being fixed).
+  # row 4: interrupted but nonzero -> flagged.
+  expect_equal(sort(res$flags$row[res$flags$column == "target_pop"]), c(1L, 4L))
+})
+
+test_that("range_overrides warns and skips a malformed override entry", {
+  schema <- list(columns = list(
+    tot = list(type = "numeric", range = list(0, 1000),
+              range_overrides = list(
+                list(when = list(op = "in", value = list("CDD Training")), range = list(0, 10000))
+              ))
+  ))
+  df <- tibble::tibble(tot = 5000, training_type = "CDD Training")
+  expect_warning(
+    res <- run_dq_checks(df, schema),
+    "malformed"
+  )
+  # override skipped (missing `when$column`) -- falls back to the base [0,1000] range
+  expect_equal(nrow(res$flags[res$flags$column == "tot", ]), 1L)
+})
+
 test_that("uga_oncho schema flags a district not in the real allowed_values list", {
   schema <- load_dq_schema("uga", "oncho", "programmatic", "treatment", azcontainer = NULL)
   df <- tibble::tibble(

--- a/tests/testthat/test-odk.R
+++ b/tests/testthat/test-odk.R
@@ -115,6 +115,21 @@ test_that(".odk_creds errors when con is not an odk_connection", {
   )
 })
 
+test_that(".odk_creds errors when resolved auth is empty", {
+  expect_error(
+    .odk_creds(NULL, "https://fallback.org/", ""),
+    "No ODK credentials resolved"
+  )
+})
+
+test_that(".odk_creds errors when con's token is empty", {
+  con <- structure(
+    list(url = "https://odk.example.org/", token = ""),
+    class = "odk_connection"
+  )
+  expect_error(.odk_creds(con, NULL, NULL), "No ODK credentials resolved")
+})
+
 #### Tests for empty-result guard ####
 
 test_that("list_odk_projects empty-result tibble has correct columns", {


### PR DESCRIPTION
## Summary

Brings `dev` (PRs #319, #321 — both already merged and reviewed there) onto `main` as a release cut per the project's dev->main convention.

- **#321** — new `range_overrides` DQ schema mechanism (conditional ranges keyed on another column's value, with `op: in`/`not_in`). Fixes two Ethiopia CMR DQ over-flagging issues Emalee reported (RB/LF `target_pop` flagged when legitimately 0; CDD/CS Training `goal`/`tot` caps too tight for their real scale). Closes #320.
- **#319** — `.odk_creds()` now aborts on unresolved/empty auth instead of letting a blank bearer token reach the network and come back as an opaque 401. Closes #318. (Landed on `dev` without a release at the time; backfilled its NEWS entry directly on `dev` just now so it isn't shipped silently.)

Version at 0.9.42 (DESCRIPTION/README already bumped on `dev`). See NEWS.md for full details.

## Test plan
- [x] Full `devtools::test()` clean on the #321 branch (only pre-existing smoke/live-dependency skips)
- [x] PR #321 passed `review-agent`; one real finding (a `range_overrides`/`range_when` condition missing `value` could silently disable a check) fixed before merge, plus regression tests added
- [x] CI (R-CMD-check, windows-latest + ubuntu-latest) green on PR #321