### PR TITLE
feat(dq): cross-sheet DQ checks via cross_consistency (ADR-0024)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: erifunctions
 Title: ERI team functions
-Version: 0.9.42
+Version: 0.9.43
 Authors@R:
     person("Nishant", "Kishore", , "ynm2@cdc.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0408-2747"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,31 @@
-# erifunctions 0.9.42
+# erifunctions 0.9.43
+
+## Cross-sheet DQ checks (`cross_consistency:`)
+
+Emalee reported (email, cc Hannah, no rush) three DQ checks needed while reviewing Ethiopia's most
+recent CMR, none of which the DQ engine could express until now -- each needs to compare data
+*across* sheets, not just within one:
+
+- Population reported for a district (IU) on the RB Treatment tab must equal population reported
+  for that same district on the LF Treatment tab.
+- For a country with CDD/CS/HW training tabs: if RB+LF treated for a district is > 0, CDD+CS+HW
+  training for that district must also be > 0 (and conversely, both must be 0 together).
+
+New declarative `cross_consistency:` block on the CMR routing schema
+(`inst/schemas/cmr/{country}.yaml`), evaluated by `eri_cmr_dq_report()` (new `cross = TRUE` arg) --
+see [ADR-0024](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0024-cross-sheet-dq-at-staged-layer.md)
+for the full design. Findings are workbook-level (not attributable to one measure), logged to
+`{country}/rblf/programmatic/consistency/logs/`, and surface through the same
+`eri_dq_review()`/`eri_dq_export()`/`eri_approve_cmr()` chain as any other DQ flag, with a new
+`cross` logical column marking them (`sheet = "(cross-sheet)"`, `excel_row`/`row` blank).
+`eri_approve_cmr()` now also blocks on an unresolved cross-consistency finding -- but only when one
+was actually logged, so a period from before this shipped, or a country with no `cross_consistency:`
+rules declared, is never retroactively blocked.
+
+Rules shipped for `eth` only; every other RBLF country's routing schema can opt in later by adding
+its own rules, since the sheet names and district-roster overlaps between diseases differ per
+country. New `R/dq_cross.R` (the engine), new registered `data_type: consistency` in
+`inst/registry/data_model.yaml`.
 
 ## `.odk_creds()` aborts on unresolved auth instead of a bare 401
 

--- a/R/cmr.R
+++ b/R/cmr.R
@@ -798,6 +798,12 @@ eri_cmr_last_plan <- function(country, period, data_con = NULL) {
 #' its `note` argument), and re-run this function -- it re-checks from
 #' scratch each time.
 #'
+#' Also blocks on an **unresolved** cross-consistency finding (ADR-0024) if
+#' [eri_cmr_dq_report()] logged one for this period -- unlike the per-measure
+#' checks, this does NOT require a cross-check to have run at all, since most
+#' countries have no `cross_consistency:` rules declared yet: a period with no
+#' cross-check log entry is never treated as outstanding on that basis alone.
+#'
 #' **A stale flag keeps blocking until it's explicitly resolved.** This checks
 #' every `dq_flags` log entry for the period, not just the most recent one: if
 #' an earlier [eri_dq_log()] run had unresolved flags and a later rerun for the
@@ -892,6 +898,41 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
       dq_reviewed <- c(dq_reviewed, dq_logs$log_path)
     }
   }
+
+  # Cross-consistency (ADR-0024) is a workbook-level check, not a measure --
+  # it blocks on an OPEN finding only, unlike the per-measure loop above,
+  # which also blocks on "never DQ-checked at all". Most countries have no
+  # cross_consistency: rules yet, so no entry ever gets logged for them; that
+  # must never be treated as outstanding, or every period approved before
+  # this feature shipped would retroactively become unapprovable. Skip the
+  # query entirely when the country declares no rules at all -- not just an
+  # optimization: it's what keeps this a true no-op for the 6 of 7 RBLF
+  # countries (and every non-CMR/non-oncho-LF country) that don't have any.
+  cmr_schema <- tryCatch(load_cmr_schema(country), error = function(e) NULL)
+  has_cross_rules <- !is.null(cmr_schema$cross_consistency) && length(cmr_schema$cross_consistency) > 0L
+
+  cross_logs <- if (has_cross_rules) {
+    tryCatch(
+      eri_logs(country, "rblf", "programmatic", "consistency",
+              operation = "dq_flags", include_handled = TRUE, data_con = data_con),
+      error = function(e) NULL
+    )
+  } else NULL
+
+  if (!is.null(cross_logs) && nrow(cross_logs) > 0L) {
+    cross_logs <- cross_logs[!is.na(cross_logs$period) & cross_logs$period == period, ]
+    open_cross <- cross_logs[cross_logs$status == "needs_review" & !cross_logs$handled, ]
+    if (nrow(open_cross) > 0L) {
+      outstanding[[length(outstanding) + 1L]] <- tibble::tibble(
+        disease = "rblf", data_type = "consistency",
+        log_path = open_cross$log_path[[1]],
+        issue = paste0(open_cross$n_issues[[1]], " unresolved cross-sheet DQ flag(s)")
+      )
+    } else {
+      dq_reviewed <- c(dq_reviewed, cross_logs$log_path)
+    }
+  }
+
   outstanding_tbl <- if (length(outstanding) > 0L) dplyr::bind_rows(outstanding) else NULL
 
   if (!is.null(outstanding_tbl) && !isTRUE(force)) {
@@ -1010,6 +1051,17 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
 #' that specific issue (`"not_important"`, `"fixed"`, or `"noted"`) before
 #' closing out the whole measure with [eri_logs_resolve()].
 #'
+#' If the country's CMR routing schema (`inst/schemas/cmr/{country}.yaml`)
+#' declares a `cross_consistency:` block, this also evaluates those rules --
+#' declarative checks that span more than one sheet (e.g. "population on the
+#' RB Treatment tab must match population on the LF Treatment tab for the
+#' same district"), which no single-sheet DQ schema can express (see
+#' ADR-0024). Findings are logged as one workbook-level `dq_flags` entry
+#' (`{country}/rblf/programmatic/consistency/logs/`, not attributable to any
+#' one measure) and returned as rows with `sheet = "(cross-sheet)"` and
+#' `cross = TRUE`. Most countries have no `cross_consistency:` block yet, in
+#' which case this step is a silent no-op.
+#'
 #' @param country `str` Country code (e.g. `"sdn"`).
 #' @param period `str` Reporting period (e.g. `"202605"`).
 #' @param plan `tibble` or `NULL` The plan from [eri_split_cmr()] /
@@ -1021,15 +1073,23 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
 #'   a "superseded by a newer run" note when this run logs a new one, so
 #'   re-running doesn't pile up entries you have to close by hand. Set `FALSE`
 #'   to keep every run's entry open until you resolve it yourself.
+#' @param cross `logical` Also evaluate the country's `cross_consistency:`
+#'   rules, if any. Default `TRUE`. Set `FALSE` to skip cross-sheet checks
+#'   entirely (e.g. when re-checking one measure in isolation and cross-sheet
+#'   context isn't needed).
 #' @param data_con Azure container for the `data/` blob. If `NULL`, connects automatically.
-#' @returns A tibble with one row per flag across every measure: `sheet`,
-#'   `disease`, `data_type`, `log_path`, `flag_id`, `row` (the flag's index
-#'   into the checked data, not the workbook), `excel_row` (the real row in
+#' @returns A tibble with one row per flag across every measure: `sheet`
+#'   (`"(cross-sheet)"` for a cross-consistency flag), `disease`, `data_type`,
+#'   `log_path`, `flag_id`, `row` (the flag's index into the checked data, not
+#'   the workbook; `NA` for a cross-sheet flag), `excel_row` (the real row in
 #'   the original Excel sheet -- use this one when telling a DA what to go
-#'   fix), `column`, `value`, `issue`, `status` (all `"open"` on a fresh run),
-#'   `note` (`NA` on a fresh run -- only set once a flag has been triaged via
-#'   [eri_dq_flag_resolve()] and this function is re-run). Zero rows if every
-#'   measure is clean.
+#'   fix; `NA` for a cross-sheet flag, which has no single row), `column`,
+#'   `value`, `issue`, `status` (all `"open"` on a fresh run), `note` (`NA` on
+#'   a fresh run -- only set once a flag has been triaged via
+#'   [eri_dq_flag_resolve()] and this function is re-run), `cross` (`TRUE`
+#'   for a cross-consistency flag, `FALSE` for an ordinary single-measure
+#'   flag). Zero rows if every measure (and any cross-consistency rules) is
+#'   clean.
 #' @examples
 #' \dontrun{
 #' flags <- eri_cmr_dq_report("sdn", "202605")
@@ -1038,12 +1098,13 @@ eri_approve_cmr <- function(country, period, plan = NULL, data_con = NULL,
 #' }
 #' @family CMR pipeline functions
 #' @export
-eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, data_con = NULL) {
+eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, cross = TRUE, data_con = NULL) {
   data_con <- .eri_logs_con(data_con)
 
   if (is.null(plan)) plan <- eri_cmr_last_plan(country, period, data_con = data_con)
 
-  rows <- list()
+  rows   <- list()
+  tables <- list()
   for (i in seq_len(nrow(plan))) {
     p <- plan[i, ]
     staged <- tryCatch(
@@ -1065,6 +1126,8 @@ eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, da
     if (is.null(schema)) next
 
     result       <- run_dq_checks(staged, schema)
+    tables[[length(tables) + 1L]] <- list(sheet = p$sheet, disease = p$disease,
+                                          data_type = p$data_type, data = result$data)
     p_source_hash <- if ("source_hash" %in% names(plan)) p$source_hash else NULL
     written <- .eri_dq_log_write(result, country, p$disease, "programmatic", p$data_type, period, data_con,
                                  source_hash = p_source_hash)
@@ -1102,8 +1165,50 @@ eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, da
         sheet = p$sheet, disease = p$disease, data_type = p$data_type,
         log_path = written$log_path, flag_id = paste0(written$log_path, "::", f$index),
         row = f$row, excel_row = excel_row_val, column = f$column, value = f$value,
-        issue = f$issue, status = f$status, note = .eri_na_chr(f$note)
+        issue = f$issue, status = f$status, note = .eri_na_chr(f$note), cross = FALSE
       )
+    }
+  }
+
+  if (isTRUE(cross)) {
+    cross_flags <- .eri_cmr_cross_flags(country, period, tables, data_con)
+    if (!is.null(cross_flags)) {
+      cross_result <- structure(
+        list(data = tibble::tibble(), log = tibble::tibble(), flags = cross_flags,
+            schema_source = NA_character_, schema_hash = NA_character_),
+        class = "dq_result"
+      )
+      p_source_hash <- if ("source_hash" %in% names(plan) && nrow(plan) > 0L) plan$source_hash[[1]] else NULL
+      written <- .eri_dq_log_write(cross_result, country, "rblf", "programmatic", "consistency", period,
+                                   data_con, source_hash = p_source_hash)
+
+      if (isTRUE(supersede)) {
+        prior <- tryCatch(
+          eri_logs(country, "rblf", "programmatic", "consistency",
+                  operation = "dq_flags", status = "needs_review",
+                  include_handled = FALSE, data_con = data_con),
+          error = function(e) NULL
+        )
+        if (!is.null(prior) && nrow(prior) > 0L) {
+          prior <- prior[!is.na(prior$period) & prior$period == period &
+                         prior$log_path != written$log_path, , drop = FALSE]
+          for (lp in prior$log_path) {
+            eri_logs_resolve(
+              lp, note = paste0("Superseded by a newer eri_cmr_dq_report() run (", written$log_path, ")."),
+              data_con = data_con
+            )
+          }
+        }
+      }
+
+      for (f in written$flags) {
+        rows[[length(rows) + 1L]] <- tibble::tibble(
+          sheet = "(cross-sheet)", disease = "rblf", data_type = "consistency",
+          log_path = written$log_path, flag_id = paste0(written$log_path, "::", f$index),
+          row = NA_integer_, excel_row = NA_integer_, column = f$column, value = f$value,
+          issue = f$issue, status = f$status, note = .eri_na_chr(f$note), cross = TRUE
+        )
+      }
     }
   }
 
@@ -1113,7 +1218,7 @@ eri_cmr_dq_report <- function(country, period, plan = NULL, supersede = TRUE, da
       sheet = character(0), disease = character(0), data_type = character(0),
       log_path = character(0), flag_id = character(0), row = integer(0),
       excel_row = integer(0), column = character(0), value = character(0),
-      issue = character(0), status = character(0), note = character(0)
+      issue = character(0), status = character(0), note = character(0), cross = logical(0)
     ))
   }
 

--- a/R/dq_cross.R
+++ b/R/dq_cross.R
@@ -1,0 +1,363 @@
+# Cross-sheet DQ consistency checks (ADR-0024)
+#
+# `consistency:` rules in a DQ schema (R/dq.R's add_anomaly_consistency())
+# compare two columns of the SAME row of ONE already-loaded sheet -- they
+# cannot express "population on the RB Treatment sheet must match population
+# on the LF Treatment sheet", because those are two different staged
+# datasets. `cross_consistency:` fills that gap: a declarative block on the
+# CMR ROUTING schema (inst/schemas/cmr/{country}.yaml, not a per-measure DQ
+# schema -- only the routing schema knows a whole workbook's sheet-to-measure
+# map), evaluated by eri_cmr_dq_report() against the already-canonicalized
+# per-sheet DQ output (post alias-resolution/type-coercion), never raw staged
+# parquet (which still carries unresolved `#field-code` columns).
+#
+# Schema format:
+#
+# cross_consistency:
+#   <rule_name>:
+#     description: <chr>              # optional, human-readable
+#     join_key: <chr>                 # canonical column, e.g. "district"
+#     lhs:
+#       agg: sum | unique | max | min | mean | n
+#       missing_as: <num>             # optional; see below
+#       sources:
+#         - disease:   <chr>
+#           data_type: <chr>
+#           column:    <chr>
+#           sheets:    [<chr>, ...]   # optional; restrict to these real CMR
+#                                     # sheet names (e.g. training_type values)
+#     rhs: { <same shape as lhs> }
+#     op: "==" | "!=" | "<" | "<=" | ">" | ">=" | same_sign
+#     tolerance: 0                    # optional, numeric; only used by ==/!=
+#     message: <chr>                  # flag text
+#
+# Aggregation, per side, per join_key value:
+#   sum/max/min/mean use na.rm = TRUE, but return NA (not 0) when EVERY value
+#   for that key is NA -- "no data" is not the same as "zero".
+#   `unique` asserts exactly one distinct non-NA value; more than one is
+#   itself flagged (a within-sheet inconsistency, e.g. population varying
+#   across treatment_round rows for the same district) and that key is
+#   excluded from the cross-sheet comparison, not silently collapsed.
+#
+# A join_key value present on only one side is DROPPED from comparison
+# (never flagged) unless that side declares `missing_as:`, in which case its
+# value for that key is treated as `missing_as` -- this is what lets
+# "district has treatment but zero training rows at all" correctly read as
+# training = 0 and flag, while "LF only covers a subset of oncho's
+# districts" (no missing_as on either side of that rule) never flags a
+# coverage difference as a population mismatch.
+#
+# A rule (or a side's `sources`) that can't be resolved at all -- an
+# unrecognized op/agg, a missing required field, or every source's
+# (disease, data_type[, sheets]) matching zero available tables (e.g. a
+# country with no CDD/CS/HW training tabs) -- is skipped, not an error: a
+# `cli_warn` for a schema-authoring mistake (impossible to miss in the log,
+# same posture as R/dq.R's range_when/range_overrides), a `cli_alert_info`
+# for "legitimately not applicable this run".
+
+# `%||%` is defined once in R/dq.R and shared package-wide.
+
+.ERI_CROSS_OPS  <- c("<=", ">=", "==", "<", ">", "!=", "same_sign")
+.ERI_CROSS_AGGS <- c("sum", "unique", "max", "min", "mean", "n")
+
+#' @keywords internal
+.eri_cross_empty_flags <- function() {
+  tibble::tibble(row = integer(0), column = character(0),
+                 value = character(0), issue = character(0))
+}
+
+#' @keywords internal
+.eri_cross_reduce <- function(vals, agg) {
+  switch(agg,
+    sum  = if (all(is.na(vals))) NA_real_ else sum(vals, na.rm = TRUE),
+    max  = if (all(is.na(vals))) NA_real_ else max(vals, na.rm = TRUE),
+    min  = if (all(is.na(vals))) NA_real_ else min(vals, na.rm = TRUE),
+    mean = if (all(is.na(vals))) NA_real_ else mean(vals, na.rm = TRUE),
+    n    = sum(!is.na(vals))
+  )
+}
+
+# Validate a rule's shape before attempting to run it. Warns (once, with every
+# problem found) and returns FALSE on anything malformed, so a schema
+# author's typo skips that ONE rule rather than either silently misbehaving
+# or aborting the whole cross-check pass.
+#' @keywords internal
+.eri_cross_validate_rule <- function(rule_name, rule) {
+  problems <- character(0)
+
+  if (is.null(rule$join_key) || !is.character(rule$join_key) || length(rule$join_key) != 1L) {
+    problems <- c(problems, "missing/invalid `join_key`")
+  }
+  for (side_name in c("lhs", "rhs")) {
+    side <- rule[[side_name]]
+    if (is.null(side) || is.null(side$sources) || length(side$sources) == 0L) {
+      problems <- c(problems, paste0("`", side_name, "` has no `sources`"))
+      next
+    }
+    for (src in side$sources) {
+      if (is.null(src$disease) || is.null(src$data_type) || is.null(src$column)) {
+        problems <- c(problems, paste0("`", side_name, "` has a source missing disease/data_type/column"))
+      }
+    }
+  }
+  op <- rule$op
+  if (is.null(op) || length(op) != 1L || !op %in% .ERI_CROSS_OPS) {
+    problems <- c(problems, paste0("unrecognized `op` ", if (is.null(op)) "(missing)" else paste0("'", op, "'")))
+  }
+
+  if (length(problems) > 0L) {
+    valid_ops <- .ERI_CROSS_OPS
+    cli::cli_warn(c(
+      "Cross-consistency rule {.val {rule_name}} is malformed -- skipping it.",
+      "i" = paste(problems, collapse = "; "),
+      "i" = "Valid ops: {.val {valid_ops}}."
+    ))
+    return(FALSE)
+  }
+  TRUE
+}
+
+# Bind every matching (disease, data_type[, sheets]) source's (join_key,
+# column) pair from `tables` into one long tibble(key, value). `tables` is a
+# list of list(sheet=, disease=, data_type=, data=<canonical tibble>), one
+# entry per CMR sheet -- exactly what eri_cmr_dq_report()'s loop already
+# produces via run_dq_checks(). Returns NULL (with an info/warn already
+# emitted) when nothing at all could be bound for this side.
+#' @keywords internal
+.eri_cross_bind_sources <- function(tables, sources, join_key, rule_name, side_label) {
+  parts        <- list()
+  missing_desc <- character(0)
+
+  for (src in sources) {
+    matches <- Filter(function(t) {
+      identical(t$disease, src$disease) && identical(t$data_type, src$data_type) &&
+        (is.null(src$sheets) || t$sheet %in% src$sheets)
+    }, tables)
+
+    if (!is.null(src$sheets)) {
+      present <- unique(vapply(matches, function(m) m$sheet, character(1L)))
+      absent  <- setdiff(src$sheets, present)
+      if (length(absent) > 0L) {
+        missing_desc <- c(missing_desc,
+                          paste0(src$disease, "/", src$data_type, " [", paste(absent, collapse = ", "), "]"))
+      }
+    } else if (length(matches) == 0L) {
+      missing_desc <- c(missing_desc, paste0(src$disease, "/", src$data_type))
+    }
+
+    for (m in matches) {
+      d <- m$data
+      if (!join_key %in% names(d)) {
+        cli::cli_warn("Cross-consistency rule {.val {rule_name}}: {.val {m$sheet}} has no column {.val {join_key}} -- skipping that sheet for {side_label}.")
+        next
+      }
+      if (!src$column %in% names(d)) {
+        cli::cli_warn("Cross-consistency rule {.val {rule_name}}: {.val {m$sheet}} has no column {.val {src$column}} -- skipping that sheet for {side_label}.")
+        next
+      }
+      parts[[length(parts) + 1L]] <- tibble::tibble(
+        key   = as.character(d[[join_key]]),
+        value = as.numeric(d[[src$column]])
+      )
+    }
+  }
+
+  if (length(missing_desc) > 0L) {
+    cli::cli_alert_info(
+      "Cross-consistency rule {.val {rule_name}} ({side_label}): no data for {paste(missing_desc, collapse = ', ')}{if (length(parts) > 0L) ' -- continuing with what is present' else ' -- skipping this rule'}."
+    )
+  }
+
+  if (length(parts) == 0L) return(NULL)
+  dplyr::bind_rows(parts)
+}
+
+# Reduce one side's bound (key, value) rows to one aggregated value per
+# join_key. Returns list(values = tibble(key, value), flags = <non-constant
+# flags from agg="unique">), or NULL (nothing left to resolve, already
+# warned/informed) when the side can't be resolved at all.
+#' @keywords internal
+.eri_cross_side_values <- function(tables, side, join_key, rule_name, side_label) {
+  bound <- .eri_cross_bind_sources(tables, side$sources, join_key, rule_name, side_label)
+  if (is.null(bound)) return(NULL)
+
+  agg <- side$agg %||% "sum"
+  if (!agg %in% .ERI_CROSS_AGGS) {
+    valid_aggs <- .ERI_CROSS_AGGS
+    cli::cli_warn(c(
+      "Cross-consistency rule {.val {rule_name}}'s {side_label} has an unrecognized {.field agg} {.val {agg}} -- skipping this rule.",
+      "i" = "Valid aggregations: {.val {valid_aggs}}."
+    ))
+    return(NULL)
+  }
+
+  bound <- bound[!is.na(bound$key) & nzchar(trimws(bound$key)), , drop = FALSE]
+  bound$key <- trimws(bound$key)
+
+  flags <- .eri_cross_empty_flags()
+  out   <- tibble::tibble(key = character(0), value = double(0))
+  if (nrow(bound) == 0L) return(list(values = out, flags = flags))
+
+  for (k in unique(bound$key)) {
+    vals <- bound$value[bound$key == k]
+    if (identical(agg, "unique")) {
+      nonna <- unique(vals[!is.na(vals)])
+      if (length(nonna) > 1L) {
+        flags <- dplyr::bind_rows(flags, tibble::tibble(
+          row = NA_integer_, column = join_key, value = k,
+          issue = glue::glue(
+            "cross_consistency [{rule_name}]: {side_label} is not constant for {join_key} \"{k}\" ({paste(nonna, collapse = ', ')}) -- excluded from comparison"
+          )
+        ))
+        next
+      }
+      v <- if (length(nonna) == 1L) nonna else NA_real_
+    } else {
+      v <- .eri_cross_reduce(vals, agg)
+    }
+    out <- dplyr::bind_rows(out, tibble::tibble(key = k, value = as.double(v)))
+  }
+  list(values = out, flags = flags)
+}
+
+# Fill a side's per-key values over the full comparison keyset. A key ABSENT
+# from `values_tbl` (never appeared on this side at all) is filled with
+# `missing_as` when given; a key PRESENT but aggregated to NA (e.g. every raw
+# value was NA) stays NA regardless -- these are deliberately different, see
+# the file header.
+#' @keywords internal
+.eri_cross_fill <- function(values_tbl, missing_as, keys) {
+  idx <- match(keys, values_tbl$key)
+  v   <- values_tbl$value[idx]
+  if (!is.null(missing_as)) v[is.na(idx)] <- missing_as
+  v
+}
+
+#' @keywords internal
+.eri_cross_compare <- function(lhs, rhs, op, tolerance) {
+  switch(op,
+    "<="        = lhs <= rhs,
+    ">="        = lhs >= rhs,
+    "=="        = abs(lhs - rhs) <= tolerance,
+    "<"         = lhs <  rhs,
+    ">"         = lhs >  rhs,
+    "!="        = abs(lhs - rhs) > tolerance,
+    # Deliberately `> 0`, not `!= 0`: a negative count reads the same as zero
+    # here ("no activity"), by design -- catching a genuinely negative count
+    # is each measure's own per-sheet DQ schema's job (e.g. treated_nonneg),
+    # not this cross-sheet activity-presence check's.
+    "same_sign" = (lhs > 0) == (rhs > 0)
+  )
+}
+
+#' @keywords internal
+.eri_cross_side_label <- function(side) {
+  diseases <- unique(vapply(side$sources, function(s) s$disease %||% "?", character(1L)))
+  dtypes   <- unique(vapply(side$sources, function(s) s$data_type %||% "?", character(1L)))
+  cols     <- unique(vapply(side$sources, function(s) s$column %||% "?", character(1L)))
+  paste0(paste(diseases, collapse = "+"), "/", paste(dtypes, collapse = "+"), " ", paste(cols, collapse = "+"))
+}
+
+#### .eri_cross_check_run ####
+
+# The pure, testable core: no Azure, no schema loading. `tables` is a list of
+# list(sheet=, disease=, data_type=, data=<canonical tibble>) -- one entry
+# per CMR sheet, already run through run_dq_checks() by the caller. `rules`
+# is the `cross_consistency` list from a CMR routing schema (possibly empty
+# or NULL). Returns a flags tibble in the same row/column/value/issue shape
+# every other DQ check in this package uses.
+#' @keywords internal
+.eri_cross_check_run <- function(tables, rules) {
+  all_flags <- .eri_cross_empty_flags()
+  rules <- rules %||% list()
+  if (length(rules) == 0L) return(all_flags)
+
+  for (rule_name in names(rules)) {
+    rule <- rules[[rule_name]]
+    if (!.eri_cross_validate_rule(rule_name, rule)) next
+
+    join_key  <- rule$join_key
+    op        <- rule$op
+    tolerance <- rule$tolerance %||% 0
+
+    lhs <- .eri_cross_side_values(tables, rule$lhs, join_key, rule_name, "lhs")
+    if (is.null(lhs)) next
+    rhs <- .eri_cross_side_values(tables, rule$rhs, join_key, rule_name, "rhs")
+    if (is.null(rhs)) next
+
+    all_flags <- dplyr::bind_rows(all_flags, lhs$flags, rhs$flags)
+
+    all_keys <- union(lhs$values$key, rhs$values$key)
+    if (length(all_keys) == 0L) next
+
+    lhs_v <- .eri_cross_fill(lhs$values, rule$lhs$missing_as, all_keys)
+    rhs_v <- .eri_cross_fill(rhs$values, rule$rhs$missing_as, all_keys)
+
+    applicable <- !is.na(lhs_v) & !is.na(rhs_v)
+    ok <- .eri_cross_compare(lhs_v, rhs_v, op, tolerance)
+
+    bad <- which(applicable & !ok)
+    if (length(bad) > 0L) {
+      msg     <- rule$message %||% paste0(join_key, " mismatch between lhs and rhs")
+      lhs_lbl <- .eri_cross_side_label(rule$lhs)
+      rhs_lbl <- .eri_cross_side_label(rule$rhs)
+      all_flags <- dplyr::bind_rows(all_flags, tibble::tibble(
+        row    = NA_integer_,
+        column = join_key,
+        value  = all_keys[bad],
+        issue  = glue::glue(
+          "cross_consistency [{rule_name}]: {msg} ({lhs_lbl} = {signif(lhs_v[bad], 6)}, {rhs_lbl} = {signif(rhs_v[bad], 6)})"
+        )
+      ))
+    }
+  }
+  all_flags
+}
+
+#### Resolver -- called from eri_cmr_dq_report() ####
+
+# Top up `tables` with any sheet from this period's FULL last plan that isn't
+# already present. eri_cmr_dq_report() is sometimes called with a scoped
+# `plan` (e.g. a targeted re-check of one flagged measure during the review
+# loop) -- without this, a cross rule referencing a sibling measure outside
+# that scope would silently see it as absent. Always safe to call: a full
+# workbook run already has every sheet, so this is a no-op past the one
+# eri_cmr_last_plan() lookup.
+#' @keywords internal
+.eri_cross_load_missing <- function(country, period, tables, data_con) {
+  full_plan <- tryCatch(eri_cmr_last_plan(country, period, data_con = data_con), error = function(e) NULL)
+  if (is.null(full_plan) || nrow(full_plan) == 0L) return(tables)
+
+  have <- vapply(tables, function(t) t$sheet, character(1L))
+  missing <- full_plan[!full_plan$sheet %in% have, , drop = FALSE]
+  if (nrow(missing) == 0L) return(tables)
+
+  for (i in seq_len(nrow(missing))) {
+    p <- missing[i, ]
+    staged <- tryCatch(eri_read(p$dest, azcontainer = data_con), error = function(e) NULL)
+    if (is.null(staged)) next
+    schema <- tryCatch(
+      load_dq_schema(country, p$disease, "programmatic", p$data_type, azcontainer = data_con),
+      error = function(e) NULL
+    )
+    if (is.null(schema)) next
+    result <- suppressMessages(run_dq_checks(staged, schema))
+    tables[[length(tables) + 1L]] <- list(sheet = p$sheet, disease = p$disease,
+                                          data_type = p$data_type, data = result$data)
+  }
+  tables
+}
+
+# Load the country's cross_consistency rules (if any) and evaluate them
+# against `tables`, topping up from the full plan first. Returns NULL when
+# the country's CMR routing schema has no cross_consistency block at all --
+# the caller's cue to skip logging anything, not just "zero flags this run".
+#' @keywords internal
+.eri_cmr_cross_flags <- function(country, period, tables, data_con = NULL) {
+  schema <- tryCatch(load_cmr_schema(country), error = function(e) NULL)
+  rules  <- schema$cross_consistency %||% list()
+  if (length(rules) == 0L) return(NULL)
+
+  tables <- .eri_cross_load_missing(country, period, tables, data_con)
+  .eri_cross_check_run(tables, rules)
+}

--- a/R/dq_review.R
+++ b/R/dq_review.R
@@ -179,17 +179,38 @@
   resolved <- list()
   for (i in seq_len(nrow(open_flags))) {
     f <- open_flags[i, ]
-    cli::cli_h3("Flag {i}/{nrow(open_flags)}: {f$sheet} row {f$excel_row}")
+    # "cross" %in% names() first: a tibble without the column returns NULL
+    # from `$`, which isTRUE() handles fine, but also emits a spurious
+    # "unknown column" warning -- avoided entirely by checking first.
+    is_cross <- "cross" %in% names(f) && isTRUE(f$cross)
+    if (is_cross) {
+      cli::cli_h3("Flag {i}/{nrow(open_flags)}: cross-sheet check")
+    } else {
+      cli::cli_h3("Flag {i}/{nrow(open_flags)}: {f$sheet} row {f$excel_row}")
+    }
     cli::cli_text("{.field {f$column}}: {.val {f$value}} -- {f$issue}")
 
-    choice <- .eri_prompt_menu("What do you want to do with this flag?", c(
-      "Fix in source (open/copy the workbook)",
-      "Adjust the schema (alias, allowed value, range...)",
-      "Mark not important",
-      "Mark noted",
-      "Skip to the next flag"
-    ))
-    if (choice == 0L || choice == 5L) next
+    # A cross-sheet flag (ADR-0024) has no single Excel row/sheet and no
+    # per-measure DQ schema to edit -- both "Fix in source" and "Adjust the
+    # schema" assume one, so the menu drops to the triage-only choices.
+    if (is_cross) {
+      choice <- .eri_prompt_menu("What do you want to do with this flag?", c(
+        "Mark not important",
+        "Mark noted",
+        "Skip to the next flag"
+      ))
+      if (choice == 0L || choice == 3L) next
+      choice <- choice + 2L  # re-align onto the full menu's 3/4 = not_important/noted
+    } else {
+      choice <- .eri_prompt_menu("What do you want to do with this flag?", c(
+        "Fix in source (open/copy the workbook)",
+        "Adjust the schema (alias, allowed value, range...)",
+        "Mark not important",
+        "Mark noted",
+        "Skip to the next flag"
+      ))
+      if (choice == 0L || choice == 5L) next
+    }
 
     if (choice == 1L) {
       .eri_dq_review_fix_in_source(f, local_path_env)
@@ -466,7 +487,20 @@ eri_dq_review_note <- function(country, period, note, data_con = NULL) {
       if (!is.null(rerun$rechecked) && nrow(rerun$rechecked) > 0L) {
         fresh <- eri_cmr_dq_report(country, period, plan = rerun$rechecked, data_con = data_con)
         key   <- function(p) paste(p$disease, p$data_type)
-        if (nrow(flags) > 0L) flags <- flags[!(key(flags) %in% key(rerun$rechecked)), , drop = FALSE]
+        if (nrow(flags) > 0L) {
+          # Cross-sheet flags (ADR-0024) are always freshly re-derived on
+          # every eri_cmr_dq_report() call (via its own fallback loader
+          # against the FULL measure set, not just this scoped re-check) --
+          # drop every old cross row unconditionally, since key()-based
+          # matching only targets the resplit measure(s) and never matches
+          # the "rblf"/"consistency" pseudo-measure a cross flag carries.
+          # `cross_col` defaults to (scalar) FALSE when the column is absent
+          # (e.g. a mocked eri_cmr_dq_report() predating this column) rather
+          # than erroring on `!flags$cross` (NULL on a tibble) or warning on
+          # a missing-column `$` access.
+          cross_col <- if ("cross" %in% names(flags)) flags$cross else FALSE
+          flags <- flags[!(key(flags) %in% key(rerun$rechecked)) & !cross_col, , drop = FALSE]
+        }
         flags <- dplyr::bind_rows(flags, fresh)
       }
     } else if (choice == 3L) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Standardized data tools for the Epidemiology, Research and Innovation (ERI) team
 **New here, start there.** The documentation site has step-by-step guides, the full function
 reference, and the project roadmap. This README is the quick orientation.
 
-**Version:** 0.9.42 · **Status:** Active development
+**Version:** 0.9.43 · **Status:** Active development
 
 > 🛣️ **Where this is going:** see the
 > [V2 roadmap](https://github.com/thecartercenter/erifunctions/blob/main/docs/roadmap.md) and the

--- a/docs/adr/0024-cross-sheet-dq-at-staged-layer.md
+++ b/docs/adr/0024-cross-sheet-dq-at-staged-layer.md
@@ -1,0 +1,134 @@
+# ADR-0024 — Cross-sheet DQ checks: declared in the CMR routing schema, evaluated at DQ time
+
+- **Status:** Accepted
+- **Date:** 2026-07-30
+
+## Context
+
+Emalee reported (email, cc Hannah, no rush, 2026-07-30) three DQ checks needed while reviewing
+Ethiopia's most recent CMR upload, none of which the existing DQ engine can express:
+
+1. Population reported for a district (IU) on the RB Treatment tab must equal population reported
+   for that same district on the LF Treatment tab.
+2. For a country with CDD/CS/HW training tabs: if the sum of RB+LF treated for a district is > 0,
+   the sum of CDD+CS+HW training for that district must also be > 0.
+3. The inverse: if that treatment sum is 0, the training sum must also be 0.
+
+`run_dq_checks()` (`R/dq.R`) operates on one already-loaded dataframe. Its `consistency:` schema
+block (`add_anomaly_consistency()`) compares two columns of the *same row* of that one sheet. Even
+`eri_cmr_dq_report()`, which already loops over every sheet in one workbook, runs `run_dq_checks()`
+separately per measure and just concatenates the flags -- it never joins or aggregates across
+measures. This relationship is not Ethiopia-specific: every RBLF country in this codebase (sdn, ssd,
+uga, eth, nga, mad, tcd) shares the same RB/LF-treatment + combined-training-schema shape, so per
+CLAUDE.md's global-vs-local guardrail this needed a real, reusable capability, not an Ethiopia-only
+script.
+
+A key constraint discovered while designing this: staged parquet still carries raw `#field-code`
+columns (`eri_split_cmr()` stages data "as-is" -- alias resolution to canonical names like
+`district`/`population`/`treated`/`tot`/`training_type` only happens inside `run_dq_checks()`). Any
+cross-sheet join has to happen on the *canonical, post-`run_dq_checks()`* data, not on raw staged
+files.
+
+## Decision
+
+1. **`cross_consistency:` is a new declarative block on the CMR *routing* schema**
+   (`inst/schemas/cmr/{country}.yaml`), not a per-measure DQ schema. Only the routing schema knows a
+   whole workbook's sheet-to-measure map; a per-measure DQ schema cannot express "compare me against
+   a sibling sheet" by construction. Rule format (see `R/dq_cross.R`'s header comment for the full
+   spec): an ordered list of named rules, each a `join_key`, an `lhs`/`rhs` side (`agg` type --
+   `sum`/`unique`/`max`/`min`/`mean`/`n` -- plus one or more `sources`, each a `(disease, data_type,
+   column[, sheets])` reference), and an `op` (`==`/`!=`/`<`/`<=`/`>`/`>=`/`same_sign`).
+2. **Rules are evaluated inside `eri_cmr_dq_report()`**, against the canonical `result$data` each
+   sheet's own `run_dq_checks()` pass already produced -- collected into a `tables` list during the
+   existing per-measure loop, joined/aggregated by a new pure engine (`R/dq_cross.R`'s
+   `.eri_cross_check_run()`) after it. Not via `eri_query()`/DuckDB: that tool works against
+   `processed/` parquet with unresolved field codes, is a `Suggests` dependency (routing a
+   default-on DQ check through it would make an optional package effectively mandatory for the CMR
+   pipeline), and the canonical tables the join needs are already in hand from the loop that just
+   ran -- re-reading them would be pure waste. `eri_query()` remains the right tool for the
+   deliberate, downstream, analytic joins it already serves.
+3. **Findings are workbook-level, not attributable to one measure.** One `dq_flags` log entry at
+   `{country}/rblf/programmatic/consistency/logs/` (`consistency` is a new registered `data_type`
+   in `inst/registry/data_model.yaml`), surfacing through the existing flags tibble ->
+   `eri_dq_review()` -> `eri_dq_export()` -> `eri_dq_flag_resolve()` chain via a new `cross` logical
+   column (`sheet = "(cross-sheet)"`, `row`/`excel_row = NA`). A population mismatch between RB and
+   LF isn't a defect of "the oncho measure" specifically -- you can't tell which side is wrong, and
+   rule 2 has three source measures with no defensible "primary" to attribute it to.
+4. **`eri_approve_cmr()` gains a workbook-level gate on unresolved cross-consistency findings**, but
+   deliberately does **not** require a cross-check to have run at all -- it blocks only on a
+   genuinely *open* finding. Most countries have no `cross_consistency:` rules declared yet, so no
+   entry is ever logged for them; treating that absence as "outstanding" would retroactively make
+   every period approved before this feature shipped unapprovable.
+5. **Absence is always a silent no-op**, at every level: a country's routing schema with no
+   `cross_consistency:` block, a rule whose sources match zero available sheets (e.g. a country
+   without CDD/CS/HW tabs), and a join key present on only one side of a comparison (e.g. LF's
+   smaller endemic-district roster versus RB's) are never errors and never flag anything. A rule
+   author's mistake (unrecognized `op`/`agg`, a missing required field) *does* warn loudly and skip
+   just that rule -- the same "fail loud on a typo, fail quiet on a legitimate absence" posture
+   `R/dq.R`'s `range_when`/`range_overrides` (fixed 2026-07-29) already established.
+
+## Why this is not the join ADR-0012 says stays downstream
+
+[ADR-0012](0012-source-measure-data-model.md) governs the **data model**: no join may be baked into
+a *stored* artifact, so a staged/processed file is always exactly one sheet's rows. Nothing here is
+written as data -- the join built by `.eri_cross_check_run()` is transient, in-memory, read-only,
+and discarded the moment the check returns. It exists solely to compute a review flag on staged data
+*before* the human approval gate. Ingest-time joining would destroy information (you could no longer
+see what each sheet said on its own); DQ-time cross-referencing preserves it and is exactly what
+makes a split-then-check-per-measure pipeline trustworthy in the first place. `processed/` remains
+the layer for deliberate downstream joins, and `eri_query()` remains the tool for them.
+
+## Why `staged/`, not `processed/`
+
+`eri_approve_cmr()` promotes measures to `processed/` **per-measure** -- one measure can be approved
+while a sibling is still blocked or unreviewed, so `processed/` is not guaranteed to have every
+measure of one workbook in sync at any given moment. `staged/`, right after `eri_split_cmr()`, is
+the only point where every sheet of one submission is simultaneously present and stable. It is also
+*before* the approval gate, which is where a blocking check belongs.
+
+## Consequences
+
+**Easier:** a DA gets a real cross-tab check inside the DQ report they already read, with no new
+concept to learn (rules reuse the `op`/`message` vocabulary the `consistency:` block already uses).
+Other RBLF countries opt in by editing their routing schema's YAML, not by writing code.
+
+**Harder / accepted:**
+- A cross flag has no single Excel row or sheet, so `eri_dq_review()`'s per-flag menu for it drops
+  "Fix in source" and "Adjust the schema" (neither has a single target to point at) -- a real,
+  if modest, usability narrowing for this flag type versus an ordinary single-measure flag.
+- `eri_approve_cmr()`'s cross gate and `eri_dq_review()`'s re-run/dedup logic both needed dedicated
+  handling (a cross flag's `(disease, data_type)` is the `"rblf"`/`"consistency"` pseudo-measure,
+  which never matches a real resplit measure's key -- without an explicit guard, a re-run would
+  duplicate the stale cross row alongside the freshly re-derived one).
+- `agg: unique` (used for the population-match rule) will surface a *new* kind of finding never
+  checked before -- population inconsistent across `treatment_round` rows within the same sheet --
+  which is a real, useful check in its own right, but means some first-run noise should be expected
+  on real workbooks that were never validated this way before.
+- `eri_cmr_dq_report()` sometimes runs against a **scoped** plan (e.g. `eri_dq_review()`'s targeted
+  re-check of one just-resplit measure) that doesn't carry every sheet a cross rule needs. A fallback
+  loader (`.eri_cross_load_missing()`) tops up from that period's full last plan before evaluating
+  rules, at the cost of one extra `eri_cmr_last_plan()` lookup on every call with rules declared --
+  a no-op past that lookup when the plan was already complete.
+
+**Not doing (out of scope for this PR):**
+- A general cross-dataset join engine for arbitrary `processed/` data -- `eri_query()` already is
+  that, and stays the tool for deliberate downstream analysis.
+- Cross-*workbook*, cross-period, or cross-country checks.
+- Materializing any joined artifact -- the join is computed and discarded every run.
+- Rules for any country other than `eth` -- each country's real sheet names (tcd/mad's templates are
+  in French) and district-roster overlaps between diseases are different enough that copying eth's
+  rules elsewhere would be guesswork, not generalization. Other countries opt in when someone with
+  real knowledge of that country's template asks.
+
+## References
+
+- [ADR-0012](0012-source-measure-data-model.md) -- the source-measure data model and its
+  "joins stay downstream" principle this ADR carves a narrow, deliberate exception from.
+- [ADR-0023](0023-cmr-ingest-stamps-sheet-name.md) -- the `sheet`/`training_type` discriminator a
+  rule's `sheets:` filter (e.g. `[CDD Training, CS Training, HW Training]`) selects against.
+- [ADR-0018](0018-dq-schema-local-overrides.md) -- the per-measure DQ schema override lifecycle;
+  `cross_consistency:` lives on the CMR *routing* schema instead, which that override path does not
+  cover.
+- `R/dq_cross.R` (the engine and its schema-format header comment), `R/cmr.R`'s
+  `eri_cmr_dq_report()`/`eri_approve_cmr()`, `R/dq_review.R`'s cross-flag guards,
+  `inst/schemas/cmr/eth.yaml`'s `cross_consistency:` block, `tests/testthat/test-dq_cross.R`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,3 +67,4 @@ What becomes easier, what becomes harder, and what we are explicitly *not* doing
 | [0021](0021-mirror-filename-period-leading.md) | Legacy mirror filename leads with period, not country | Accepted |
 | [0022](0022-cmr-duplicate-field-code-blocks-workbook.md) | A duplicate CMR field code blocks the whole workbook, not just its sheet | Accepted — reverses v0.9.8 |
 | [0023](0023-cmr-ingest-stamps-sheet-name.md) | `eri_ingest_cmr()` stamps the real sheet name onto every row | Accepted |
+| [0024](0024-cross-sheet-dq-at-staged-layer.md) | Cross-sheet DQ checks: declared in the CMR routing schema, evaluated at staged-layer DQ time | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,6 +83,7 @@ brief's "Some Questions" section (see [`vision.md`](vision.md)).
 | [0021](adr/0021-mirror-filename-period-leading.md) | Legacy `projects`-blob mirror filename leads with period (`{period}_{country}_{timestamp}`), matching the real convention | CMR pilot-session filename mismatch |
 | [0022](adr/0022-cmr-duplicate-field-code-blocks-workbook.md) | A duplicate CMR field code blocks the whole workbook, not just its sheet; reverses the v0.9.8 per-sheet-tolerant behavior | CMR pilot-session template-defect handling |
 | [0023](adr/0023-cmr-ingest-stamps-sheet-name.md) | `eri_ingest_cmr()` stamps the real sheet name onto every row, so a combined schema (e.g. training) can discriminate its sources | `training_type` discriminator for rolled-up measures |
+| [0024](adr/0024-cross-sheet-dq-at-staged-layer.md) | Cross-sheet DQ checks (`cross_consistency:`) declared on the CMR routing schema, evaluated at staged-layer DQ time, workbook-level findings | Cross-sheet DQ checks (DQ workflow redesign follow-on) |
 
 ---
 
@@ -291,6 +292,19 @@ item, which now hands it the in-session flags tibble (including any `status`/`no
 session) instead of only printing to console. Closes the loop the whole redesign started from: a DA's
 DQ triage now produces a structured, attributable handback artifact instead of an ad hoc table. All 8
 phases of the DQ workflow redesign are now shipped.
+
+**Cross-sheet DQ checks (shipped, 2026-07-30, follow-on to the DQ workflow redesign):** every check
+above still operates on one already-loaded sheet at a time. Emalee's report from Ethiopia's most
+recent CMR (population must match between the RB and LF Treatment tabs for the same district;
+treatment activity for a district should imply training activity, and vice versa) needed something
+none of the 8 phases built: a check that spans *multiple* sheets. Shipped as
+[ADR-0024](adr\0024-cross-sheet-dq-at-staged-layer.md): a new declarative `cross_consistency:` block
+on the CMR routing schema (`inst/schemas/cmr/{country}.yaml`, the one artifact that knows a whole
+workbook's sheet-to-measure map), evaluated by `eri_cmr_dq_report()` against each sheet's own
+already-canonical DQ output and surfaced as a workbook-level `dq_flags` entry (not attributable to
+one measure) through the same `eri_dq_review()`/`eri_dq_export()`/`eri_approve_cmr()` chain every
+other DQ flag already uses. Rules shipped for `eth` only; the engine (`R/dq_cross.R`) is general and
+every other RBLF country can opt in by editing its own routing schema's YAML.
 
 **Docs site & guidance system redesign (in progress):** the DQ workflow redesign's biggest lesson —
 collapsing "remember N functions in the right order" into "answer a guided menu" — prompted a second

--- a/inst/registry/data_model.yaml
+++ b/inst/registry/data_model.yaml
@@ -60,6 +60,7 @@ data_types:
   tas:        "Transmission assessment survey (LF)."
   prevalence: "Prevalence survey (e.g. Kato-Katz, skin snip)."
   entomology: "Vector / entomological surveillance (e.g. larval prospection)."
+  consistency: "Cross-sheet/cross-measure consistency check spanning multiple measures of one CMR workbook (not a single-sheet measure itself; see ADR-0024)."
 
 formats:
   cmr:      "Country Monitoring Report Excel template (a programmatic input format)."

--- a/inst/schemas/cmr/eth.yaml
+++ b/inst/schemas/cmr/eth.yaml
@@ -233,3 +233,51 @@ sheets:
       - "#rb_ento_surv_adm2_id"
       - "#rb_ento_surv_adm3"
       - "#rb_ento_surv_disease"
+
+# Cross-sheet DQ checks (ADR-0024) -- rules that need to compare data across
+# more than one sheet, which no single-measure DQ schema can express. Reported
+# by Emalee (email, cc Hannah, 2026-07-30), from the most recent Ethiopia CMR.
+# Evaluated by eri_cmr_dq_report() against each sheet's own already-canonical
+# (post run_dq_checks()) data -- see R/dq_cross.R for the schema format and
+# aggregation semantics.
+cross_consistency:
+  rb_lf_pop_match:
+    description: >
+      Population reported for a district (IU) on the RB Treatment tab must
+      match population reported for that same district on the LF Treatment
+      tab. LF only covers a subset of RB's endemic districts -- a district
+      appearing on only one tab is a coverage difference, not a mismatch, and
+      is never flagged (no missing_as on either side).
+    join_key: district
+    lhs:
+      agg: unique
+      sources:
+        - {disease: oncho, data_type: treatment, column: population}
+    rhs:
+      agg: unique
+      sources:
+        - {disease: lf, data_type: treatment, column: population}
+    op: "=="
+    message: "RB and LF Treatment report different population for this district"
+  treatment_implies_training:
+    description: >
+      If a district's RB+LF treated total is > 0, its CDD+CS+HW training
+      total must also be > 0 (and conversely, both must be 0 together). Only
+      evaluated where at least one of those training sheets has real data
+      this period -- a country/period with none of them present skips this
+      rule entirely, not a false flag.
+    join_key: district
+    lhs:
+      agg: sum
+      missing_as: 0
+      sources:
+        - {disease: oncho, data_type: treatment, column: treated}
+        - {disease: lf, data_type: treatment, column: treated}
+    rhs:
+      agg: sum
+      missing_as: 0
+      sources:
+        - {disease: rblf, data_type: training, column: tot,
+          sheets: ["CDD Training", "CS Training", "HW Training"]}
+    op: same_sign
+    message: "treatment and training activity disagree on whether this district had any activity this period"

--- a/man/eri_approve_cmr.Rd
+++ b/man/eri_approve_cmr.Rd
@@ -54,6 +54,12 @@ close it out with \code{\link[=eri_logs_resolve]{eri_logs_resolve()}} (passing w
 its \code{note} argument), and re-run this function -- it re-checks from
 scratch each time.
 
+Also blocks on an \strong{unresolved} cross-consistency finding (ADR-0024) if
+\code{\link[=eri_cmr_dq_report]{eri_cmr_dq_report()}} logged one for this period -- unlike the per-measure
+checks, this does NOT require a cross-check to have run at all, since most
+countries have no \verb{cross_consistency:} rules declared yet: a period with no
+cross-check log entry is never treated as outstanding on that basis alone.
+
 \strong{A stale flag keeps blocking until it's explicitly resolved.} This checks
 every \code{dq_flags} log entry for the period, not just the most recent one: if
 an earlier \code{\link[=eri_dq_log]{eri_dq_log()}} run had unresolved flags and a later rerun for the

--- a/man/eri_cmr_dq_report.Rd
+++ b/man/eri_cmr_dq_report.Rd
@@ -9,6 +9,7 @@ eri_cmr_dq_report(
   period,
   plan = NULL,
   supersede = TRUE,
+  cross = TRUE,
   data_con = NULL
 )
 }
@@ -28,17 +29,26 @@ a "superseded by a newer run" note when this run logs a new one, so
 re-running doesn't pile up entries you have to close by hand. Set \code{FALSE}
 to keep every run's entry open until you resolve it yourself.}
 
+\item{cross}{\code{logical} Also evaluate the country's \verb{cross_consistency:}
+rules, if any. Default \code{TRUE}. Set \code{FALSE} to skip cross-sheet checks
+entirely (e.g. when re-checking one measure in isolation and cross-sheet
+context isn't needed).}
+
 \item{data_con}{Azure container for the \verb{data/} blob. If \code{NULL}, connects automatically.}
 }
 \value{
-A tibble with one row per flag across every measure: \code{sheet},
-\code{disease}, \code{data_type}, \code{log_path}, \code{flag_id}, \code{row} (the flag's index
-into the checked data, not the workbook), \code{excel_row} (the real row in
+A tibble with one row per flag across every measure: \code{sheet}
+(\code{"(cross-sheet)"} for a cross-consistency flag), \code{disease}, \code{data_type},
+\code{log_path}, \code{flag_id}, \code{row} (the flag's index into the checked data, not
+the workbook; \code{NA} for a cross-sheet flag), \code{excel_row} (the real row in
 the original Excel sheet -- use this one when telling a DA what to go
-fix), \code{column}, \code{value}, \code{issue}, \code{status} (all \code{"open"} on a fresh run),
-\code{note} (\code{NA} on a fresh run -- only set once a flag has been triaged via
-\code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}} and this function is re-run). Zero rows if every
-measure is clean.
+fix; \code{NA} for a cross-sheet flag, which has no single row), \code{column},
+\code{value}, \code{issue}, \code{status} (all \code{"open"} on a fresh run), \code{note} (\code{NA} on
+a fresh run -- only set once a flag has been triaged via
+\code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}} and this function is re-run), \code{cross} (\code{TRUE}
+for a cross-consistency flag, \code{FALSE} for an ordinary single-measure
+flag). Zero rows if every measure (and any cross-consistency rules) is
+clean.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
@@ -54,6 +64,17 @@ one place instead of twelve.
 Each row's \code{flag_id} is what you pass to \code{\link[=eri_dq_flag_resolve]{eri_dq_flag_resolve()}} to triage
 that specific issue (\code{"not_important"}, \code{"fixed"}, or \code{"noted"}) before
 closing out the whole measure with \code{\link[=eri_logs_resolve]{eri_logs_resolve()}}.
+
+If the country's CMR routing schema (\verb{inst/schemas/cmr/\{country\}.yaml})
+declares a \verb{cross_consistency:} block, this also evaluates those rules --
+declarative checks that span more than one sheet (e.g. "population on the
+RB Treatment tab must match population on the LF Treatment tab for the
+same district"), which no single-sheet DQ schema can express (see
+ADR-0024). Findings are logged as one workbook-level \code{dq_flags} entry
+(\verb{\{country\}/rblf/programmatic/consistency/logs/}, not attributable to any
+one measure) and returned as rows with \code{sheet = "(cross-sheet)"} and
+\code{cross = TRUE}. Most countries have no \verb{cross_consistency:} block yet, in
+which case this step is a silent no-op.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-cmr.R
+++ b/tests/testthat/test-cmr.R
@@ -1236,6 +1236,59 @@ test_that("eri_approve_cmr prints the registered next-step hint on success (task
   )
 })
 
+#### Tests for eri_approve_cmr()'s cross-consistency gate (ADR-0024) ####
+
+test_that("eri_approve_cmr blocks on an unresolved cross-consistency finding", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  approve_called <- FALSE
+  local_mocked_bindings(
+    load_cmr_schema = function(...) list(cross_consistency = list(rule1 = list())),  # declares rules
+    eri_logs = function(country, disease, data_source, data_type, ...) {
+      if (identical(data_type, "consistency")) {
+        tibble::tibble(log_path = "eth/rblf/programmatic/consistency/logs/x.yaml", period = "202606",
+                       status = "needs_review", handled = FALSE, n_issues = 2L)
+      } else {
+        tibble::tibble(log_path = "eth/oncho/programmatic/treatment/logs/x.yaml", period = "202606",
+                       status = "clean", handled = FALSE, n_issues = 0L)
+      }
+    },
+    eri_approve = function(...) { approve_called <<- TRUE },
+    .package = "erifunctions"
+  )
+
+  result <- eri_approve_cmr("eth", "202606", plan = plan, data_con = structure(list(), class = "mock"))
+  expect_false(approve_called)
+  expect_true(any(result$data_type == "consistency"))
+  expect_match(result$issue[result$data_type == "consistency"], "2 unresolved cross-sheet DQ flag")
+})
+
+test_that("eri_approve_cmr does not block on a period that was never cross-checked, even when the country declares rules", {
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                         data_type = "treatment", dest = "a", n_rows = 1L)
+  approve_called <- FALSE
+  local_mocked_bindings(
+    load_cmr_schema = function(...) list(cross_consistency = list(rule1 = list())),  # declares rules
+    eri_logs = function(country, disease, data_source, data_type, ...) {
+      if (identical(data_type, "consistency")) {
+        # no cross-check log entry at all for this period -- must NOT be
+        # treated as outstanding (decision: block only on unresolved findings)
+        tibble::tibble(log_path = character(0), period = character(0),
+                       status = character(0), handled = logical(0), n_issues = integer(0))
+      } else {
+        tibble::tibble(log_path = "eth/oncho/programmatic/treatment/logs/x.yaml", period = "202606",
+                       status = "clean", handled = FALSE, n_issues = 0L)
+      }
+    },
+    eri_approve = function(...) { approve_called <<- TRUE },
+    .package = "erifunctions"
+  )
+
+  result <- eri_approve_cmr("eth", "202606", plan = plan, data_con = structure(list(), class = "mock"))
+  expect_true(approve_called)
+  expect_equal(nrow(result), 1L)  # only the real measure, no spurious "consistency" row
+})
+
 test_that("eri_approve_cmr records a dq_reviewed cross-reference in its own op-log", {
   plan <- tibble::tibble(
     sheet = "RB Treatment", disease = "oncho",
@@ -1596,4 +1649,266 @@ test_that("eri_cmr_dq_report's excel_row survives real run_dq_checks() row-dropp
 
   expect_equal(nrow(flags), 1L)
   expect_equal(flags$excel_row, 8L)   # NOT 2 (the post-drop row index) or 7 (pre-drop, wrong row)
+})
+
+#### Tests for eri_cmr_dq_report()'s cross_consistency evaluation (ADR-0024) ####
+
+test_that("eri_cmr_dq_report is a byte-identical no-op for cross-checking when the country has no cross_consistency block", {
+  plan <- tibble::tibble(
+    sheet = "RB Treatment", disease = "oncho",
+    data_type = "treatment", dest = "a", n_rows = 1L
+  )
+  clean_result <- structure(list(data = tibble::tibble(x = 1), log = tibble::tibble(row = integer()),
+                                 flags = tibble::tibble(row = integer(), column = character(),
+                                                         value = character(), issue = character())),
+                            class = "dq_result")
+  dq_log_write_calls <- list()
+
+  local_mocked_bindings(
+    eri_read = function(...) tibble::tibble(x = 1),
+    load_dq_schema = function(...) list(columns = list()),
+    run_dq_checks = function(...) clean_result,
+    load_cmr_schema = function(...) list(sheets = list("RB Treatment" = list())),  # no cross_consistency at all
+    .eri_dq_log_write = function(result, country, disease, data_source, data_type, ...) {
+      dq_log_write_calls[[length(dq_log_write_calls) + 1L]] <<- list(disease = disease, data_type = data_type)
+      list(n_flags = 0L, status = "clean", log_path = "x.yaml", flags = list())
+    },
+    .package = "erifunctions"
+  )
+
+  flags <- eri_cmr_dq_report("sdn", "202605", plan = plan, data_con = structure(list(), class = "mock"))
+  expect_equal(nrow(flags), 0L)
+  expect_true("cross" %in% names(flags))
+  # exactly the one per-measure call -- no second call for disease="rblf"/data_type="consistency"
+  expect_length(dq_log_write_calls, 1L)
+  expect_false(any(vapply(dq_log_write_calls, function(c) c$data_type == "consistency", logical(1L))))
+})
+
+test_that("eri_cmr_dq_report evaluates cross_consistency rules and returns extra rows with cross = TRUE", {
+  plan <- tibble::tibble(
+    sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),
+    data_type = c("treatment", "treatment"),
+    dest = c("eth/oncho/programmatic/treatment/staged/a.parquet",
+            "eth/lf/programmatic/treatment/staged/b.parquet"),
+    n_rows = c(1L, 1L)
+  )
+  rb_data <- tibble::tibble(district = "Ari", population = 1000)
+  lf_data <- tibble::tibble(district = "Ari", population = 900)  # mismatch
+  clean_flags <- tibble::tibble(row = integer(), column = character(), value = character(), issue = character())
+
+  cross_rule_schema <- list(
+    sheets = list("RB Treatment" = list(), "LF Treatment" = list()),
+    cross_consistency = list(pop_match = list(
+      join_key = "district",
+      lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+      rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+      op = "=="
+    ))
+  )
+
+  local_mocked_bindings(
+    eri_read = function(path, ...) if (grepl("oncho", path, fixed = TRUE)) rb_data else lf_data,
+    load_dq_schema = function(...) list(columns = list()),
+    run_dq_checks = function(data, schema, ...) structure(
+      list(data = data, log = tibble::tibble(row = integer()), flags = clean_flags,
+          schema_source = NA_character_, schema_hash = NA_character_),
+      class = "dq_result"
+    ),
+    load_cmr_schema = function(...) cross_rule_schema,
+    eri_cmr_last_plan = function(...) plan,  # nothing missing from `tables` -- fallback loader is a no-op
+    .eri_dq_log_write = function(result, country, disease, data_source, data_type, ...) {
+      list(n_flags = nrow(result$flags), status = if (nrow(result$flags) > 0L) "needs_review" else "clean",
+          log_path = paste0(country, "/", disease, "/", data_source, "/", data_type, "/logs/x.yaml"),
+          flags = lapply(seq_len(nrow(result$flags)), function(i) list(
+            index = i, row = result$flags$row[i], column = result$flags$column[i],
+            value = result$flags$value[i], issue = result$flags$issue[i], status = "open"
+          )))
+    },
+    .package = "erifunctions"
+  )
+
+  flags <- eri_cmr_dq_report("eth", "202606", plan = plan, data_con = structure(list(), class = "mock"))
+  cross_rows <- flags[flags$cross, , drop = FALSE]
+  expect_equal(nrow(cross_rows), 1L)
+  expect_equal(cross_rows$sheet, "(cross-sheet)")
+  expect_equal(cross_rows$disease, "rblf")
+  expect_equal(cross_rows$data_type, "consistency")
+  expect_true(is.na(cross_rows$excel_row))
+  expect_true(is.na(cross_rows$row))
+  expect_match(cross_rows$flag_id, "::\\d+$")
+  expect_equal(cross_rows$value, "Ari")
+})
+
+test_that("eri_cmr_dq_report(cross = FALSE) suppresses cross_consistency evaluation entirely", {
+  plan <- tibble::tibble(
+    sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),
+    data_type = c("treatment", "treatment"), dest = c("a", "b"), n_rows = c(1L, 1L)
+  )
+  rb_data <- tibble::tibble(district = "Ari", population = 1000)
+  lf_data <- tibble::tibble(district = "Ari", population = 900)
+  clean_flags <- tibble::tibble(row = integer(), column = character(), value = character(), issue = character())
+  cross_schema_touched <- FALSE
+
+  local_mocked_bindings(
+    eri_read = function(path, ...) if (grepl("^a$", path)) rb_data else lf_data,
+    load_dq_schema = function(...) list(columns = list()),
+    run_dq_checks = function(data, schema, ...) structure(
+      list(data = data, log = tibble::tibble(row = integer()), flags = clean_flags,
+          schema_source = NA_character_, schema_hash = NA_character_),
+      class = "dq_result"
+    ),
+    load_cmr_schema = function(...) { cross_schema_touched <<- TRUE; list() },
+    .eri_dq_log_write = function(...) list(n_flags = 0L, status = "clean", log_path = "x.yaml", flags = list()),
+    .package = "erifunctions"
+  )
+
+  flags <- eri_cmr_dq_report("eth", "202606", plan = plan, cross = FALSE, data_con = structure(list(), class = "mock"))
+  expect_false(cross_schema_touched)  # load_cmr_schema() never even called
+  expect_false(any(flags$cross))
+})
+
+test_that("eri_cmr_dq_report writes a clean cross-consistency log entry when rules pass", {
+  plan <- tibble::tibble(
+    sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),
+    data_type = c("treatment", "treatment"), dest = c("a", "b"), n_rows = c(1L, 1L)
+  )
+  data_by_dest <- tibble::tibble(district = "Ari", population = 500)
+  clean_flags <- tibble::tibble(row = integer(), column = character(), value = character(), issue = character())
+  cross_rule_schema <- list(
+    sheets = list("RB Treatment" = list(), "LF Treatment" = list()),
+    cross_consistency = list(pop_match = list(
+      join_key = "district",
+      lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+      rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+      op = "=="
+    ))
+  )
+  cross_log_calls <- 0L
+
+  local_mocked_bindings(
+    eri_read = function(...) data_by_dest,
+    load_dq_schema = function(...) list(columns = list()),
+    run_dq_checks = function(data, schema, ...) structure(
+      list(data = data, log = tibble::tibble(row = integer()), flags = clean_flags,
+          schema_source = NA_character_, schema_hash = NA_character_),
+      class = "dq_result"
+    ),
+    load_cmr_schema = function(...) cross_rule_schema,
+    eri_cmr_last_plan = function(...) plan,
+    .eri_dq_log_write = function(result, country, disease, data_source, data_type, ...) {
+      if (identical(data_type, "consistency")) cross_log_calls <<- cross_log_calls + 1L
+      list(n_flags = nrow(result$flags), status = if (nrow(result$flags) > 0L) "needs_review" else "clean",
+          log_path = paste0(country, "/", disease, "/", data_source, "/", data_type, "/logs/x.yaml"),
+          flags = list())
+    },
+    .package = "erifunctions"
+  )
+
+  flags <- eri_cmr_dq_report("eth", "202606", plan = plan, data_con = structure(list(), class = "mock"))
+  expect_equal(cross_log_calls, 1L)  # a clean cross-check still logs a "clean" entry
+  expect_false(any(flags$cross))     # but produces no flag ROWS
+})
+
+test_that("eri_cmr_dq_report(supersede = TRUE) auto-resolves a prior open cross-consistency entry", {
+  plan <- tibble::tibble(
+    sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),
+    data_type = c("treatment", "treatment"), dest = c("a", "b"), n_rows = c(1L, 1L)
+  )
+  data_by_dest <- tibble::tibble(district = "Ari", population = 500)
+  clean_flags <- tibble::tibble(row = integer(), column = character(), value = character(), issue = character())
+  cross_rule_schema <- list(
+    sheets = list("RB Treatment" = list(), "LF Treatment" = list()),
+    cross_consistency = list(pop_match = list(
+      join_key = "district",
+      lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+      rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+      op = "=="
+    ))
+  )
+  resolved <- character(0)
+
+  local_mocked_bindings(
+    eri_read = function(...) data_by_dest,
+    load_dq_schema = function(...) list(columns = list()),
+    run_dq_checks = function(data, schema, ...) structure(
+      list(data = data, log = tibble::tibble(row = integer()), flags = clean_flags,
+          schema_source = NA_character_, schema_hash = NA_character_),
+      class = "dq_result"
+    ),
+    load_cmr_schema = function(...) cross_rule_schema,
+    eri_cmr_last_plan = function(...) plan,
+    .eri_dq_log_write = function(result, country, disease, data_source, data_type, ...) {
+      log_path <- if (identical(data_type, "consistency")) {
+        "eth/rblf/programmatic/consistency/logs/new.yaml"
+      } else {
+        paste0("eth/", disease, "/programmatic/", data_type, "/logs/new.yaml")
+      }
+      list(n_flags = 0L, status = "clean", log_path = log_path, flags = list())
+    },
+    eri_logs = function(country, disease, data_source, data_type, ...) {
+      if (identical(data_type, "consistency")) {
+        tibble::tibble(log_path = c("eth/rblf/programmatic/consistency/logs/old.yaml",
+                                    "eth/rblf/programmatic/consistency/logs/new.yaml"),
+                       period = c("202606", "202606"))
+      } else {
+        tibble::tibble(log_path = character(0), period = character(0))
+      }
+    },
+    eri_logs_resolve = function(log_path, note = NULL, ...) { resolved <<- c(resolved, log_path); invisible(TRUE) },
+    .package = "erifunctions"
+  )
+
+  eri_cmr_dq_report("eth", "202606", plan = plan, data_con = structure(list(), class = "mock"))
+  expect_equal(resolved, "eth/rblf/programmatic/consistency/logs/old.yaml")  # not the entry just written
+})
+
+test_that("eri_cmr_dq_report tops up a scoped plan via eri_cmr_last_plan so a cross rule still sees the sibling measure", {
+  # Simulates .eri_dq_review_loop()'s targeted re-run: `plan` only covers the ONE
+  # resplit measure (LF Treatment), but the cross rule also needs RB Treatment,
+  # which must come from the FULL last plan, not the scoped one passed in.
+  scoped_plan <- tibble::tibble(
+    sheet = "LF Treatment", disease = "lf", data_type = "treatment", dest = "b", n_rows = 1L
+  )
+  full_plan <- tibble::tibble(
+    sheet = c("RB Treatment", "LF Treatment"), disease = c("oncho", "lf"),
+    data_type = c("treatment", "treatment"), dest = c("a", "b"), n_rows = c(1L, 1L)
+  )
+  rb_data <- tibble::tibble(district = "Ari", population = 1000)
+  lf_data <- tibble::tibble(district = "Ari", population = 900)
+  clean_flags <- tibble::tibble(row = integer(), column = character(), value = character(), issue = character())
+  cross_rule_schema <- list(
+    sheets = list("RB Treatment" = list(), "LF Treatment" = list()),
+    cross_consistency = list(pop_match = list(
+      join_key = "district",
+      lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+      rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+      op = "=="
+    ))
+  )
+  last_plan_called <- FALSE
+
+  local_mocked_bindings(
+    eri_read = function(path, ...) if (identical(path, "a")) rb_data else lf_data,
+    load_dq_schema = function(...) list(columns = list()),
+    run_dq_checks = function(data, schema, ...) structure(
+      list(data = data, log = tibble::tibble(row = integer()), flags = clean_flags,
+          schema_source = NA_character_, schema_hash = NA_character_),
+      class = "dq_result"
+    ),
+    load_cmr_schema = function(...) cross_rule_schema,
+    eri_cmr_last_plan = function(...) { last_plan_called <<- TRUE; full_plan },
+    .eri_dq_log_write = function(result, country, disease, data_source, data_type, ...) {
+      list(n_flags = nrow(result$flags), status = if (nrow(result$flags) > 0L) "needs_review" else "clean",
+          log_path = "x.yaml",
+          flags = lapply(seq_len(nrow(result$flags)), function(i) list(
+            index = i, row = result$flags$row[i], column = result$flags$column[i],
+            value = result$flags$value[i], issue = result$flags$issue[i], status = "open"
+          )))
+    },
+    .package = "erifunctions"
+  )
+
+  flags <- eri_cmr_dq_report("eth", "202606", plan = scoped_plan, data_con = structure(list(), class = "mock"))
+  expect_true(last_plan_called)
+  expect_equal(nrow(flags[flags$cross, , drop = FALSE]), 1L)  # the mismatch was still caught
 })

--- a/tests/testthat/test-dq_cross.R
+++ b/tests/testthat/test-dq_cross.R
@@ -1,0 +1,451 @@
+# Pure-core tests for R/dq_cross.R -- no Azure, no schema loading. `tables`
+# mirrors what eri_cmr_dq_report()'s loop already assembles: one entry per
+# CMR sheet, with the already-canonicalized (post run_dq_checks()) data.
+
+tbl <- function(sheet, disease, data_type, data) {
+  list(sheet = sheet, disease = disease, data_type = data_type, data = data)
+}
+
+test_that("a source with no sheets: selects all tables for that (disease, data_type)", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = c("A", "B"), population = c(100, 200))),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = c("A", "B"), population = c(100, 200)))
+  )
+  rules <- list(pop_match = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("a source with sheets: selects only the named sheets, excluding others of the same measure", {
+  tables <- list(
+    tbl("CDD Training", "rblf", "training", tibble::tibble(district = "A", tot = 5)),
+    tbl("ToT Regional",  "rblf", "training", tibble::tibble(district = "A", tot = 1000)) # would blow up the sum if included
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "rblf", data_type = "training", column = "tot",
+                                   sheets = list("CDD Training")))),
+    rhs = list(sources = list(list(disease = "rblf", data_type = "training", column = "tot",
+                                   sheets = list("CDD Training")))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)  # 5 == 5, ToT's 1000 never entered the sum
+})
+
+test_that("zero matching tables produces zero flags and only an info message, not a warning", {
+  tables <- list(tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", treated = 10)))
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "treated"))),
+    rhs = list(sources = list(list(disease = "rblf", data_type = "training", column = "tot",
+                                   sheets = list("CDD Training", "CS Training", "HW Training")))),
+    op = "same_sign"
+  ))
+  expect_no_warning(flags <- .eri_cross_check_run(tables, rules))
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("a multi-source side binds rows across sources before aggregating", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", treated = 3)),
+    tbl("LF Treatment",  "lf",    "treatment", tibble::tibble(district = "A", treated = 4)),
+    tbl("CDD Training",  "rblf",  "training",  tibble::tibble(district = "A", tot = 7))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "sum", sources = list(
+      list(disease = "oncho", data_type = "treatment", column = "treated"),
+      list(disease = "lf", data_type = "treatment", column = "treated")
+    )),
+    rhs = list(agg = "sum", sources = list(list(disease = "rblf", data_type = "training", column = "tot"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)  # 3+4 == 7
+})
+
+test_that("sum aggregates multiple rows (e.g. multiple treatment_round rows) per key", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment",
+        tibble::tibble(district = c("A", "A", "A"), treated = c(10, 20, 0))),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", treated = 30))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "sum", sources = list(list(disease = "oncho", data_type = "treatment", column = "treated"))),
+    rhs = list(agg = "sum", sources = list(list(disease = "lf", data_type = "treatment", column = "treated"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)  # 10+20+0 == 30
+})
+
+test_that("sum returns NA (key skipped, not zero) when every value for a key is NA", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", treated = NA_real_)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", treated = 0))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "sum", sources = list(list(disease = "oncho", data_type = "treatment", column = "treated"))),
+    rhs = list(agg = "sum", sources = list(list(disease = "lf", data_type = "treatment", column = "treated"))),
+    op = "same_sign"
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)  # lhs is NA (no data), not 0 -- not "applicable", never compared
+})
+
+test_that("unique returns the single value when constant across rows", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment",
+        tibble::tibble(district = c("A", "A"), population = c(500, 500))),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 500))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "unique", sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(agg = "unique", sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("unique with two distinct values flags a within-sheet inconsistency and excludes the key from comparison", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment",
+        tibble::tibble(district = c("A", "A"), population = c(500, 600))),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 500))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "unique", sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(agg = "unique", sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 1L)
+  expect_match(flags$issue, "not constant", fixed = TRUE)
+  # NOT a population-mismatch flag -- the inconsistency itself is the only flag
+  expect_false(any(grepl("cross_consistency \\[r\\]: district mismatch", flags$issue)))
+})
+
+test_that("max/min/mean/n produce expected scalars", {
+  data_a <- tibble::tibble(district = c("A", "A", "A"), treated = c(1, 5, 9))
+
+  # lhs reads oncho (data_a); rhs reads a different disease (lf) holding just
+  # the expected constant, so the two sides never cross-contaminate.
+  run_agg <- function(agg, expected) {
+    tables <- list(
+      tbl("S", "oncho", "treatment", data_a),
+      tbl("S2", "lf", "treatment", tibble::tibble(district = "A", treated = expected))
+    )
+    rules <- list(r = list(
+      join_key = "district",
+      lhs = list(agg = agg, sources = list(list(disease = "oncho", data_type = "treatment", column = "treated"))),
+      rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "treated"))),
+      op = "=="
+    ))
+    .eri_cross_check_run(tables, rules)
+  }
+  expect_equal(nrow(run_agg("max", 9)), 0L)
+  expect_equal(nrow(run_agg("min", 1)), 0L)
+  expect_equal(nrow(run_agg("mean", 5)), 0L)
+  expect_equal(nrow(run_agg("n", 3)), 0L)  # 3 non-NA rows for district A
+})
+
+test_that("== flags a genuine mismatch and passes on equality", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 450))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 1L)
+  expect_equal(flags$value, "A")
+  expect_equal(flags$column, "district")
+})
+
+test_that("tolerance suppresses a within-tolerance difference", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 501))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "==", tolerance = 1
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("same_sign covers all four combinations (Emalee's rules 2 and 3)", {
+  mk <- function(treated_val, tot_val) {
+    list(
+      tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", treated = treated_val)),
+      tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", treated = 0)),
+      tbl("CDD Training", "rblf", "training", tibble::tibble(district = "A", tot = tot_val))
+    )
+  }
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "sum", missing_as = 0, sources = list(
+      list(disease = "oncho", data_type = "treatment", column = "treated"),
+      list(disease = "lf", data_type = "treatment", column = "treated")
+    )),
+    rhs = list(agg = "sum", missing_as = 0, sources = list(
+      list(disease = "rblf", data_type = "training", column = "tot", sheets = list("CDD Training"))
+    )),
+    op = "same_sign"
+  ))
+  expect_equal(nrow(.eri_cross_check_run(mk(10, 5), rules)), 0L)  # both >0
+  expect_equal(nrow(.eri_cross_check_run(mk(0, 0), rules)), 0L)   # both ==0
+  expect_equal(nrow(.eri_cross_check_run(mk(10, 0), rules)), 1L)  # treatment>0, training==0
+  expect_equal(nrow(.eri_cross_check_run(mk(0, 5), rules)), 1L)   # treatment==0, training>0
+})
+
+test_that("<=, >=, and != behave as their symbols", {
+  mk_tables <- function(l, r) list(
+    tbl("A", "oncho", "treatment", tibble::tibble(district = "A", treated = l)),
+    tbl("B", "lf", "treatment", tibble::tibble(district = "A", treated = r))
+  )
+  rule <- function(op) list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "treated"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "treated"))),
+    op = op
+  ))
+  expect_equal(nrow(.eri_cross_check_run(mk_tables(5, 10), rule("<="))), 0L)
+  expect_equal(nrow(.eri_cross_check_run(mk_tables(10, 5), rule("<="))), 1L)
+  expect_equal(nrow(.eri_cross_check_run(mk_tables(10, 5), rule(">="))), 0L)
+  # "!=" asserts the two sides MUST differ: equal values violate it (flagged),
+  # genuinely different values satisfy it (not flagged).
+  expect_equal(nrow(.eri_cross_check_run(mk_tables(5, 5), rule("!="))), 1L)
+  expect_equal(nrow(.eri_cross_check_run(mk_tables(5, 6), rule("!="))), 0L)
+})
+
+test_that("a key present on only one side, with no missing_as, is never flagged", {
+  # The LF-subset case: LF only reports a fraction of oncho's districts.
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = c("A", "B"), population = c(500, 700))),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 500))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)  # district B (oncho only) is not a mismatch
+})
+
+test_that("missing_as on both sides flags a district with treatment but no training row at all", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", treated = 50)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", treated = 0)),
+    # the CDD Training sheet exists and has real data -- just none for district A
+    # specifically, distinct from the "sheet doesn't exist in this workbook at
+    # all" case (which correctly skips the whole rule, tested separately above)
+    tbl("CDD Training", "rblf", "training", tibble::tibble(district = "B", tot = 20))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "sum", missing_as = 0, sources = list(
+      list(disease = "oncho", data_type = "treatment", column = "treated"),
+      list(disease = "lf", data_type = "treatment", column = "treated")
+    )),
+    rhs = list(agg = "sum", missing_as = 0, sources = list(
+      list(disease = "rblf", data_type = "training", column = "tot",
+          sheets = list("CDD Training", "CS Training", "HW Training"))
+    )),
+    op = "same_sign"
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  # District A: treatment>0, no training row -> missing_as fills training=0 -> flagged.
+  # District B: no treatment row -> missing_as fills treatment=0, but training=20>0 ->
+  # ALSO a genuine same_sign violation (the symmetric case), not a bug.
+  expect_equal(nrow(flags), 2L)
+  expect_setequal(flags$value, c("A", "B"))
+})
+
+test_that("NA and whitespace-only join keys are dropped", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment",
+        tibble::tibble(district = c("A", NA, "  "), population = c(500, 999, 999))),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 500))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("whitespace-padded keys are trimmed and still match", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "Jimma ", population = 500)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = " Jimma", population = 450))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_equal(nrow(flags), 1L)
+  expect_equal(flags$value, "Jimma")
+})
+
+test_that("an unknown op warns and skips that rule, while a valid rule in the same block still runs", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 450))
+  )
+  rules <- list(
+    bad = list(join_key = "district",
+              lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+              rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+              op = "approx"),
+    good = list(join_key = "district",
+               lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+               rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+               op = "==")
+  )
+  expect_warning(flags <- .eri_cross_check_run(tables, rules), "malformed")
+  expect_equal(nrow(flags), 1L)
+  expect_match(flags$issue, "\\[good\\]")
+})
+
+test_that("an unknown agg warns and skips the rule", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 450))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(agg = "median", sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  expect_warning(flags <- .eri_cross_check_run(tables, rules), "agg")
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("a missing join_key/lhs/rhs/sources/column each warn and skip the rule", {
+  base <- list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  )
+  variants <- list(
+    no_join_key = modifyList(base, list(join_key = NULL)),
+    no_lhs      = modifyList(base, list(lhs = NULL)),
+    no_rhs      = modifyList(base, list(rhs = NULL)),
+    no_op       = modifyList(base, list(op = NULL))
+  )
+  for (nm in names(variants)) {
+    expect_warning(ok <- .eri_cross_validate_rule(nm, variants[[nm]]), "malformed", label = nm)
+    expect_false(ok, label = nm)
+  }
+
+  # Built explicitly, not via modifyList(): modifyList()'s recursive merge on
+  # nested unnamed lists (sources' elements aren't named) doesn't reliably
+  # replace a deeply-nested field the way a naive override might suggest.
+  no_column <- list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment"))),  # column omitted
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  )
+  expect_warning(ok <- .eri_cross_validate_rule("no_column", no_column), "malformed")
+  expect_false(ok)
+})
+
+test_that("a join_key or column absent from a resolved table warns and skips that sheet, no flag", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)), # no `tot`
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 450))
+  )
+  rules <- list(r = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "tot"))),  # doesn't exist
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "=="
+  ))
+  expect_warning(flags <- .eri_cross_check_run(tables, rules), "no column")
+  expect_equal(nrow(flags), 0L)
+})
+
+test_that("emitted flags have the row/column/value/issue shape with the rule name in the message", {
+  tables <- list(
+    tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)),
+    tbl("LF Treatment", "lf", "treatment", tibble::tibble(district = "A", population = 450))
+  )
+  rules <- list(rb_lf_pop_match = list(
+    join_key = "district",
+    lhs = list(sources = list(list(disease = "oncho", data_type = "treatment", column = "population"))),
+    rhs = list(sources = list(list(disease = "lf", data_type = "treatment", column = "population"))),
+    op = "==", message = "RB/LF population mismatch"
+  ))
+  flags <- .eri_cross_check_run(tables, rules)
+  expect_named(flags, c("row", "column", "value", "issue"))
+  expect_true(is.na(flags$row))
+  expect_equal(flags$column, "district")
+  expect_equal(flags$value, "A")
+  expect_match(flags$issue, "^cross_consistency \\[rb_lf_pop_match\\]: RB/LF population mismatch")
+})
+
+test_that("an empty or NULL cross_consistency block produces zero flags with no warnings", {
+  tables <- list(tbl("RB Treatment", "oncho", "treatment", tibble::tibble(district = "A", population = 500)))
+  expect_no_warning(expect_equal(nrow(.eri_cross_check_run(tables, list())), 0L))
+  expect_no_warning(expect_equal(nrow(.eri_cross_check_run(tables, NULL)), 0L))
+})
+
+test_that("every bundled CMR routing schema's cross_consistency rules are well-formed, and sheets: names are real", {
+  schema_dir <- system.file("schemas", "cmr", package = "erifunctions")
+  files <- list.files(schema_dir, pattern = "\\.yaml$", full.names = TRUE)
+  expect_true(length(files) > 0L)
+
+  checked_any <- FALSE
+  for (f in files) {
+    schema <- yaml::read_yaml(f)
+    rules <- schema$cross_consistency
+    if (is.null(rules) || length(rules) == 0L) next
+    checked_any <- TRUE
+    known_sheets <- names(schema$sheets)
+
+    for (rule_name in names(rules)) {
+      expect_true(.eri_cross_validate_rule(rule_name, rules[[rule_name]]),
+                 label = paste0(basename(f), "::", rule_name))
+
+      for (side_name in c("lhs", "rhs")) {
+        for (src in rules[[rule_name]][[side_name]]$sources) {
+          if (!is.null(src$sheets)) {
+            bad <- setdiff(unlist(src$sheets), known_sheets)
+            expect_length(bad, 0L)  # a typo'd sheet name would silently never match anything
+          }
+        }
+      }
+    }
+  }
+  expect_true(checked_any)  # this test is only meaningful if at least one schema exercises it (eth.yaml)
+})

--- a/tests/testthat/test-dq_review.R
+++ b/tests/testthat/test-dq_review.R
@@ -179,6 +179,105 @@ flagged_tbl <- tibble::tibble(
   issue = "not an allowed value", status = "open", note = NA_character_
 )
 
+cross_flagged_tbl <- tibble::tibble(
+  sheet = "(cross-sheet)", disease = "rblf", data_type = "consistency",
+  log_path = "eth/rblf/programmatic/consistency/logs/dq.yaml",
+  flag_id = "eth/rblf/programmatic/consistency/logs/dq.yaml::1",
+  row = NA_integer_, excel_row = NA_integer_, column = "district", value = "Ari",
+  issue = "cross_consistency [rb_lf_pop_match]: RB and LF Treatment report different population",
+  status = "open", note = NA_character_, cross = TRUE
+)
+
+test_that("a cross-sheet flag (ADR-0024) gets a reduced menu (no 'fix in source'/'adjust schema') and a distinct header", {
+  withr::local_options(rlang_interactive = TRUE)
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho", data_type = "treatment",
+                         dest = "a", n_rows = 1L)
+  flag_resolved      <- FALSE
+  schema_edit_called <- FALSE
+  fix_source_called  <- FALSE
+
+  local_mocked_bindings(
+    eri_cmr_last_plan = function(...) plan,
+    eri_cmr_dq_report  = function(...) cross_flagged_tbl,
+    eri_dq_flag_resolve = function(flag_id, status, note = NULL, data_con = NULL) {
+      flag_resolved <<- TRUE
+      expect_equal(status, "not_important")
+    },
+    eri_dq_schema_edit = function(...) { schema_edit_called <<- TRUE; "unused" },
+    .eri_dq_review_fix_in_source = function(...) { fix_source_called <<- TRUE },
+    eri_logs_resolve = function(...) invisible(NULL),
+    eri_approve_cmr = function(...) invisible(NULL),
+    # main menu: "Work through flags"; the cross flag's REDUCED menu (3 items,
+    # not 5): choice 1 = "Mark not important"; back at main menu: "Exit"
+    .eri_prompt_menu = scripted(list(1L, 1L, 6L)),
+    .eri_prompt_line = scripted(list("")),
+    .package = "erifunctions"
+  )
+
+  msgs <- testthat::capture_messages(
+    eri_dq_review("sdn", "202605", data_con = structure(list(), class = "mock"))
+  )
+  expect_true(any(grepl("cross-sheet check", msgs, fixed = TRUE)))
+  expect_true(flag_resolved)
+  expect_false(schema_edit_called)  # "Adjust the schema" was never offered, so never chosen
+  expect_false(fix_source_called)   # neither was "Fix in source"
+})
+
+test_that("re-running the DQ check drops the OLD cross-sheet flag row instead of duplicating it", {
+  withr::local_options(rlang_interactive = TRUE)
+  plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho", data_type = "treatment",
+                         dest = "a", n_rows = 1L)
+  # First call: the RB Treatment flag plus a STALE cross flag ("Ari"). Rerun
+  # call (scoped to just RB Treatment): RB Treatment itself came back clean,
+  # and a FRESH cross flag with a different value ("Bale") -- if the stale
+  # one isn't dropped, both would coexist after the rerun.
+  first_call  <- dplyr::bind_rows(flagged_tbl, cross_flagged_tbl)
+  fresh_cross <- cross_flagged_tbl
+  fresh_cross$value <- "Bale"
+  rerun_call  <- fresh_cross
+
+  new_plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho",
+                             data_type = "treatment", dest = "a_fixed", n_rows = 1L)
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  writeLines("x", tmp)
+
+  dq_report_calls <- 0L
+  exported_flags  <- NULL
+  local_mocked_bindings(
+    eri_cmr_last_plan = function(...) plan,
+    eri_cmr_dq_report  = function(...) {
+      dq_report_calls <<- dq_report_calls + 1L
+      if (dq_report_calls == 1L) first_call else rerun_call
+    },
+    eri_split_cmr = function(...) new_plan,
+    .eri_open_file = function(...) invisible(NULL),
+    eri_logs_resolve = function(...) invisible(NULL),
+    eri_approve_cmr = function(...) invisible(NULL),
+    # eri_dq_export() is what .eri_dq_review_print_report() hands the CURRENT
+    # in-memory flags tibble to -- capturing it here is a direct, robust
+    # assertion on the actual data, instead of scraping printed console text
+    # (which would also show the pre-rerun "Ari" honestly, since it prints
+    # the state as it walks through a flag before you choose to skip it).
+    eri_dq_export = function(flags, ...) { exported_flags <<- flags; invisible("fake.html") },
+    # main: "Work through flags"; RB Treatment flag: "Fix in source" (sets the
+    # local path .eri_dq_review_rerun() needs); cross flag's reduced menu:
+    # "Skip to the next flag"; main: "Re-run the DQ check"; rerun sub-menu:
+    # "Yes"; main (now just the fresh cross flag left): "Print report"; main: "Exit"
+    .eri_prompt_menu = scripted(list(1L, 1L, 3L, 2L, 1L, 5L, 6L)),
+    .eri_prompt_line = scripted(list(tmp)),
+    .package = "erifunctions"
+  )
+
+  eri_dq_review("sdn", "202605", data_con = structure(list(), class = "mock"))
+
+  expect_equal(dq_report_calls, 2L)
+  cross_only <- exported_flags[exported_flags$cross %in% TRUE, , drop = FALSE]
+  # exactly one cross-sheet row survives -- the fresh one ("Bale") -- not both
+  # the stale ("Ari") and fresh row
+  expect_equal(nrow(cross_only), 1L)
+  expect_equal(cross_only$value, "Bale")
+})
+
 test_that("eri_dq_review marking the only flag not_important closes out the entry so approve can proceed", {
   withr::local_options(rlang_interactive = TRUE)
   plan <- tibble::tibble(sheet = "RB Treatment", disease = "oncho", data_type = "treatment",

--- a/vignettes/da-cmr-guide.Rmd
+++ b/vignettes/da-cmr-guide.Rmd
@@ -319,11 +319,16 @@ flags <- eri_cmr_dq_report("uga", "202406")
 #> ✔ Logged 1 DQ flag (needs_review).
 #> ✔ Logged 0 DQ flags (clean).
 flags
-#> # A tibble: 1 × 11
-#>   sheet        disease data_type log_path      flag_id        row column value issue         status note
-#>   <chr>        <chr>   <chr>     <chr>         <chr>        <int> <chr>  <chr> <chr>         <chr>  <chr>
-#> 1 RB Treatment oncho   treatment uga/oncho/... uga/oncho...     4 target 0     out of range  open   <NA>
+#> # A tibble: 1 × 13
+#>   sheet        disease data_type log_path      flag_id        row excel_row column value issue         status note  cross
+#>   <chr>        <chr>   <chr>     <chr>         <chr>        <int>     <int> <chr>  <chr> <chr>         <chr>  <chr> <lgl>
+#> 1 RB Treatment oncho   treatment uga/oncho/... uga/oncho...     4         9 target 0     out of range  open   <NA>  FALSE
 ```
+
+If the country's CMR routing schema declares `cross_consistency:` rules (Ethiopia, as of this
+writing), a flag comparing data *across* sheets can also show up here, with `sheet =
+"(cross-sheet)"`, a blank `excel_row`, and `cross = TRUE` -- see the
+[DQ review guide](da-dq-review-guide.html#split) for what that means and how to work through one.
 
 Work through it **issue by issue**, not measure by measure: mark each flag `"not_important"`,
 `"fixed"`, or `"noted"`, with a note explaining what you did or decided:

--- a/vignettes/da-dq-review-guide.Rmd
+++ b/vignettes/da-dq-review-guide.Rmd
@@ -122,6 +122,14 @@ flags[, c("excel_row", "column", "value", "issue", "status")]
 
 Two flags, one measure. Now forget that tibble exists -- from here on, one function.
 
+> **A note on cross-sheet flags.** For a country whose CMR routing schema declares
+> `cross_consistency:` rules (Ethiopia, as of this writing -- e.g. "population must match between
+> the RB and LF Treatment tabs for the same district"), `eri_cmr_dq_report()` also compares data
+> *across* sheets, not just within one. Those flags show `sheet = "(cross-sheet)"` and a blank
+> `excel_row` -- there's no single cell to point at, since the issue is a relationship between two
+> (or more) sheets, not a bad value in one. `eri_dq_review()`'s menu for one of these drops "Fix in
+> source" and "Adjust the schema" accordingly; you can still mark it not important or noted.
+
 ## 3. Run the review {#review}
 
 ```{r review, eval=FALSE}


### PR DESCRIPTION
## Summary

Fixes #323 — Emalee reported (email, cc Hannah, no rush) three DQ checks needed on Ethiopia's CMR that no existing single-sheet DQ schema can express:

- Population reported for a district (IU) on the RB Treatment tab must equal population reported for that same district on the LF Treatment tab.
- For a country with CDD/CS/HW training tabs: if RB+LF treated for a district is > 0, CDD+CS+HW training for that district must also be > 0 (and conversely, both must be 0 together).

This is the same RB/LF/training relationship in every RBLF country in this codebase, not Ethiopia-specific, so this ships as a general, reusable capability rather than a one-off script — see [ADR-0024](https://github.com/thecartercenter/erifunctions/blob/main/docs/adr/0024-cross-sheet-dq-at-staged-layer.md) for the full design rationale (why staged-layer not processed-layer, why not `eri_query()`/DuckDB, why workbook-level not measure-level flags, why the approval gate only blocks on unresolved findings).

**What's new:**
- New declarative `cross_consistency:` block on the CMR routing schema (`inst/schemas/cmr/{country}.yaml`), evaluated by `eri_cmr_dq_report()` (new `cross = TRUE` arg) via a new pure engine, `R/dq_cross.R`.
- Findings are workbook-level, logged to `{country}/rblf/programmatic/consistency/logs/` (new registered `data_type: consistency`), surfaced through the existing `eri_dq_review()`/`eri_dq_export()`/`eri_approve_cmr()` chain via a new `cross` column.
- `eri_approve_cmr()` gains a gate that blocks on an unresolved cross-consistency finding, but never on the mere absence of one — no already-approved period is retroactively blocked, and countries without `cross_consistency:` rules see zero behavior change.
- `eri_dq_review()`'s per-flag menu (drops "Fix in source"/"Adjust the schema" for a cross flag, which has no single Excel row/schema to point at) and its re-run/dedup logic both got cross-aware guards.
- Rules shipped for `eth` only; other RBLF countries opt in later by editing their own routing schema.

**Review note:** `review-agent` passed clean (verdict: Comment, no blockers). Four minor findings all fixed: a stale `excel_row`-column omission in a vignette example (pre-existing, this PR touched the same hunk), missing test coverage for the `agg: n` aggregation, a clarifying comment on `same_sign`'s deliberate negative-value handling, and a roxygen formatting nit.

## Test plan
- [x] Full `devtools::test()` — clean, twice (before and after applying review-agent's fixes)
- [x] New pure-engine tests (`tests/testthat/test-dq_cross.R`, ~25 tests): source/sheet selection, every `agg` (sum/unique/max/min/mean/n), every `op` (incl. `same_sign`'s 4 sign combinations — Emalee's actual rules), `missing_as` semantics (including the LF-subset-districts non-flagging case), malformed-rule warn-and-skip, a bundled-schema validity check
- [x] New `eri_cmr_dq_report()`/`eri_approve_cmr()` integration tests (`tests/testthat/test-cmr.R`, ~10 tests): no-op for countries without rules, flag emission shape, `cross = FALSE`, clean-entry logging, supersede/auto-resolve, scoped-plan fallback loading, the approval gate's block/no-block cases
- [x] New `eri_dq_review()` tests (`tests/testthat/test-dq_review.R`): reduced menu for a cross flag, re-run dedup (no duplicate rows)
- [x] `devtools::document()` — `man/eri_cmr_dq_report.Rd` / `man/eri_approve_cmr.Rd` regenerated, no unexpected diff

Tracking: feedback tickets #11/#12 in `_feedback/feedback_log.yaml`.